### PR TITLE
[Branch fix] Merging `main` back in `develop`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Create a bug report to help us improve
+title: ''
+labels: Bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is
+
+**To Reproduce**
+Steps to reproduce the behavior
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**System Environment**
+Describe the system environment, include:
+- OS: [e.g. RHEL 7.2]
+- Backend used [e.g. dace:cpu]
+- Environment variables set
+- Compiler(s): Type and version [e.g. Intel 19.1]
+- MPI type, and version (e.g. MPICH, Cray MPI, openMPI)
+- netCDF Version: For both C and Fortran
+- Configure options: Any additional flags, or macros passed to configure
+- If this bug came from a model run, which model
+
+**Additional context**
+Add any other context about the problem.  If applicable, include where any files
+that help describe, or reproduce the problem exist.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,14 @@
+---
+name: Support request
+about: Request for help
+title: ''
+labels: 'question'
+assignees: ''
+---
+
+**Is your question related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe what you have tried**
+A clear and concise description of what steps you have taken.  Include command
+lines, and any messages from the command.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+**Description**
+Include a summary of the change and which issue is fixed. Please also include
+relevant motivation and context. List any dependencies that are required for
+this change.
+
+Fixes # (issue)
+If this is a hotfix to a released version, please specify it.
+
+**How Has This Been Tested?**
+Please describe the tests that you ran to verify your changes. Please also note
+any relevant details for your test configuration (e.g. compiler, OS).  Include
+enough information so someone can reproduce your tests.
+
+**Checklist:**
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] New check tests, if applicable, are included


### PR DESCRIPTION
We merged PRs directly into `main` by mistake. Correcting this.

@fmalatino Data named has changed on the datashare which leads to ci breakage. Please force merge this and I will PR a fix to the ci to develop next

NB: we need to switch the `default` branch to `develop`

