### PR TITLE
Cast parameters in Translate test to proper float precision

### DIFF
--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl.dsl.stencil import StencilFactory
-from ndsl.dsl.typing import Field  # noqa: F401
+from ndsl.dsl.typing import Field, Float  # noqa: F401
 from ndsl.quantity import Quantity
 from ndsl.stencils.testing.grid import Grid  # type: ignore
 
@@ -168,7 +168,7 @@ class TranslateFortranData2Py:
             if type(inputs_in[p]) in [np.int64, np.int32]:
                 inputs_out[p] = int(inputs_in[p])
             else:
-                inputs_out[p] = inputs_in[p]
+                inputs_out[p] = Float(inputs_in[p])
         for d, info in storage_vars.items():
             serialname = info["serialname"] if "serialname" in info else d
             self.update_info(info, inputs_in)


### PR DESCRIPTION
**Description**
Part of the mixed precision small details left after the original push. "Parameters" in translate test are not casted to Float using the global precision mechanism, leading to numerical errors for translate check at 32-bit float.

**How Has This Been Tested?**
Ongoing port of the microphysics in GEOS

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
