### PR TITLE
Add 3.11.7 to python in unit tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,10 +11,10 @@ jobs:
           uses: actions/checkout@v3.5.2
           with:
             submodules: 'recursive'
-        - name: Step Python 3.8.12
+        - name: Step Python
           uses: actions/setup-python@v4.6.0
           with:
-            python-version: '3.8.12'
+            python-version: '3.11.7'
         - name: Install OpenMPI for gt4py
           run: |
             sudo apt-get install libopenmpi-dev

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
         - name: Step Python
           uses: actions/setup-python@v4.6.0
           with:
-            python-version: '3.11.7'
+            python-version: '3.8.12'
         - name: Install OpenMPI for gt4py
           run: |
             sudo apt-get install libopenmpi-dev

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -30,4 +30,4 @@ jobs:
             pytest -x tests
         - name: Run parallel-cpu tests
           run: |
-            mpirun -np --oversubscribe 6 pytest -x tests/mpi
+            mpirun -np 6 --oversubscribe pytest -x tests/mpi

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   all:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.8.12, 3.11.7]
     steps:
         - name: Checkout repository
           uses: actions/checkout@v3.5.2
@@ -14,7 +17,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4.6.0
           with:
-            python-version: '3.8.12'
+            python-version: ${{ matrix.python }}
         - name: Install OpenMPI & Boost for gt4py
           run: |
             sudo apt-get install libopenmpi-dev libboost1.74-dev
@@ -27,4 +30,4 @@ jobs:
             pytest -x tests
         - name: Run parallel-cpu tests
           run: |
-              pytest -x tests/mpi
+            mpirun -np 6 pytest -x tests/mpi

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -30,4 +30,4 @@ jobs:
             pytest -x tests
         - name: Run parallel-cpu tests
           run: |
-            mpirun -np 6 pytest -x tests/mpi
+            mpirun -np --oversubscribe 6 pytest -x tests/mpi

--- a/.gitignore
+++ b/.gitignore
@@ -119,7 +119,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/


### PR DESCRIPTION
GT4Py is looking into deprecating 3.8/3.9. In the interim of a decision, we begin the process to test for newer versions of Python.