### PR TITLE
Serialbox tool: fix type mismatch

### DIFF
--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -139,7 +139,16 @@ def main(data_path: str, output_path: str, data_name: Optional[str] = None):
 
 
 def get_data(data_shape, total_ranks, n_savepoints, output_list, varname):
-    array = np.full([n_savepoints, total_ranks] + data_shape, fill_value=np.nan)
+    # Read in dtype
+    if total_ranks <= 0:
+        return
+    varname_dtype = output_list[0][varname][0].dtype
+    # Build data array
+    array = np.full(
+        [n_savepoints, total_ranks] + data_shape,
+        fill_value=np.nan,
+        dtype=varname_dtype,
+    )
     dims = ["savepoint", "rank"] + [
         f"dim_{varname}_{i}" for i in range(len(data_shape))
     ]


### PR DESCRIPTION
**Description**
The tool to bring Serialbox raw data to netCDF was creating `np.float64` for all fields and scalars. This fix make sure the netCDF reflects the Fortran type as saved


**How Has This Been Tested?**
Local generation of dataset at f32 and f64 precision.


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
