### PR TITLE
[Refactor] Centralize Translate Test architecture

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import xarray as xr
 import yaml
 
-import ndsl.dsl
+from ndsl import CompilationConfig, StencilConfig, StencilFactory
 from ndsl.comm.communicator import (
     Communicator,
     CubedSphereCommunicator,
@@ -17,9 +17,85 @@ from ndsl.comm.mpi import MPI
 from ndsl.comm.partitioner import CubedSpherePartitioner, TilePartitioner
 from ndsl.dsl.dace.dace_config import DaceConfig
 from ndsl.namelist import Namelist
+from ndsl.stencils.testing.grid import Grid  # type: ignore
 from ndsl.stencils.testing.parallel_translate import ParallelTranslate
 from ndsl.stencils.testing.savepoint import SavepointCase, dataset_to_dict
 from ndsl.stencils.testing.translate import TranslateGrid
+
+
+def pytest_addoption(parser):
+    """Option for the Translate Test system
+
+    See -h or inline help for details.
+    """
+    parser.addoption(
+        "--backend",
+        action="store",
+        default="numpy",
+        help="Backend to execute the test with, can only be one.",
+    )
+    parser.addoption(
+        "--which_modules",
+        action="store",
+        help="Whitelist of modules to run. Only the part after Translate, e.g. in TranslateXYZ it'd be XYZ",
+    )
+    parser.addoption(
+        "--skip_modules",
+        action="store",
+        help="Blacklist of modules to not run. Only the part after Translate, e.g. in TranslateXYZ it'd be XYZ",
+    )
+    parser.addoption(
+        "--which_rank", action="store", help="Restrict test to a single rank"
+    )
+    parser.addoption(
+        "--data_path",
+        action="store",
+        default="./",
+        help="Path of Netcdf input and outputs. Naming pattern needs to be XYZ-In and XYZ-Out for a test class named TranslateXYZ",
+    )
+    parser.addoption(
+        "--threshold_overrides_file",
+        action="store",
+        default=None,
+        help="Path to a yaml overriding the default error threshold for a custom value.",
+    )
+    parser.addoption(
+        "--print_failures",
+        action="store_true",
+        help="Print the failures detail. Default to True.",
+    )
+    parser.addoption(
+        "--failure_stride",
+        action="store",
+        default=1,
+        help="How many indices of failures to print from worst to best. Default to 1.",
+    )
+    parser.addoption(
+        "--grid",
+        action="store",
+        default="file",
+        help='Grid loading mode. "file" looks for "Grid-Info.nc", "compute" does the same but recomputes MetricTerms, "default" creates a simple grid with no metrics terms. Default to "file".',
+    )
+    parser.addoption(
+        "--layout",
+        action="store",
+        default="cube",
+        help='Layout of the grid. "cube" means a 6-faced grid, "tile" means a 1 tile grid. Default to "cube".',
+    )
+
+
+def pytest_configure(config):
+    # register an additional marker
+    config.addinivalue_line(
+        "markers", "sequential(name): mark test as running sequentially on ranks"
+    )
+    config.addinivalue_line(
+        "markers", "parallel(name): mark test as running in parallel across ranks"
+    )
+    config.addinivalue_line(
+        "markers",
+        "mock_parallel(name): mark test as running in mock parallel across ranks",
+    )
 
 
 @pytest.fixture()
@@ -109,12 +185,14 @@ def get_parallel_savepoint_names(metafunc, data_path):
 
 def get_ranks(metafunc, layout):
     only_rank = metafunc.config.getoption("which_rank")
-    dperiodic = metafunc.config.getoption("dperiodic")
+    layout_mode = metafunc.config.getoption("layout")
     if only_rank is None:
-        if dperiodic:
+        if layout_mode == "tile":
             total_ranks = layout[0] * layout[1]
-        else:
+        elif layout_mode == "cube":
             total_ranks = 6 * layout[0] * layout[1]
+        else:
+            raise NotImplementedError(f"Layout {layout_mode} is unknown.")
         return range(total_ranks)
     else:
         return [int(only_rank)]
@@ -125,8 +203,8 @@ def get_namelist(namelist_filename):
 
 
 def get_config(backend: str, communicator: Optional[Communicator]):
-    stencil_config = ndsl.dsl.stencil.StencilConfig(
-        compilation_config=ndsl.dsl.stencil.CompilationConfig(
+    stencil_config = StencilConfig(
+        compilation_config=CompilationConfig(
             backend=backend, rebuild=False, validate_args=True
         ),
         dace_config=DaceConfig(
@@ -142,8 +220,8 @@ def sequential_savepoint_cases(metafunc, data_path, namelist_filename, *, backen
     namelist = get_namelist(namelist_filename)
     stencil_config = get_config(backend, None)
     ranks = get_ranks(metafunc, namelist.layout)
-    compute_grid = metafunc.config.getoption("compute_grid")
-    dperiodic = metafunc.config.getoption("dperiodic")
+    grid_mode = metafunc.config.getoption("grid")
+    layout_mode = metafunc.config.getoption("layout")
     return _savepoint_cases(
         savepoint_names,
         ranks,
@@ -151,8 +229,8 @@ def sequential_savepoint_cases(metafunc, data_path, namelist_filename, *, backen
         namelist,
         backend,
         data_path,
-        compute_grid,
-        dperiodic,
+        grid_mode,
+        layout_mode,
     )
 
 
@@ -161,25 +239,38 @@ def _savepoint_cases(
     ranks,
     stencil_config,
     namelist,
-    backend,
-    data_path,
-    compute_grid: bool,
-    dperiodic: bool,
+    backend: str,
+    data_path: str,
+    grid_mode: str,
+    layout_mode: bool,
 ):
     return_list = []
-    ds_grid: xr.Dataset = xr.open_dataset(os.path.join(data_path, "Grid-Info.nc")).isel(
-        savepoint=0
-    )
     for rank in ranks:
-        grid = TranslateGrid(
-            dataset_to_dict(ds_grid.isel(rank=rank)),
-            rank=rank,
-            layout=namelist.layout,
-            backend=backend,
-        ).python_grid()
-        if compute_grid:
-            compute_grid_data(grid, namelist, backend, namelist.layout, dperiodic)
-        stencil_factory = ndsl.dsl.stencil.StencilFactory(
+        if grid_mode == "default":
+            grid = Grid._make(
+                namelist.npx + 1,
+                namelist.npy + 1,
+                namelist.npz,
+                namelist.layout,
+                rank,
+                backend,
+            )
+        elif grid_mode == "file" or grid_mode == "compute":
+            ds_grid: xr.Dataset = xr.open_dataset(
+                os.path.join(data_path, "Grid-Info.nc")
+            ).isel(savepoint=0)
+            grid = TranslateGrid(
+                dataset_to_dict(ds_grid.isel(rank=rank)),
+                rank=rank,
+                layout=namelist.layout,
+                backend=backend,
+            ).python_grid()
+            if grid_mode == "compute":
+                compute_grid_data(grid, namelist, backend, namelist.layout, layout_mode)
+        else:
+            raise NotImplementedError(f"Grid mode {grid_mode} is unknown.")
+
+        stencil_factory = StencilFactory(
             config=stencil_config,
             grid_indexing=grid.grid_indexing,
         )
@@ -204,12 +295,12 @@ def _savepoint_cases(
     return return_list
 
 
-def compute_grid_data(grid, namelist, backend, layout, dperiodic):
+def compute_grid_data(grid, namelist, backend, layout, layout_mode):
     grid.make_grid_data(
         npx=namelist.npx,
         npy=namelist.npy,
         npz=namelist.npz,
-        communicator=get_communicator(MPI.COMM_WORLD, layout, dperiodic),
+        communicator=get_communicator(MPI.COMM_WORLD, layout, layout_mode),
         backend=backend,
     )
 
@@ -218,11 +309,11 @@ def parallel_savepoint_cases(
     metafunc, data_path, namelist_filename, mpi_rank, *, backend: str, comm
 ):
     namelist = get_namelist(namelist_filename)
-    dperiodic = metafunc.config.getoption("dperiodic")
-    communicator = get_communicator(comm, namelist.layout, dperiodic)
+    layout_mode = metafunc.config.getoption("layout")
+    communicator = get_communicator(comm, namelist.layout, layout_mode)
     stencil_config = get_config(backend, communicator)
     savepoint_names = get_parallel_savepoint_names(metafunc, data_path)
-    compute_grid = metafunc.config.getoption("compute_grid")
+    grid_mode = metafunc.config.getoption("grid")
     return _savepoint_cases(
         savepoint_names,
         [mpi_rank],
@@ -230,8 +321,8 @@ def parallel_savepoint_cases(
         namelist,
         backend,
         data_path,
-        compute_grid,
-        dperiodic,
+        grid_mode,
+        layout_mode,
     )
 
 
@@ -276,8 +367,8 @@ def generate_parallel_stencil_tests(metafunc, *, backend: str):
     )
 
 
-def get_communicator(comm, layout, dperiodic):
-    if (MPI.COMM_WORLD.Get_size() > 1) and (not dperiodic):
+def get_communicator(comm, layout, layout_mode):
+    if (MPI.COMM_WORLD.Get_size() > 1) and (layout_mode == "tile"):
         partitioner = CubedSpherePartitioner(TilePartitioner(layout))
         communicator = CubedSphereCommunicator(comm, partitioner)
     else:
@@ -297,10 +388,15 @@ def failure_stride(pytestconfig):
 
 
 @pytest.fixture()
-def compute_grid(pytestconfig):
-    return pytestconfig.getoption("compute_grid")
+def grid(pytestconfig):
+    return pytestconfig.getoption("grid")
 
 
 @pytest.fixture()
-def dperiodic(pytestconfig):
-    return pytestconfig.getoption("dperiodic")
+def layout_mode(pytestconfig):
+    return pytestconfig.getoption("layout_mode")
+
+
+@pytest.fixture()
+def backend(pytestconfig):
+    return pytestconfig.getoption("backend")

--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -266,7 +266,9 @@ def _savepoint_cases(
                 backend=backend,
             ).python_grid()
             if grid_mode == "compute":
-                compute_grid_data(grid, namelist, backend, namelist.layout, topology_mode)
+                compute_grid_data(
+                    grid, namelist, backend, namelist.layout, topology_mode
+                )
         else:
             raise NotImplementedError(f"Grid mode {grid_mode} is unknown.")
 

--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -1,0 +1,147 @@
+import argparse
+import os
+import shutil
+import xarray as xr
+import f90nml
+import numpy as np
+from typing import Optional
+
+try:
+    import serialbox
+except ModuleNotFoundError:
+    raise ModuleNotFoundError("Serialbox couldn't be imported, make sure it's in your PYTHONPATH or you env")
+
+
+def get_parser():
+    parser = argparse.ArgumentParser("Converts Serialbox data to netcdf")
+    parser.add_argument(
+        "data_path",
+        type=str,
+        help="path of serialbox data to convert",
+    )
+    parser.add_argument(
+        "output_path", type=str, help="output directory where netcdf data will be saved"
+    )
+    parser.add_argument(
+        "-dn", "--data_name", type=str, help="[Optional] Give the name of the data, will default to Generator_rankX"
+    )
+    return parser
+
+
+def read_serialized_data(serializer, savepoint, variable):
+    data = serializer.read(variable, savepoint)
+    if len(data.flatten()) == 1:
+        return data[0]
+    data[data == 1e40] = 0.0
+    return data
+
+
+def get_all_savepoint_names(serializer):
+    savepoint_names = set()
+    for savepoint in serializer.savepoint_list():
+        savepoint_names.add(savepoint.name)
+    return savepoint_names
+
+
+def get_serializer(data_path: str, rank:int , data_name:Optional[str] = None):
+    if data_name:
+        name = data_name
+    else:
+        name = f"Generator_rank{rank}"
+    return serialbox.Serializer(serialbox.OpenModeKind.Read, data_path, name)
+
+
+def main(data_path: str, output_path: str, data_name: Optional[str] = None):
+    os.makedirs(output_path, exist_ok=True)
+    namelist_filename_in = os.path.join(data_path, "input.nml")
+
+    if not os.path.exists(namelist_filename_in):
+        raise FileNotFoundError(f"Can't find input.nml in {data_path}. Required.")
+
+    namelist_filename_out = os.path.join(output_path, "input.nml")
+    if namelist_filename_out != namelist_filename_in:
+        shutil.copyfile(os.path.join(data_path, "input.nml"), namelist_filename_out)
+    namelist = f90nml.read(namelist_filename_out)
+    total_ranks = (
+        6 * namelist["fv_core_nml"]["layout"][0] * namelist["fv_core_nml"]["layout"][1]
+    )
+
+    # all ranks have the same names, just look at first one
+    serializer_0 = get_serializer(data_path, rank=0, data_name=data_name)
+
+    savepoint_names = get_all_savepoint_names(serializer_0)
+    for savepoint_name in sorted(list(savepoint_names)):
+        rank_list = []
+        names_list = list(
+            serializer_0.fields_at_savepoint(serializer_0.get_savepoint(savepoint_name)[0])
+        )
+        serializer_list = []
+        for rank in range(total_ranks):
+            serializer = get_serializer(data_path, rank, data_name)
+            serializer_list.append(serializer)
+            savepoints = serializer.get_savepoint(savepoint_name)
+            rank_data = {}
+            for name in set(names_list):
+                rank_data[name] = []
+                for savepoint in savepoints:
+                    rank_data[name].append(
+                        read_serialized_data(serializer, savepoint, name)
+                    )
+            rank_list.append(rank_data)
+        n_savepoints = len(savepoints)  # checking from last rank is fine
+        data_vars = {}
+        if n_savepoints > 0:
+            encoding = {}
+            for varname in set(names_list).difference(["rank"]):
+                data_shape = list(rank_list[0][varname][0].shape)
+                if savepoint_name in ["FVDynamics-In", "FVDynamics-Out", "Driver-In", "Driver-Out"]:
+                    if varname in [
+                        "qvapor",
+                        "qliquid",
+                        "qice",
+                        "qrain",
+                        "qsnow",
+                        "qgraupel",
+                        "qo3mr",
+                        "qsgs_tke",
+                    ]:
+                        data_vars[varname] = get_data(
+                            data_shape, total_ranks, n_savepoints, rank_list, varname
+                        )[:, :, 3:-3, 3:-3, :]
+                    else:
+                        data_vars[varname] = get_data(
+                            data_shape, total_ranks, n_savepoints, rank_list, varname
+                        )
+                else:
+                    data_vars[varname] = get_data(
+                        data_shape, total_ranks, n_savepoints, rank_list, varname
+                    )
+                if len(data_shape) > 2:
+                    encoding[varname] = {"zlib": True, "complevel": 1}
+            dataset = xr.Dataset(data_vars=data_vars)
+            dataset.to_netcdf(
+                os.path.join(output_path, f"{savepoint_name}.nc"), encoding=encoding
+            )
+
+
+def get_data(data_shape, total_ranks, n_savepoints, output_list, varname):
+    array = np.full([n_savepoints, total_ranks] + data_shape, fill_value=np.nan)
+    dims = ["savepoint", "rank"] + [
+        f"dim_{varname}_{i}" for i in range(len(data_shape))
+    ]
+    data = xr.DataArray(array, dims=dims)
+    for rank in range(total_ranks):
+        for i_savepoint in range(n_savepoints):
+            if len(data_shape) > 0:
+                data[i_savepoint, rank, :] = output_list[rank][varname][i_savepoint]
+            else:
+                data[i_savepoint, rank] = output_list[rank][varname][i_savepoint]
+    return data
+
+def entry_point():
+    parser = get_parser()
+    args = parser.parse_args()
+    main(data_path=args.data_path, output_path=args.output_path, data_name=args.data_name)
+
+if __name__ == "__main__":
+    entry_point()

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -353,7 +353,7 @@ def test_parallel_savepoint(
     subtests,
     caplog,
     threshold_overrides,
-    compute_grid,
+    grid,
     xy_indices=True,
 ):
     if MPI.COMM_WORLD.Get_size() % 6 != 0:
@@ -389,8 +389,8 @@ def test_parallel_savepoint(
         )
     if case.testobj.skip_test:
         return
-    if compute_grid and not case.testobj.compute_grid_option:
-        pytest.xfail(f"compute_grid option not used for test {case.savepoint_name}")
+    if grid and not case.testobj.compute_grid_option:
+        pytest.xfail(f"Grid compute option not used for test {case.savepoint_name}")
     input_data = dataset_to_dict(case.ds_in)
     # run python version of functionality
     output = case.testobj.compute_parallel(input_data, communicator)

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,9 @@ setup(
     url="https://github.com/NOAA-GFDL/NDSL",
     version="2024.04.00",
     zip_safe=False,
+    entry_points={
+        "console_scripts": [
+            "ndsl-serialbox_to_netcdf = ndsl.stencils.testing.serialbox_to_netcdf:entry_point",
+        ]
+    },
 )


### PR DESCRIPTION
**Description**
The Translate Test needs a lot of love. The first step is to make sure no code lives outside of `ndsl` that should be back to the mothership. This pulls `pyFV3` and `pySHiELD` code that should not be there.

⚠️ `pyFV3` and `pySHiELD` will break and need to be adapted. Namely there `conftest` needs to import `ndsl.conftest`⚠️ 

Other change to allow for an easier "from scratch" experience for testing are:
- `--dperiodic` is removed, replaced with a `--layout` option with `cube` and `tile` as values to describe which grid the test needs
- `--compute_grid` is removed and extended by `--grid` option with `file` (default), `compute` (replaces `--compute_grid` and `default` which allows to run a test with no `Grid-Info.nc` present on a simple `npx/npy/npz` grid with no metric terms
- The script to turn serialbox `.dat` to `netcdf` is now in `ndsl` and available on the command line with `ndsl-serialbox_to_netcdf`

**How Has This Been Tested?**
This comes around as we are building 101 notebooks. In the series, we are showing how to port Fortran code and are making a translate test from scratch, which prompted and tested those changes.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
