### PR TITLE
Option to merge blocks in serialized data

### DIFF
--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -33,10 +33,11 @@ def get_parser():
         help="[Optional] Give the name of the data, will default to Generator_rankX",
     )
     parser.add_argument(
-        "-m", "--merge",
-        action='store_true',
+        "-m",
+        "--merge",
+        action="store_true",
         default=False,
-        help="merges datastreams blocked into separate savepoints"
+        help="merges datastreams blocked into separate savepoints",
     )
     return parser
 
@@ -64,7 +65,12 @@ def get_serializer(data_path: str, rank: int, data_name: Optional[str] = None):
     return serialbox.Serializer(serialbox.OpenModeKind.Read, data_path, name)
 
 
-def main(data_path: str, output_path: str, merge_blocks: bool, data_name: Optional[str] = None):
+def main(
+    data_path: str,
+    output_path: str,
+    merge_blocks: bool,
+    data_name: Optional[str] = None,
+):
     os.makedirs(output_path, exist_ok=True)
     namelist_filename_in = os.path.join(data_path, "input.nml")
 
@@ -77,18 +83,20 @@ def main(data_path: str, output_path: str, merge_blocks: bool, data_name: Option
     namelist = f90nml.read(namelist_filename_out)
     if namelist["fv_core_nml"]["grid_type"] <= 3:
         total_ranks = (
-            6 * namelist["fv_core_nml"]["layout"][0] * namelist["fv_core_nml"]["layout"][1]
+            6
+            * namelist["fv_core_nml"]["layout"][0]
+            * namelist["fv_core_nml"]["layout"][1]
         )
     else:
         total_ranks = (
             namelist["fv_core_nml"]["layout"][0] * namelist["fv_core_nml"]["layout"][1]
         )
-    nx = int((namelist["fv_core_nml"]['npx'] - 1) / (
-        namelist["fv_core_nml"]['layout'][0]
-    ))
-    ny = int((namelist["fv_core_nml"]['npy'] - 1) / (
-        namelist["fv_core_nml"]['layout'][1]
-    ))
+    nx = int(
+        (namelist["fv_core_nml"]["npx"] - 1) / (namelist["fv_core_nml"]["layout"][0])
+    )
+    ny = int(
+        (namelist["fv_core_nml"]["npy"] - 1) / (namelist["fv_core_nml"]["layout"][1])
+    )
 
     # all ranks have the same names, just look at first one
     serializer_0 = get_serializer(data_path, rank=0, data_name=data_name)
@@ -117,7 +125,7 @@ def main(data_path: str, output_path: str, merge_blocks: bool, data_name: Option
                 if merge_blocks and len(rank_data[name] > 1):
                     full_data = np.array(rank_data[name])
                     if len(full_data.shape) > 1:
-                        if (nx * ny == full_data.shape[0] * full_data.shape[1]):
+                        if nx * ny == full_data.shape[0] * full_data.shape[1]:
                             # If we have an (i, x) array from each block reshape it
                             new_shape = (nx, ny) + full_data.shape[2:]
                             full_data = full_data.reshape(new_shape)

--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -113,7 +113,7 @@ def main(data_path: str, output_path: str, merge_blocks: bool, data_name: Option
                     rank_data[name].append(
                         read_serialized_data(serializer, savepoint, name)
                     )
-                nblocks = len(rank_data.name)
+                nblocks = len(rank_data[name])
                 if merge_blocks and len(rank_data[name] > 1):
                     full_data = np.array(rank_data[name])
                     if len(full_data.shape) > 1:

--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -134,12 +134,6 @@ def main(
                             # could be a k-array or something else, so we take one copy
                             # TODO: is there a decent check for this?
                             full_data = full_data[0]
-                        #else:
-                        #    raise IndexError(
-                        #        "Shape mismatch in block merging: "
-                        #        f"{full_data.shape[0]} by {full_data.shape[1]} "
-                        #        f"is not compatible with {nx} by {ny}"
-                        #    )
                     elif len(full_data.shape) == 1:
                         # if it's a scalar from each block then just take one
                         full_data = full_data[0]

--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -113,6 +113,7 @@ def main(data_path: str, output_path: str, merge_blocks: bool, data_name: Option
                     rank_data[name].append(
                         read_serialized_data(serializer, savepoint, name)
                     )
+                nblocks = len(rank_data.name)
                 if merge_blocks and len(rank_data[name] > 1):
                     full_data = np.array(rank_data[name])
                     if len(full_data.shape) > 1:
@@ -120,11 +121,12 @@ def main(data_path: str, output_path: str, merge_blocks: bool, data_name: Option
                             # If we have an (i, x) array from each block reshape it
                             new_shape = (nx, ny) + full_data.shape[2:]
                             full_data = full_data.reshape(new_shape)
-                        elif full_data.shape[1] == namelist["fv_core_nml"]['npz']:
-                            # If it's a k-array from each block just take one
+                        elif full_data.shape[0] == nblocks:
+                            # We have one array for all blocks
+                            # could be a k-array or something else, so we take one copy
                             full_data = full_data[0]
                         else:
-                            return IndexError(
+                            raise IndexError(
                                 "Shape mismatch in block merging: "
                                 f"{full_data.shape[0]} by {full_data.shape[1]} "
                                 f"is not compatible with {nx} by {ny}"


### PR DESCRIPTION
**Description**
This PR adds an option to merge data into a single savepoint when the Fortran code has been horizontally blocked. Data is reshaped into nx by ny in order to fit directly into the correct quantity size.

**How Has This Been Tested?**
This code has been used to postprocess test data for pySHiELD development

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
