### PR TITLE
[feature] Expose stencil vertical domain to Frozen Stencil

### DIFF
--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -349,14 +349,14 @@ class FrozenStencil(SDFGConvertible):
             ):
                 unblock_waiting_tiles(MPI.COMM_WORLD)
 
-        self._timing_collector.build_info[_stencil_object_name(self.stencil_object)] = (
-            build_info
-        )
+        self._timing_collector.build_info[
+            _stencil_object_name(self.stencil_object)
+        ] = build_info
         field_info = self.stencil_object.field_info
 
-        self._field_origins: Dict[str, Tuple[int, ...]] = (
-            FrozenStencil._compute_field_origins(field_info, self.origin)
-        )
+        self._field_origins: Dict[
+            str, Tuple[int, ...]
+        ] = FrozenStencil._compute_field_origins(field_info, self.origin)
         """mapping from field names to field origins"""
 
         self._stencil_run_kwargs: Dict[str, Any] = {

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -349,14 +349,14 @@ class FrozenStencil(SDFGConvertible):
             ):
                 unblock_waiting_tiles(MPI.COMM_WORLD)
 
-        self._timing_collector.build_info[
-            _stencil_object_name(self.stencil_object)
-        ] = build_info
+        self._timing_collector.build_info[_stencil_object_name(self.stencil_object)] = (
+            build_info
+        )
         field_info = self.stencil_object.field_info
 
-        self._field_origins: Dict[
-            str, Tuple[int, ...]
-        ] = FrozenStencil._compute_field_origins(field_info, self.origin)
+        self._field_origins: Dict[str, Tuple[int, ...]] = (
+            FrozenStencil._compute_field_origins(field_info, self.origin)
+        )
         """mapping from field names to field origins"""
 
         self._stencil_run_kwargs: Dict[str, Any] = {
@@ -737,7 +737,7 @@ class GridIndexing:
             "local_js": gtscript.J[0] + self.jsc - origin[1],
             "j_end": j_end,
             "local_je": gtscript.J[-1] + self.jec - origin[1] - domain[1] + 1,
-            "k_start": self.origin[2],
+            "k_start": origin[2],
             "k_end": self.origin[2] + domain[2] - 1,
         }
 

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -737,6 +737,8 @@ class GridIndexing:
             "local_js": gtscript.J[0] + self.jsc - origin[1],
             "j_end": j_end,
             "local_je": gtscript.J[-1] + self.jec - origin[1] - domain[1] + 1,
+            "k_start": self.origin[2],
+            "k_end": self.origin[2] + domain[2] - 1,
         }
 
     def get_origin_domain(

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -737,8 +737,9 @@ class GridIndexing:
             "local_js": gtscript.J[0] + self.jsc - origin[1],
             "j_end": j_end,
             "local_je": gtscript.J[-1] + self.jec - origin[1] - domain[1] + 1,
-            "k_start": origin[2],
-            "k_end": self.origin[2] + domain[2] - 1,
+            "k_start": origin[2] if len(origin) > 2 else 0,
+            "k_end": (origin[2] if len(origin) > 2 else 0)
+            + (domain[2] - 1 if len(domain) > 2 else 0),
         }
 
     def get_origin_domain(

--- a/tests/dsl/test_stencil_factory.py
+++ b/tests/dsl/test_stencil_factory.py
@@ -107,6 +107,23 @@ def test_get_stencils_with_varied_bounds_and_regions(backend: str):
     np.testing.assert_array_equal(q_orig.data, q_ref.data)
 
 
+def test_stencil_vertical_bounds(backend: str):
+    factory = get_stencil_factory(backend)
+    origins = [(3, 3, 0), (2, 2, 1)]
+    domains = [(1, 1, 3), (2, 2, 4)]
+    stencils = get_stencils_with_varied_bounds(
+        add_1_in_region_stencil,
+        origins,
+        domains,
+        stencil_factory=factory,
+    )
+
+    assert "k_start" in stencils[0].externals and stencils[0].externals["k_start"] == 0
+    assert "k_end" in stencils[0].externals and stencils[0].externals["k_end"] == 2
+    assert "k_start" in stencils[1].externals and stencils[1].externals["k_start"] == 1
+    assert "k_end" in stencils[1].externals and stencils[1].externals["k_end"] == 3
+
+
 @pytest.mark.parametrize("enabled", [True, False])
 def test_stencil_factory_numpy_comparison_from_dims_halo(enabled: bool):
     backend = "numpy"

--- a/tests/dsl/test_stencil_factory.py
+++ b/tests/dsl/test_stencil_factory.py
@@ -121,7 +121,7 @@ def test_stencil_vertical_bounds(backend: str):
     assert "k_start" in stencils[0].externals and stencils[0].externals["k_start"] == 0
     assert "k_end" in stencils[0].externals and stencils[0].externals["k_end"] == 2
     assert "k_start" in stencils[1].externals and stencils[1].externals["k_start"] == 1
-    assert "k_end" in stencils[1].externals and stencils[1].externals["k_end"] == 3
+    assert "k_end" in stencils[1].externals and stencils[1].externals["k_end"] == 4
 
 
 @pytest.mark.parametrize("enabled", [True, False])


### PR DESCRIPTION
**Description**
The new feature in development to allow absolute indexing in K allows to easily code patterns like "get the top of the column"... as long as you know what top is.

As we have done in the past for I and J, we expose via `__externals__` the bounds of K for the stencil.

This is a zero-cost variable (no cost when not used, no perf cost when used)

**How Has This Been Tested?**
Extended utest

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
