### PR TITLE
FIX: Pinning numpy version in setup.py

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
         - name: Step Python
           uses: actions/setup-python@v4.6.0
           with:
-            python-version: '3.8.12'
+            python-version: '3.11.7'
         - name: Install OpenMPI for gt4py
           run: |
             sudo apt-get install libopenmpi-dev

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -11,7 +11,7 @@ jobs:
         python: [3.11.7]
     steps:
         - name: Checkout repository
-          uses: actions/checkout@v3.5.2
+          uses: actions/checkout@v4
           with:
             submodules: 'recursive'
         - name: Setup Python

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8.12, 3.11.7]
+        python: [3.11.7]
     steps:
         - name: Checkout repository
           uses: actions/checkout@v3.5.2

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -25,7 +25,6 @@ jobs:
           run: |
             python -m pip install --upgrade pip setuptools wheel
             pip install .[test]
-            pip list
         - name: Run serial-cpu tests
           run: |
             coverage run --rcfile=setup.cfg -m pytest -x tests

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -25,6 +25,7 @@ jobs:
           run: |
             python -m pip install --upgrade pip setuptools wheel
             pip install .[test]
+            pip list
         - name: Run serial-cpu tests
           run: |
             coverage run --rcfile=setup.cfg -m pytest -x tests

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,13 @@ requirements: List[str] = [
     "xarray",
     "f90nml>=1.1.0",
     "fsspec",
-    "netcdf4",
+    "netcdf4==1.7.0",
     "scipy",  # restart capacities only
     "h5netcdf",  # for xarray
-    "dask",  # for xarray
+    "dask==2024.5.2",  # for xarray
     "numpy==1.26.4",
+    "importlib_metadata==7.1.0",
+    "Faker==25.8.0",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements: List[str] = [
     "scipy",  # restart capacities only
     "h5netcdf",  # for xarray
     "dask",  # for xarray
-    # "numpy==1.26.4",
+    "numpy==1.26.4",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,8 @@ requirements: List[str] = [
     "netcdf4==1.7.0",
     "scipy",  # restart capacities only
     "h5netcdf",  # for xarray
-    "dask==2024.5.2",  # for xarray
+    "dask",  # for xarray
     "numpy==1.26.4",
-    "importlib_metadata==7.1.0",
-    "Faker==25.8.0",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements: List[str] = [
     "scipy",  # restart capacities only
     "h5netcdf",  # for xarray
     "dask",  # for xarray
-    "numpy==1.26.4",
+    # "numpy==1.26.4",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requirements: List[str] = [
     "scipy",  # restart capacities only
     "h5netcdf",  # for xarray
     "dask",  # for xarray
+    "numpy==1.26.4",
 ]
 
 


### PR DESCRIPTION
**Description**
FIX: Pins `numpy` and `netcdf5` versions to avoid API issues.

Tested in the dependent repositories `pace`, `pyFV3`, and `pySHiELD`.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
