### PR TITLE
[Feature] Porting workflow: enhancing errors readability

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -97,6 +97,12 @@ def pytest_addoption(parser):
         default="ulp",
         help='Sort the report by "index" (ascending) or along the metric: "ulp", "absolute", "relative" (descending). Default to "ulp"',
     )
+    parser.addoption(
+        "--no_report",
+        action="store_true",
+        default=False,
+        help="Do not generate logging report or NetCDF in .translate-errors",
+    )
 
 
 def pytest_configure(config):
@@ -244,6 +250,7 @@ def sequential_savepoint_cases(metafunc, data_path, namelist_filename, *, backen
     grid_mode = metafunc.config.getoption("grid")
     topology_mode = metafunc.config.getoption("topology")
     sort_report = metafunc.config.getoption("sort_report")
+    no_report = metafunc.config.getoption("no_report")
     return _savepoint_cases(
         savepoint_names,
         ranks,
@@ -255,6 +262,7 @@ def sequential_savepoint_cases(metafunc, data_path, namelist_filename, *, backen
         grid_mode,
         topology_mode,
         sort_report=sort_report,
+        no_report=no_report,
     )
 
 
@@ -269,6 +277,7 @@ def _savepoint_cases(
     grid_mode: str,
     topology_mode: bool,
     sort_report: str,
+    no_report: bool,
 ):
     return_list = []
     for rank in ranks:
@@ -322,6 +331,7 @@ def _savepoint_cases(
                         testobj=testobj,
                         grid=grid,
                         sort_report=sort_report,
+                        no_report=no_report,
                     )
                 )
     return return_list
@@ -343,6 +353,7 @@ def parallel_savepoint_cases(
     namelist = get_namelist(namelist_filename)
     topology_mode = metafunc.config.getoption("topology")
     sort_report = metafunc.config.getoption("sort_report")
+    no_report = metafunc.config.getoption("no_report")
     communicator = get_communicator(comm, namelist.layout, topology_mode)
     stencil_config = get_config(backend, communicator)
     savepoint_names = get_parallel_savepoint_names(metafunc, data_path)
@@ -359,6 +370,7 @@ def parallel_savepoint_cases(
         grid_mode,
         topology_mode,
         sort_report=sort_report,
+        no_report=no_report,
     )
 
 
@@ -425,11 +437,6 @@ def failure_stride(pytestconfig):
 @pytest.fixture()
 def multimodal_metric(pytestconfig):
     return bool(pytestconfig.getoption("multimodal_metric"))
-
-
-@pytest.fixture()
-def sort_report(pytestconfig):
-    return pytestconfig.getoption("report_sort")
 
 
 @pytest.fixture()

--- a/ndsl/stencils/testing/savepoint.py
+++ b/ndsl/stencils/testing/savepoint.py
@@ -21,11 +21,32 @@ def _process_if_scalar(value: np.ndarray) -> Union[np.ndarray, float, int]:
         return value
 
 
+class DataLoader:
+    def __init__(self, rank: int, data_path: str):
+        self._data_path = data_path
+        self._rank = rank
+
+    def load(
+        self,
+        name: str,
+        postfix: str = "",
+        i_call: int = 0,
+    ) -> Dict[str, Union[np.ndarray, float, int]]:
+        return dataset_to_dict(
+            xr.open_dataset(os.path.join(self._data_path, f"{name}{postfix}.nc"))
+            .isel(rank=self._rank)
+            .isel(savepoint=i_call)
+        )
+
+
 class Translate(Protocol):
     def collect_input_data(self, ds: xr.Dataset) -> dict:
         ...
 
     def compute(self, data: dict):
+        ...
+
+    def extra_data_load(self, data_loader: DataLoader):
         ...
 
 

--- a/ndsl/stencils/testing/savepoint.py
+++ b/ndsl/stencils/testing/savepoint.py
@@ -41,6 +41,7 @@ class SavepointCase:
     testobj: Translate
     grid: Grid
     sort_report: str
+    no_report: bool
 
     def __str__(self):
         return f"{self.savepoint_name}-rank={self.grid.rank}-call={self.i_call}"

--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -140,7 +140,8 @@ def main(
         data_vars = {}
         if n_savepoints > 0:
             encoding = {}
-            for varname in set(names_list).difference(["rank"]):
+            names_indices = np.sort(list(set(names_list).difference(["rank"])))
+            for varname in names_indices:
                 # Check that all ranks have the same size. If not, aggregate and
                 # feedback on one rank
                 collapse_all_ranks = False

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -67,9 +67,9 @@ def process_override(threshold_overrides, testobj, test_name, backend):
                         for key in testobj.out_vars.keys():
                             if key not in testobj.ignore_near_zero_errors:
                                 testobj.ignore_near_zero_errors[key] = {}
-                                testobj.ignore_near_zero_errors[key]["near_zero"] = (
-                                    float(match["all_other_near_zero"])
-                                )
+                                testobj.ignore_near_zero_errors[key][
+                                    "near_zero"
+                                ] = float(match["all_other_near_zero"])
 
                 else:
                     raise TypeError(
@@ -235,8 +235,9 @@ def test_sequential_savepoint(
         ref_data_out[varname] = [ref_data]
 
     # Reporting & data save
-    _report_results(case.savepoint_name, case.grid.rank, results)
-    if len(failing_names) > 0:
+    if not case.no_report:
+        _report_results(case.savepoint_name, case.grid.rank, results)
+    if len(failing_names) > 0 and not case.no_report:
         get_thresholds(case.testobj, input_data=original_input_data)
         os.makedirs(OUTDIR, exist_ok=True)
         nc_filename = os.path.join(OUTDIR, f"translate-{case.savepoint_name}.nc")
@@ -424,7 +425,8 @@ def _report_results(
     rank: int,
     results: Dict[str, BaseMetric],
 ) -> None:
-    os.makedirs(OUTDIR, exist_ok=True)
+    detail_dir = f"{OUTDIR}/details"
+    os.makedirs(detail_dir, exist_ok=True)
 
     # Summary
     with open(f"{OUTDIR}/summary-{savepoint_name}-{rank}.log", "w") as f:
@@ -434,7 +436,7 @@ def _report_results(
     # Detailed log
     for varname, metric in results.items():
         log_filename = os.path.join(
-            OUTDIR, f"details-{savepoint_name}-{varname}-{rank}.log"
+            detail_dir, f"{savepoint_name}-{varname}-{rank}.log"
         )
         metric.report(log_filename)
 

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -14,7 +14,7 @@ from ndsl.dsl.dace.dace_config import DaceConfig
 from ndsl.dsl.stencil import CompilationConfig, StencilConfig
 from ndsl.quantity import Quantity
 from ndsl.restart._legacy_restart import RESTART_PROPERTIES
-from ndsl.stencils.testing.savepoint import SavepointCase, dataset_to_dict
+from ndsl.stencils.testing.savepoint import DataLoader, SavepointCase, dataset_to_dict
 from ndsl.testing.comparison import BaseMetric, LegacyMetric, MultiModalFloatMetric
 from ndsl.testing.perturbation import perturb
 
@@ -191,6 +191,9 @@ def test_sequential_savepoint(
             f"Variable {e} was described in the translate test but cannot be found in the NetCDF"
         )
     original_input_data = copy.deepcopy(input_data)
+    # give the user a chance to load data from other savepoints to allow
+    # for gathering required data from multiple sources (constants, etc.)
+    case.testobj.extra_data_load(DataLoader(case.grid.rank, case.data_dir))
     # run python version of functionality
     output = case.testobj.compute(input_data)
     failing_names: List[str] = []

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -208,7 +208,7 @@ def test_sequential_savepoint(
         try:
             ref_data = all_ref_data[varname]
         except KeyError:
-            raise KeyError(f'Output "{varname}" couldn\'t be found in output data')
+            raise KeyError(f"Output {varname} couldn't be found in output data")
         if hasattr(case.testobj, "subset_output"):
             ref_data = case.testobj.subset_output(varname, ref_data)
         with subtests.test(varname=varname):

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -79,24 +79,33 @@ class TranslateFortranData2Py:
     def extra_data_load(self, data_loader: DataLoader):
         pass
 
-    def setup(self, inputs):
+    def setup(self, inputs) -> None:
+        """Transform inputs to gt4py.storages specification (correct device, layout)"""
         self.make_storage_data_input_vars(inputs)
 
-    def compute_func(self, **inputs):
+    def compute_func(self, **inputs) -> Optional[dict[str, Any]]:
         """Compute function to transform the dictionary of `inputs`.
         Must return a dictionnary of updated variables"""
         raise NotImplementedError("Implement a child class compute method")
 
-    def compute(self, inputs):
+    def compute(self, inputs) -> dict[str, Any]:
+        """Transform inputs from NetCDF to gt4py.storagers, run compute_func then slice
+        the outputs based on specifications.
+
+        Return: Dictonnary of storages reshaped for comparison
+        """
         self.setup(inputs)
         return self.slice_output(self.compute_from_storage(inputs))
 
     # assume inputs already has been turned into gt4py storages (or Quantities)
-    def compute_from_storage(self, inputs):
+    def compute_from_storage(self, inputs) -> dict[str, Any]:
         """Run `compute_func` and return an updated `inputs` dictionary with
         the returned results of `compute_func`.
 
-        Hypothesis: `inputs` are `gt4py.storages`"""
+        Hypothesis: `inputs` are `gt4py.storages`
+
+        Return: Outputs in the form of a Dict[str, gt4py.storages]
+        """
         outputs = self.compute_func(**inputs)
         if outputs is not None:
             inputs.update(outputs)
@@ -124,10 +133,12 @@ class TranslateFortranData2Py:
         names_4d: Optional[List[str]] = None,
         read_only: bool = False,
         full_shape: bool = False,
-    ) -> Dict[str, "Field"]:
+    ) -> "Field":
         """Copy input data into a gt4py.storage with given shape.
 
         `array` is copied. Takes care of the device upload if necessary.
+
+        Return: Array in the form of a Dict[str, gt4py.storages]
         """
         use_shape = list(self.maxshape)
         if dummy_axes:
@@ -187,9 +198,14 @@ class TranslateFortranData2Py:
         kstart = self.get_index_from_info(varinfo, "kstart", 0)
         return istart, jstart, kstart
 
-    def make_storage_data_input_vars(self, inputs, storage_vars=None, dict_4d=True):
-        """From a set of raw inputs, use the `in_vars` dictionnary to update inputs to
-        their configured shape."""
+    def make_storage_data_input_vars(
+        self, inputs, storage_vars=None, dict_4d=True
+    ) -> None:
+        """From a set of raw inputs (straight from NetCDF), use the `in_vars` dictionnary to update inputs to
+        their configured shape.
+
+        Return: None
+        """
         inputs_in = {**inputs}
         inputs_out = {}
         if storage_vars is None:
@@ -236,7 +252,7 @@ class TranslateFortranData2Py:
         inputs.clear()
         inputs.update(inputs_out)
 
-    def slice_output(self, inputs, out_data=None):
+    def slice_output(self, inputs, out_data=None) -> dict[str, Any]:
         utils.device_sync(backend=self.stencil_factory.backend)
         if out_data is None:
             out_data = inputs

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -8,6 +8,7 @@ from ndsl.dsl.stencil import StencilFactory
 from ndsl.dsl.typing import Field, Float, Int  # noqa: F401
 from ndsl.quantity import Quantity
 from ndsl.stencils.testing.grid import Grid  # type: ignore
+from ndsl.stencils.testing.savepoint import DataLoader
 
 
 try:
@@ -74,6 +75,9 @@ class TranslateFortranData2Py:
         self.ordered_input_vars = None
         self.ignore_near_zero_errors: Dict[str, Any] = {}
         self.skip_test: bool = False
+
+    def extra_data_load(self, data_loader: DataLoader):
+        pass
 
     def setup(self, inputs):
         self.make_storage_data_input_vars(inputs)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements: List[str] = [
     local_pkg("dace", "external/dace"),
     "mpi4py==3.1.5",
     "cftime",
-    "xarray",
+    "xarray>=2025.01.2",  # datatree + fixes
     "f90nml>=1.1.0",
     "fsspec",
     "netcdf4==1.7.1",


### PR DESCRIPTION
A few small tweaks to improve the porting workflow:
- `--no_report` option: doesn't save logs or netcdf when failing translate test.
- Organize fields in error report netcdf by `fail` / `pass` and variable names (sorted).
- Logs moved to a `details` subfolder
- Order variable name in the resulting NetCDF when using `serialbox-to-netcdf`

:warning: Update to `xarray` to make the new netcdf datatree possible :warning: 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
