### PR TITLE
[Fix] f32 scalars in DaCe

### DIFF
--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -11,6 +11,7 @@ from ndsl.dsl.caches.cache_location import identify_code_path
 from ndsl.dsl.caches.codepath import FV3CodePath
 from ndsl.dsl.gt4py_utils import is_gpu_backend
 from ndsl.optional_imports import cupy as cp
+from ndsl.dsl.typing import floating_point_precision
 
 
 # This can be turned on to revert compilation for orchestration
@@ -261,6 +262,15 @@ class DaceConfig:
             dace.config.Config.set(
                 "compiler", "cuda", "syncdebug", value=dace_debug_env_var
             )
+
+            if floating_point_precision() == 32:
+                # When using 32-bit float, we flip the default dtypes to be all
+                # C, e.g. 32 bit.
+                dace.Config.set(
+                    "compiler",
+                    "default_data_types",
+                    value="c",
+                )
 
         # attempt to kill the dace.conf to avoid confusion
         if dace.config.Config._cfg_filename:

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -10,8 +10,8 @@ from ndsl.comm.communicator import Communicator, Partitioner
 from ndsl.dsl.caches.cache_location import identify_code_path
 from ndsl.dsl.caches.codepath import FV3CodePath
 from ndsl.dsl.gt4py_utils import is_gpu_backend
-from ndsl.optional_imports import cupy as cp
 from ndsl.dsl.typing import floating_point_precision
+from ndsl.optional_imports import cupy as cp
 
 
 # This can be turned on to revert compilation for orchestration

--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -26,15 +26,22 @@ def floating_point_precision() -> int:
     return int(os.getenv("PACE_FLOAT_PRECISION", "64"))
 
 
+# We redefine the type as a way to distinguish
+# the model definition of a float to other usage of the
+# common numpy type in the rest of the code.
+NDSL_32BIT_FLOAT_TYPE = np.float32
+NDSL_64BIT_FLOAT_TYPE = np.float64
+
+
 def global_set_floating_point_precision():
     """Set the global floating point precision for all reference
     to Float in the codebase. Defaults to 64 bit."""
     global Float
     precision_in_bit = floating_point_precision()
     if precision_in_bit == 64:
-        return np.float64
+        return NDSL_64BIT_FLOAT_TYPE
     elif precision_in_bit == 32:
-        return np.float32
+        return NDSL_32BIT_FLOAT_TYPE
     else:
         NotImplementedError(
             f"{precision_in_bit} bit precision not implemented or tested"


### PR DESCRIPTION
When asked for 32 bit float, we flip the DaCe default type to be a `f32`