### PR TITLE
[Fix] Pressure coefficients from external source

### DIFF
--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -298,7 +298,7 @@ class MetricTerms:
         self._dy_center = None
         self._area = None
         self._area_c = None
-        if eta_file is not None:
+        if eta_file is not None or ak is not None or bk is not None:
             (
                 self._ks,
                 self._ptop,


### PR DESCRIPTION
Fix passing down ak/bk for pressure coefficients when they are available from an outside source (online model case) and given direct to `MetricTerms.__init__`


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
