### PR TITLE
[Feature] Tests via Github actions + README

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,27 @@
+name: "Lint"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3.5.2
+          with:
+            submodules: 'recursive'
+        - name: Step Python 3.8.12
+          uses: actions/setup-python@v4.6.0
+          with:
+            python-version: '3.8.12'
+        - name: Install OpenMPI for gt4py
+          run: |
+            sudo apt-get install libopenmpi-dev
+        - name: Install Python packages
+          run: |
+            python -m pip install --upgrade pip setuptools wheel
+            pip install .[develop]
+        - name: Run lint via pre-commit
+          run: |
+            pre-commit run --all-files

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,31 @@
+name: "Unit tests"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  main_unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3.5.2
+          with:
+            submodules: 'recursive'
+        - name: Setup Python
+          uses: actions/setup-python@v4.6.0
+          with:
+            python-version: '3.8.12'
+        - name: Install OpenMPI & Boost for gt4py
+          run: |
+            sudo apt-get install libopenmpi-dev libboost1.74-dev
+        - name: Install Python packages
+          run: |
+            python -m pip install --upgrade pip setuptools wheel
+            pip install -r requirements_dev.txt -c constraints.txt
+        - name: Run serial-cpu tests
+          run: |
+            pytest -x tests
+        - name: Run parallel-cpu tests
+          run: |
+              pytest -x tests/mpi
+  

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,10 @@ dmypy.json
 # GT4Py
 **/.gt_cache*/
 
+# Tests
+.my_cache_path/*
+.my_relocated_cache_path/*
+
 # Run outputs
 plot_output/
 profiling_results/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # NOAA/NASA Domain Specific Language middleware
 
-Use `git clone --recurse-submodule` to pull all vetted versions of the submodules used by `ndsl`
+NDSL is a middleware for climate and weather modelling developped conjointment by NOAA and NASA. The middleware brings together [GT4Py](https://github.com/GridTools/gt4py/) (the `cartesian` flavor), an ETH CSCS's stencil DSL, and [DaCE](https://github.com/spcl/dace/), an ETH SPCL's data flow framework, both developped for high-performance and portability. On top of those pillars, NDSL deploys a series of optimized APIs for common operations (Halo exchange, domain decomposition, MPI...) and a set of bespoke optimizations for the models targeted by the middleware.
+
+## Battery-included for FV-based models
+
+Historically NDSL was developed to port the FV3 dynamical core on the cube-sphere. Therefore, the middleware ships with ready-to-execute specilization for models based on cube-sphere grid and FV-based model in particular.
+
+## Quickstart
+
+NDSL submodules `gt4py` and `dace` to point to vetted versions, use `git clone --recurse-submodule`.
+
+NDSL is __NOT__ available on `pypi`. Installation of the package has to be local, via `pip install ./NDSL` (`-e` supported). The packages has a few options:
+
+- `ndsl[test]`: installs the test packages (based on `pytest`)
+- `ndsl[develop]`: installs tools for development and tests.
+
+Tests are available via:
+
+- `pytest -x test`: running CPU serial tests (GPU as well if `cupy` is installed)
+- `mpirun -np 6 pytest -x test/mpi`: running CPU parallel tests (GPU as well if `cupy` is installed)

--- a/ndsl/utils.py
+++ b/ndsl/utils.py
@@ -55,7 +55,7 @@ def is_c_contiguous(array: np.ndarray) -> bool:
 
 def ensure_contiguous(maybe_array: Union[np.ndarray, None]) -> None:
     if maybe_array is not None and not is_contiguous(maybe_array):
-        raise ValueError("ndarray is not contiguous")
+        raise BufferError("dlpack: buffer is not contiguous")
 
 
 def safe_assign_array(to_array: np.ndarray, from_array: np.ndarray):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     install_requires=requirements,
-    extras_requires=extras_requires,
+    extras_require=extras_requires,
     name="ndsl",
     license="BSD license",
     packages=find_namespace_packages(include=["ndsl", "ndsl.*"]),

--- a/tests/dsl/test_caches.py
+++ b/tests/dsl/test_caches.py
@@ -10,6 +10,7 @@ from ndsl.dsl.stencil import (
     StencilConfig,
     StencilFactory,
 )
+from ndsl.comm.mpi import MPI
 
 
 def _make_storage(
@@ -77,6 +78,9 @@ class OrchestratedProgam:
         pytest.param("dace:cpu"),
     ],
 )
+@pytest.mark.skipif(
+    MPI is not None, reason="relocatibility checked with a one-rank setup"
+)
 def test_relocatability_orchestration(backend):
     import os
     import shutil
@@ -133,14 +137,15 @@ def test_relocatability_orchestration(backend):
         pytest.param("dace:cpu"),
     ],
 )
+@pytest.mark.skipif(
+    MPI is not None, reason="relocatibility checked with a one-rank setup"
+)
 def test_relocatability(backend: str):
     import os
     import shutil
 
     import gt4py
     from gt4py.cartesian import config as gt_config
-
-    from ..mpi.mpi_comm import MPI
 
     # Restore original dir name
     gt4py.cartesian.config.cache_settings["dir_name"] = os.environ.get(


### PR DESCRIPTION
## Summary

### Github actions
Restore the unit tests using Github actions. Runs serial & parallel CPU tests. GPU tests is a logged issue #7 

### README

Basic README describing the project and describing how to install and how to run the tests

## Technical details

- Fix `setup.py` with bad arguments
- Align the error for non-contiguous buffer on the newer GT4Py usage of DLPack
- Deactivate the caches relocability tests when running with MPI. The test is design for a single rank and tests filepaths manipulation, and therefore doesn't required MPI.