### PR TITLE
Hotfix for legacy metric error comparison

### DIFF
--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -53,11 +53,14 @@ def mark_untested(msg="This is not tested"):
 def _mask_to_dimensions(
     mask: Tuple[bool, ...], shape: Sequence[int]
 ) -> List[Union[str, int]]:
-    assert len(mask) == 3
+    assert len(mask) >= 3
     dimensions: List[Union[str, int]] = []
     for i, axis in enumerate(("I", "J", "K")):
         if mask[i]:
             dimensions.append(axis)
+    if len(mask) > 3:
+        for i in range(len(mask) - 3):
+            dimensions.append(None)
     offset = int(sum(mask))
     dimensions.extend(shape[offset:])
     return dimensions

--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -59,8 +59,8 @@ def _mask_to_dimensions(
         if mask[i]:
             dimensions.append(axis)
     if len(mask) > 3:
-        for i in range(len(mask) - 3):
-            dimensions.append(None)
+        for i in range(3, len(mask)):
+            dimensions.append(str(shape[i]))
     offset = int(sum(mask))
     dimensions.extend(shape[offset:])
     return dimensions

--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -154,6 +154,9 @@ def make_storage_data(
         data = _make_storage_data_2d(
             data, shape, start, dummy, axis, read_only, backend=backend
         )
+    elif n_dims == 4:
+        
+        data = _make_storage_data_4d(data, shape, start, backend=backend)
     else:
         data = _make_storage_data_3d(data, shape, start, backend=backend)
 
@@ -256,6 +259,23 @@ def _make_storage_data_3d(
     ] = asarray(data, type(buffer))
     return buffer
 
+def _make_storage_data_4d(
+    data: Field,
+    shape: Tuple[int, ...],
+    start: Tuple[int, ...] = (0, 0, 0, 0),
+    *,
+    backend: str,
+) -> Field:
+    istart, jstart, kstart, lstart = start
+    isize, jsize, ksize, lsize = data.shape
+    buffer = zeros(shape, backend=backend)
+    buffer[
+        istart : istart + isize,
+        jstart : jstart + jsize,
+        kstart : kstart + ksize,
+        lstart : lstart + lsize,
+    ] = asarray(data, type(buffer))
+    return buffer
 
 def make_storage_from_shape(
     shape: Tuple[int, ...],

--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -158,7 +158,6 @@ def make_storage_data(
             data, shape, start, dummy, axis, read_only, backend=backend
         )
     elif n_dims == 4:
-
         data = _make_storage_data_4d(data, shape, start, backend=backend)
     else:
         data = _make_storage_data_3d(data, shape, start, backend=backend)

--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -158,7 +158,7 @@ def make_storage_data(
             data, shape, start, dummy, axis, read_only, backend=backend
         )
     elif n_dims == 4:
-        
+
         data = _make_storage_data_4d(data, shape, start, backend=backend)
     else:
         data = _make_storage_data_3d(data, shape, start, backend=backend)
@@ -262,6 +262,7 @@ def _make_storage_data_3d(
     ] = asarray(data, type(buffer))
     return buffer
 
+
 def _make_storage_data_4d(
     data: Field,
     shape: Tuple[int, ...],
@@ -279,6 +280,7 @@ def _make_storage_data_4d(
         lstart : lstart + lsize,
     ] = asarray(data, type(buffer))
     return buffer
+
 
 def make_storage_from_shape(
     shape: Tuple[int, ...],
@@ -333,6 +335,7 @@ def make_storage_dict(
     axis: int = 2,
     *,
     backend: str,
+    dtype: DTypes = Float,
 ) -> Dict[str, "Field"]:
     assert names is not None, "for 4d variable storages, specify a list of names"
     if shape is None:
@@ -347,6 +350,7 @@ def make_storage_dict(
             dummy=dummy,
             axis=axis,
             backend=backend,
+            dtype=dtype,
         )
     return data_dict
 

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -125,7 +125,7 @@ class TranslateFortranData2Py:
                 backend=self.stencil_factory.backend,
             )
         else:
-            if len(array.shape == 4):
+            if len(array.shape) == 4:
                 start = (int(istart), int(jstart), int(kstart), 0)
                 use_shape.append(array.shape[-1])
             return utils.make_storage_data(

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -123,6 +123,7 @@ class TranslateFortranData2Py:
                 axis=axis,
                 names=names_4d,
                 backend=self.stencil_factory.backend,
+                dtype=array.dtype,
             )
         else:
             if len(array.shape) == 4:
@@ -137,6 +138,7 @@ class TranslateFortranData2Py:
                 axis=axis,
                 read_only=read_only,
                 backend=self.stencil_factory.backend,
+                dtype=array.dtype,
             )
 
     def storage_vars(self):

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl.dsl.stencil import StencilFactory
-from ndsl.dsl.typing import Field, Float  # noqa: F401
+from ndsl.dsl.typing import Field, Float, Int  # noqa: F401
 from ndsl.quantity import Quantity
 from ndsl.stencils.testing.grid import Grid  # type: ignore
 
@@ -113,6 +113,12 @@ class TranslateFortranData2Py:
         elif not full_shape and len(array.shape) < 3 and axis == len(array.shape) - 1:
             use_shape[1] = 1
         start = (int(istart), int(jstart), int(kstart))
+        if 'float' in str(array.dtype):
+            dtype = Float
+        elif 'int' in str(array.dtype):
+            dtype = Int
+        else:
+            dtype = array.dtype
         if names_4d:
             return utils.make_storage_dict(
                 array,
@@ -123,7 +129,7 @@ class TranslateFortranData2Py:
                 axis=axis,
                 names=names_4d,
                 backend=self.stencil_factory.backend,
-                dtype=array.dtype,
+                dtype=dtype,
             )
         else:
             if len(array.shape) == 4:
@@ -138,7 +144,7 @@ class TranslateFortranData2Py:
                 axis=axis,
                 read_only=read_only,
                 backend=self.stencil_factory.backend,
-                dtype=array.dtype,
+                dtype=dtype,
             )
 
     def storage_vars(self):

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -125,6 +125,9 @@ class TranslateFortranData2Py:
                 backend=self.stencil_factory.backend,
             )
         else:
+            if len(array.shape == 4):
+                start = (int(istart), int(jstart), int(kstart), 0)
+                use_shape.append(array.shape[-1])
             return utils.make_storage_data(
                 array,
                 tuple(use_shape),
@@ -159,7 +162,7 @@ class TranslateFortranData2Py:
         kstart = self.get_index_from_info(varinfo, "kstart", 0)
         return istart, jstart, kstart
 
-    def make_storage_data_input_vars(self, inputs, storage_vars=None):
+    def make_storage_data_input_vars(self, inputs, storage_vars=None, dict_4d=True):
         inputs_in = {**inputs}
         inputs_out = {}
         if storage_vars is None:
@@ -183,7 +186,7 @@ class TranslateFortranData2Py:
             )
 
             names_4d = None
-            if len(inputs_in[serialname].shape) == 4:
+            if (len(inputs_in[serialname].shape) == 4) and dict_4d:
                 names_4d = info.get("names_4d", utils.tracer_variables)
 
             dummy_axes = info.get("dummy_axes", None)

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -113,9 +113,9 @@ class TranslateFortranData2Py:
         elif not full_shape and len(array.shape) < 3 and axis == len(array.shape) - 1:
             use_shape[1] = 1
         start = (int(istart), int(jstart), int(kstart))
-        if 'float' in str(array.dtype):
+        if "float" in str(array.dtype):
             dtype = Float
-        elif 'int' in str(array.dtype):
+        elif "int" in str(array.dtype):
             dtype = Int
         else:
             dtype = array.dtype
@@ -133,7 +133,7 @@ class TranslateFortranData2Py:
             )
         else:
             if len(array.shape) == 4:
-                start = (int(istart), int(jstart), int(kstart), 0)
+                start = (int(istart), int(jstart), int(kstart), 0)  # type: ignore
                 use_shape.append(array.shape[-1])
             return utils.make_storage_data(
                 array,

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -123,7 +123,7 @@ class LegacyMetric(BaseMetric):
                 f"{reference_failures[b]}  {abs_errs[-1]:.3e}  {metric_err:.3e}"
             )
 
-            if np.isnan(metric_err) or (metric_err > worst_metric_err):
+            if np.isnan(metric_err) or (abs(metric_err) > abs(worst_metric_err)):
                 worst_metric_err = metric_err
                 worst_full_idx = full_index
                 worst_abs_err = abs_errs[-1]
@@ -249,7 +249,7 @@ class MultiModalFloatMetric(BaseMetric):
             f"All failures ({bad_indices_count}/{full_count}) ({failures_pct}%),\n",
             f"Index   Computed   Reference   "
             f"Absolute E(<{self.absolute_eps:.2e})  "
-            f"Relative E(<{self.relative_fraction*100:.2e}%)   "
+            f"Relative E(<{self.relative_fraction * 100:.2e}%)   "
             f"ULP E(<{self.ulp_threshold})",
         ]
         # Summary and worst result


### PR DESCRIPTION
**Description**
The comparison in LegacyMetric `if np.isnan(metric_err) or (metric_err > worst_metric_err):` can fail if all metric errors are negative real numbers, leading to no "worst index" being assigned and causing a memory error. It also means large negative errors won't be considered as bad as small positive ones, which is undersirable. This PR fixes that by comparing the absolute value of the errors to find the worst.

Fixes #72 

**How Has This Been Tested?**
Physics translate tests have been run with this

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
