### PR TITLE
Allow pressure coeff to be read from ak & bk data

### DIFF
--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -1,7 +1,7 @@
 import dataclasses
 import functools
 import warnings
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -238,6 +238,8 @@ class MetricTerms:
         deglat: float = 15.0,
         extdgrid: bool = False,
         eta_file: str = "None",
+        ak: Optional[np.ndarray] = None,
+        bk: Optional[np.ndarray] = None,
     ):
         self._grid_type = grid_type
         self._dx_const = dx_const
@@ -300,7 +302,7 @@ class MetricTerms:
             self._ptop,
             self._ak,
             self._bk,
-        ) = self._set_hybrid_pressure_coefficients(eta_file)
+        ) = self._set_hybrid_pressure_coefficients(eta_file, ak, bk)
         self._ec1 = None
         self._ec2 = None
         self._ew1 = None
@@ -2147,7 +2149,12 @@ class MetricTerms:
         area_cgrid_64.data[:, :] = self._dx_const * self._dy_const
         return quantity_cast_to_model_float(self.quantity_factory, area_cgrid_64)
 
-    def _set_hybrid_pressure_coefficients(self, eta_file):
+    def _set_hybrid_pressure_coefficients(
+        self,
+        eta_file,
+        ak_data: Optional[np.ndarray] = None,
+        bk_data: Optional[np.ndarray] = None,
+    ):
         ks = self.quantity_factory.zeros(
             [],
             "",
@@ -2169,7 +2176,10 @@ class MetricTerms:
             dtype=Float,
         )
         pressure_coefficients = eta.set_hybrid_pressure_coefficients(
-            self._npz, eta_file
+            self._npz,
+            eta_file,
+            ak_data,
+            bk_data,
         )
         ks = pressure_coefficients.ks
         ptop = pressure_coefficients.ptop

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_requires = {"test": test_requirements, "develop": develop_requirements}
 requirements: List[str] = [
     local_pkg("gt4py", "external/gt4py"),
     local_pkg("dace", "external/dace"),
-    "mpi4py",
+    "mpi4py==3.1.5",
     "cftime",
     "xarray",
     "f90nml>=1.1.0",


### PR DESCRIPTION
**Description**
In order to facilitate integration with existing model, we allow the pressure coefficients AK/BK to be read from data. We keep the same checks and give precedence to the data to keep backward compatibility.

**How Has This Been Tested?**
Tested on GEOS integration. No unit test present but default behavior did _not_ change.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
