### PR TITLE
Translate test: "default" grid over-compute the npx/npy parameters

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -238,7 +238,7 @@ def _savepoint_cases(
     savepoint_names,
     ranks,
     stencil_config,
-    namelist,
+    namelist: Namelist,
     backend: str,
     data_path: str,
     grid_mode: str,
@@ -248,8 +248,8 @@ def _savepoint_cases(
     for rank in ranks:
         if grid_mode == "default":
             grid = Grid._make(
-                namelist.npx + 1,
-                namelist.npy + 1,
+                namelist.npx,
+                namelist.npy,
                 namelist.npz,
                 namelist.layout,
                 rank,


### PR DESCRIPTION
**Description**
When building a default Grid, do not pass adjusted npx/npy, as the `_make` function will do it for you.

**How Has This Been Tested?**
pyMoist (GEOSmoist physics) is using this feature.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
