### PR TITLE
Hotfix for grid generation use of mpi operators

### DIFF
--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
+from ndsl.comm.comm_abc import ReductionOperator
 from ndsl.comm.communicator import Communicator
 from ndsl.constants import (
     N_HALO_DEFAULT,
@@ -3428,7 +3429,11 @@ class MetricTerms:
         max_area = self._np.max(self.area.data[3:-4, 3:-4])[()]
         min_area_c = self._np.min(self.area_c.data[3:-4, 3:-4])[()]
         max_area_c = self._np.max(self.area_c.data[3:-4, 3:-4])[()]
-        self._da_min = float(self._comm.comm.allreduce(min_area, min))
-        self._da_max = float(self._comm.comm.allreduce(max_area, max))
-        self._da_min_c = float(self._comm.comm.allreduce(min_area_c, min))
-        self._da_max_c = float(self._comm.comm.allreduce(max_area_c, max))
+        self._da_min = float(self._comm.comm.allreduce(min_area, ReductionOperator.MIN))
+        self._da_max = float(self._comm.comm.allreduce(max_area, ReductionOperator.MAX))
+        self._da_min_c = float(
+            self._comm.comm.allreduce(min_area_c, ReductionOperator.MIN)
+        )
+        self._da_max_c = float(
+            self._comm.comm.allreduce(max_area_c, ReductionOperator.MAX)
+        )


### PR DESCRIPTION
**Description**
This PR amends the usage of `MPIComm.allreduce` in `ndsl/grid/generation::MetricTerms._reduce_global_area_minmaxes` to use `ReductionOperator` instances instead of built-in methods.

**How Has This Been Tested?**
Tested using the tests currently include in the github workflow. An additional test of a numpy backend c12 baroclinic, 1x1 layout run will be added to the pace workflow as well to ensure future commits do not effect model runs.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
