### PR TITLE
Fixing a typo that breaks bools in translate tests

### DIFF
--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -179,7 +179,7 @@ class TranslateFortranData2Py:
             if type(inputs_in[p]) in [np.int64, np.int32]:
                 inputs_out[p] = int(inputs_in[p])
             elif type(inputs_in[p]) is bool:
-                inputs_out[p] == inputs_in[p]
+                inputs_out[p] = inputs_in[p]
             else:
                 inputs_out[p] = Float(inputs_in[p])
         for d, info in storage_vars.items():


### PR DESCRIPTION
**Description**
There is a typo in the translate test class that causes crashes with bool test data

**How Has This Been Tested?**
Tests don't crash with this fix

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
