### PR TITLE
[CI] Streamline linting workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,20 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout repository
-          uses: actions/checkout@v3.5.2
+          uses: actions/checkout@v4
           with:
             submodules: 'recursive'
-        - name: Step Python
-          uses: actions/setup-python@v4.6.0
+
+        - name: Setup Python 3.11
+          uses: actions/setup-python@v5
           with:
-            python-version: '3.11.7'
-        - name: Install OpenMPI for gt4py
-          run: |
-            sudo apt-get install libopenmpi-dev
-        - name: Install Python packages
-          run: |
-            python -m pip install --upgrade pip setuptools wheel
-            pip install .[develop]
+            python-version: '3.11'
+
+        - name: Install pre-commit
+          run: pip install pre-commit
+
         - name: Run lint via pre-commit
-          run: |
-            pre-commit run --all-files
+          run: pre-commit run --all-files


### PR DESCRIPTION
**Description**

Linting should give fast feedback. The current workflow takes ~3mins where most of the time is spent installing (unnecessary) python packages. To run `pre-commit`, we only need the source files and `pre-commit` itself, which can be installed standalone. This brings runtime of the linting stage down to less than a minute.

Other changes

- update checkout action to v4
- update python setup action to v5
- change python version from 3.11.7 to 3.11 (any patch number will do)

This is a follow-up of PR https://github.com/NOAA-GFDL/PyFV3/pull/40 in PyFV3.

**How Has This Been Tested?**

Changed CI workflow is still passing.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
