### PR TITLE
Reverting changes to use of mysign in corners.py

### DIFF
--- a/ndsl/stencils/corners.py
+++ b/ndsl/stencils/corners.py
@@ -989,6 +989,7 @@ def fill_corners_dgrid_defn(
     x_out: FloatField,
     y_in: FloatField,
     y_out: FloatField,
+    mysign: float,
 ):
     """
     Args:
@@ -997,7 +998,7 @@ def fill_corners_dgrid_defn(
         y_in (in):
         y_out (inout):
     """
-    from __externals__ import i_end, i_start, j_end, j_start, mysign
+    from __externals__ import i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
         # sw corner


### PR DESCRIPTION
**Description**
Regarding fixes to orchestration for unused variables, this change of `mysign` to an external variable is no longer necessary, and so to preserve the original state of the python source this change is being reverted.

**How Has This Been Tested?**
Tested via CI triggering translate tests across dependent repositories

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
