### PR TITLE
Hotfix to netcdf python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requirements: List[str] = [
     "xarray",
     "f90nml>=1.1.0",
     "fsspec",
-    "netcdf4==1.7.0",
+    "netcdf4==1.7.1",
     "scipy",  # restart capacities only
     "h5netcdf",  # for xarray
     "dask",  # for xarray


### PR DESCRIPTION
**Description**
This updates the version of netcdf4 to 1.7.1, which fixes install paths we need for our dockerfiles.

**How Has This Been Tested?**
docker images have been successfully built after this change

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
