### PR TITLE
Adding in exception for compute domains with sizes less than or equal to halo size

### DIFF
--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -460,14 +460,18 @@ class Communicator(abc.ABC):
 
         # TODO: TO be removed following correction to issue
         for quantity in x_quantities:
-            if quantity.view.extent[0] < 4 or quantity.view.extent[1] < 4:
+            halo_x = (quantity.data.shape[0] - quantity.view.extent[0])/2
+            halo_y = (quantity.data.shape[1] - quantity.view.extent[1])/2
+            if quantity.view.extent[0] <= halo_x or quantity.view.extent[1] <= halo_y:
                 raise Exception(
-                    "Communicator::vector_halo_update Compute domain must have at least 4 points"
+                    "Communicator::vector_halo_update Compute domain edge size must greater than halo size"
                 )
         for quantity in y_quantities:
-            if quantity.view.extent[0] < 4 or quantity.view.extent[1] < 4:
+            halo_x = (quantity.data.shape[0] - quantity.view.extent[0])/2
+            halo_y = (quantity.data.shape[1] - quantity.view.extent[1])/2
+            if quantity.view.extent[0] <= halo_x or quantity.view.extent[1] <= halo_y:
                 raise Exception(
-                    "Communicator::vector_halo_update Compute domain must have at least 4 points"
+                    "Communicator::vector_halo_update Compute domain edge size must greater than halo size"
                 )
 
         halo_updater = self.start_vector_halo_update(

--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -460,15 +460,15 @@ class Communicator(abc.ABC):
 
         # TODO: TO be removed following correction to issue
         for quantity in x_quantities:
-            halo_x = (quantity.data.shape[0] - quantity.view.extent[0])/2
-            halo_y = (quantity.data.shape[1] - quantity.view.extent[1])/2
+            halo_x = (quantity.data.shape[0] - quantity.view.extent[0]) / 2
+            halo_y = (quantity.data.shape[1] - quantity.view.extent[1]) / 2
             if quantity.view.extent[0] <= halo_x or quantity.view.extent[1] <= halo_y:
                 raise Exception(
                     "Communicator::vector_halo_update Compute domain edge size must greater than halo size"
                 )
         for quantity in y_quantities:
-            halo_x = (quantity.data.shape[0] - quantity.view.extent[0])/2
-            halo_y = (quantity.data.shape[1] - quantity.view.extent[1])/2
+            halo_x = (quantity.data.shape[0] - quantity.view.extent[0]) / 2
+            halo_y = (quantity.data.shape[1] - quantity.view.extent[1]) / 2
             if quantity.view.extent[0] <= halo_x or quantity.view.extent[1] <= halo_y:
                 raise Exception(
                     "Communicator::vector_halo_update Compute domain edge size must greater than halo size"

--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -458,22 +458,6 @@ class Communicator(abc.ABC):
         else:
             y_quantities = y_quantity
 
-        # TODO: TO be removed following correction to issue
-        for quantity in x_quantities:
-            halo_x = (quantity.data.shape[0] - quantity.view.extent[0]) / 2
-            halo_y = (quantity.data.shape[1] - quantity.view.extent[1]) / 2
-            if quantity.view.extent[0] <= halo_x or quantity.view.extent[1] <= halo_y:
-                raise Exception(
-                    "Communicator::vector_halo_update Compute domain edge size must greater than halo size"
-                )
-        for quantity in y_quantities:
-            halo_x = (quantity.data.shape[0] - quantity.view.extent[0]) / 2
-            halo_y = (quantity.data.shape[1] - quantity.view.extent[1]) / 2
-            if quantity.view.extent[0] <= halo_x or quantity.view.extent[1] <= halo_y:
-                raise Exception(
-                    "Communicator::vector_halo_update Compute domain edge size must greater than halo size"
-                )
-
         halo_updater = self.start_vector_halo_update(
             x_quantities, y_quantities, n_points
         )

--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -458,6 +458,18 @@ class Communicator(abc.ABC):
         else:
             y_quantities = y_quantity
 
+        # TODO: TO be removed following correction to issue
+        for quantity in x_quantities:
+            if quantity.view.extent[0] < 4 or quantity.view.extent[1] < 4:
+                raise Exception(
+                    "Communicator::vector_halo_update Compute domain must have at least 4 points"
+                )
+        for quantity in y_quantities:
+            if quantity.view.extent[0] < 4 or quantity.view.extent[1] < 4:
+                raise Exception(
+                    "Communicator::vector_halo_update Compute domain must have at least 4 points"
+                )
+
         halo_updater = self.start_vector_halo_update(
             x_quantities, y_quantities, n_points
         )

--- a/ndsl/initialization/sizer.py
+++ b/ndsl/initialization/sizer.py
@@ -66,6 +66,17 @@ class SubtileGridSizer(GridSizer):
         )
         nx = x_slice.stop - x_slice.start
         ny = y_slice.stop - y_slice.start
+
+        # TODO: Remove after vector halo update issue resolved
+        if nx <= n_halo:
+            raise Exception(
+                "SubtileGridSizer::from_tile_params: Compute domain extent must be greater than halo size"
+            )
+        if ny <= n_halo:
+            raise Exception(
+                "SubtileGridSizer::from_tile_params: Compute domain extent must be greater than halo size"
+            )
+
         return cls(nx, ny, nz, n_halo, extra_dim_lengths)
 
     @classmethod


### PR DESCRIPTION
**Description**
This PR is linked to the discussion and investigation linked to [Issue 81](https://github.com/NOAA-GFDL/NDSL/issues/81). For `Quantity` objects with a compute domain containing less than 4 points and exception will be raised when calling `vector_halo_update`.

**How Has This Been Tested?**
Tested using the current unit tests available within `NDSL` and the repositories of which it is a submodule.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
