### PR TITLE
Move `DaCe` to top of `master` as of March 1st.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = https://github.com/GridTools/gt4py.git
 [submodule "external/dace"]
 	path = external/dace
-	url = https://github.com/FlorianDeconinck/dace.git
-	branch = fix/gcc_dies_on_dacecpu
+	url = https://github.com/spcl/dace.git


### PR DESCRIPTION
**Description**
DaCe team fixed the `dace:cpu` compilation issue we were having by removing the double `const` on read pointers at code generation (which was tripping `gcc`).

The new version comes with a lot of fixes to merging transform we might take advantage off. No tests have been done on those.

**How Has This Been Tested?**
Ran validation on `FVDynamics` for `dace:cpu` and `dace:gpu` orchestrated.
No performance benchmark.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings