### PR TITLE
Adds some quick capacities used in the post-radiation phase of the physics, including the  Stefan-Boltzmann constant

### DIFF
--- a/ndsl/constants.py
+++ b/ndsl/constants.py
@@ -126,6 +126,7 @@ else:
     raise RuntimeError("Constant selector failed, bad code.")
 
 SECONDS_PER_DAY = Float(86400.0)
+SBC = 5.670400e-8  # Stefan-Boltzmann constant (W/m^2/K^4)
 DZ_MIN = Float(2.0)
 CV_AIR = CP_AIR - RDGAS  # Heat capacity of dry air at constant volume
 RDG = -RDGAS / GRAV

--- a/ndsl/constants.py
+++ b/ndsl/constants.py
@@ -126,7 +126,8 @@ else:
     raise RuntimeError("Constant selector failed, bad code.")
 
 SECONDS_PER_DAY = Float(86400.0)
-SBC = 5.670400e-8  # Stefan-Boltzmann constant (W/m^2/K^4)
+SBC = 5.670400e-8
+"""Stefan-Boltzmann constant (W/m^2/K^4)"""
 DZ_MIN = Float(2.0)
 CV_AIR = CP_AIR - RDGAS  # Heat capacity of dry air at constant volume
 RDG = -RDGAS / GRAV

--- a/ndsl/namelist.py
+++ b/ndsl/namelist.py
@@ -490,6 +490,7 @@ class Namelist:
     nf_omega: int = NamelistDefaults.nf_omega
     fv_sg_adj: int = NamelistDefaults.fv_sg_adj
     n_sponge: int = NamelistDefaults.n_sponge
+    daily_mean: bool = False # flag to replace cosz with daily mean value in physics
 
     @classmethod
     def from_f90nml(cls, namelist: f90nml.Namelist):

--- a/ndsl/namelist.py
+++ b/ndsl/namelist.py
@@ -490,7 +490,7 @@ class Namelist:
     nf_omega: int = NamelistDefaults.nf_omega
     fv_sg_adj: int = NamelistDefaults.fv_sg_adj
     n_sponge: int = NamelistDefaults.n_sponge
-    daily_mean: bool = False # flag to replace cosz with daily mean value in physics
+    daily_mean: bool = False  # flag to replace cosz with daily mean value in physics
 
     @classmethod
     def from_f90nml(cls, namelist: f90nml.Namelist):

--- a/ndsl/namelist.py
+++ b/ndsl/namelist.py
@@ -490,7 +490,8 @@ class Namelist:
     nf_omega: int = NamelistDefaults.nf_omega
     fv_sg_adj: int = NamelistDefaults.fv_sg_adj
     n_sponge: int = NamelistDefaults.n_sponge
-    daily_mean: bool = False  # flag to replace cosz with daily mean value in physics
+    daily_mean: bool = False
+    """Flag to replace cosz with daily mean value in physics"""
 
     @classmethod
     def from_f90nml(cls, namelist: f90nml.Namelist):


### PR DESCRIPTION
**Description**
Adds the Stephan-Boltzmann constant to constants, and adds the "daily mean" namelist option for physics to use daily mean radiation values instead of interpolated ones.

**How Has This Been Tested?**
PySHiELD tests pass with these changes

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
