### PR TITLE
Changes to test configurations options and externals for parsing

### DIFF
--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -763,6 +763,7 @@ class GridIndexing:
             "local_js": gtscript.J[0] + self.jsc - origin[1],
             "j_end": j_end,
             "local_je": gtscript.J[-1] + self.jec - origin[1] - domain[1] + 1,
+            "mysign": -1.0,
         }
 
     def get_origin_domain(

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -763,7 +763,6 @@ class GridIndexing:
             "local_js": gtscript.J[0] + self.jsc - origin[1],
             "j_end": j_end,
             "local_je": gtscript.J[-1] + self.jec - origin[1] - domain[1] + 1,
-            "mysign": -1.0,
         }
 
     def get_origin_domain(

--- a/ndsl/stencils/corners.py
+++ b/ndsl/stencils/corners.py
@@ -997,7 +997,7 @@ def fill_corners_dgrid_defn(
         y_in (in):
         y_out (inout):
     """
-    from __externals__ import mysign, i_end, i_start, j_end, j_start
+    from __externals__ import i_end, i_start, j_end, j_start, mysign
 
     with computation(PARALLEL), interval(...):
         # sw corner

--- a/ndsl/stencils/corners.py
+++ b/ndsl/stencils/corners.py
@@ -989,7 +989,6 @@ def fill_corners_dgrid_defn(
     x_out: FloatField,
     y_in: FloatField,
     y_out: FloatField,
-    mysign: float,
 ):
     """
     Args:
@@ -998,7 +997,7 @@ def fill_corners_dgrid_defn(
         y_in (in):
         y_out (inout):
     """
-    from __externals__ import i_end, i_start, j_end, j_start
+    from __externals__ import mysign, i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
         # sw corner

--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -79,8 +79,8 @@ def pytest_addoption(parser):
     parser.addoption(
         "--topology",
         action="store",
-        default="cube-sphere",
-        help='Topology of the grid. "cube-sphere" means a 6-faced grid, "doubly-periodic" means a 1 tile grid. Default to "cube-sphere".',
+        default="cubed-sphere",
+        help='Topology of the grid. "cubed-sphere" means a 6-faced grid, "doubly-periodic" means a 1 tile grid. Default to "cube-sphere".',
     )
 
 
@@ -370,7 +370,7 @@ def generate_parallel_stencil_tests(metafunc, *, backend: str):
 
 
 def get_communicator(comm, layout, topology_mode):
-    if (MPI.COMM_WORLD.Get_size() > 1) and (topology_mode == "doubly-periodic"):
+    if (MPI.COMM_WORLD.Get_size() > 1) and (topology_mode == "cubed-sphere"):
         partitioner = CubedSpherePartitioner(TilePartitioner(layout))
         communicator = CubedSphereCommunicator(comm, partitioner)
     else:

--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -80,7 +80,7 @@ def pytest_addoption(parser):
         "--topology",
         action="store",
         default="cubed-sphere",
-        help='Topology of the grid. "cubed-sphere" means a 6-faced grid, "doubly-periodic" means a 1 tile grid. Default to "cube-sphere".',
+        help='Topology of the grid. "cubed-sphere" means a 6-faced grid, "doubly-periodic" means a 1 tile grid. Default to "cubed-sphere".',
     )
 
 
@@ -189,7 +189,7 @@ def get_ranks(metafunc, layout):
     if only_rank is None:
         if topology == "doubly-periodic":
             total_ranks = layout[0] * layout[1]
-        elif topology == "cube-sphere":
+        elif topology == "cubed-sphere":
             total_ranks = 6 * layout[0] * layout[1]
         else:
             raise NotImplementedError(f"Topology {topology} is unknown.")

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -389,7 +389,7 @@ def test_parallel_savepoint(
         )
     if case.testobj.skip_test:
         return
-    if grid and not case.testobj.compute_grid_option:
+    if (grid=="compute") and not case.testobj.compute_grid_option:
         pytest.xfail(f"Grid compute option not used for test {case.savepoint_name}")
     input_data = dataset_to_dict(case.ds_in)
     # run python version of functionality

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -389,7 +389,7 @@ def test_parallel_savepoint(
         )
     if case.testobj.skip_test:
         return
-    if (grid=="compute") and not case.testobj.compute_grid_option:
+    if (grid == "compute") and not case.testobj.compute_grid_option:
         pytest.xfail(f"Grid compute option not used for test {case.savepoint_name}")
     input_data = dataset_to_dict(case.ds_in)
     # run python version of functionality


### PR DESCRIPTION
**Description**
Conditional statement in `stencils/testing/test_translate.py` changed to check for `compute` passed via the `--grid` pytest option.

Switched conditional statement in `ndsl/stencils/testing/conftest.py` to check for option of `cubed-sphere` selection

Made `mysign` parameter of `fill_corners_dgrid_defn` an external variable

Resolves Issue [52](https://github.com/NOAA-GFDL/NDSL/issues/52)

**How Has This Been Tested?**
Tested in `pyFV3` and `pySHiELD` translate tests github workflow.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
