### PR TITLE
Ttranslate test `--which_savepoint`

### DIFF
--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -46,7 +46,6 @@ def global_set_floating_point_precision():
         NotImplementedError(
             f"{precision_in_bit} bit precision not implemented or tested"
         )
-    return None
 
 
 # Default float and int types

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -200,7 +200,10 @@ def test_sequential_savepoint(
     # Assign metrics and report on terminal any failures
     for varname in case.testobj.serialnames(case.testobj.out_vars):
         ignore_near_zero = case.testobj.ignore_near_zero_errors.get(varname, False)
-        ref_data = all_ref_data[varname]
+        try:
+            ref_data = all_ref_data[varname]
+        except KeyError:
+            raise KeyError(f'Output "{varname}" couldn\'t be found in output data')
         if hasattr(case.testobj, "subset_output"):
             ref_data = case.testobj.subset_output(varname, ref_data)
         with subtests.test(varname=varname):

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -179,7 +179,7 @@ class TranslateFortranData2Py:
         if storage_vars is None:
             storage_vars = self.storage_vars()
         for p in self.in_vars["parameters"]:
-            if type(inputs_in[p]) in [np.int64, np.int32]:
+            if type(inputs_in[p]) in [int, np.int64, np.int32]:
                 inputs_out[p] = int(inputs_in[p])
             elif type(inputs_in[p]) is bool:
                 inputs_out[p] = inputs_in[p]


### PR DESCRIPTION
New feature for translate test `--which_savepoint=X` with `X` a number, that allows to run only the given savepoint for a test when there's more than 1

Other QOL:
- better error when output netcdf is missing a required field
- remove return `None` on `Float` which throws mypy/flak8 into a tailspin
- fix a missing type check for regular python `int`