### PR TITLE
hotfix to handle bools in serialized test data

### DIFF
--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -167,6 +167,8 @@ class TranslateFortranData2Py:
         for p in self.in_vars["parameters"]:
             if type(inputs_in[p]) in [np.int64, np.int32]:
                 inputs_out[p] = int(inputs_in[p])
+            elif type(inputs_in[p]) is bool:
+                inputs_out[p] == inputs_in[p]
             else:
                 inputs_out[p] = Float(inputs_in[p])
         for d, info in storage_vars.items():


### PR DESCRIPTION
**Description**
Previously, boolean namelist parameters were being cast to floats, which passed typechecks because native Python can handle int or float values as bools, but GT4Py does not, which caused problems with non-boolean conditionals inside stencils. This fixes that behavior by preserving boolean parameters in the translate test data.

Fixes # (issue)
If this is a hotfix to a released version, please specify it.

**How Has This Been Tested?**
Tested with physics translate tests

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
