### PR TITLE
Feature: NetCDF output precision configurable

### DIFF
--- a/ndsl/monitor/netcdf_monitor.py
+++ b/ndsl/monitor/netcdf_monitor.py
@@ -115,7 +115,7 @@ class NetCDFMonitor:
         path: str,
         communicator: Communicator,
         time_chunk_size: int = 1,
-        precision: str="Float",
+        precision: str = "Float",
     ):
         """Create a NetCDFMonitor.
 
@@ -137,11 +137,15 @@ class NetCDFMonitor:
         elif precision == "float32":
             self._transfer_type = np.float32
         elif precision == "float64":
+            if np.float32 == Float:
+                raise ValueError(
+                    f"Cannot output float64 with PACE_FLOAT_PRECISION set to {Float}"
+                )
             self._transfer_type = np.float64
         else:
             raise ValueError(
                 "precision must be set to one of 'Float', 'float32', or 'float64"
-                f"got {self.precision}"
+                f"got {precision}"
             )
 
     @property
@@ -177,12 +181,16 @@ class NetCDFMonitor:
                     set(state.keys()), self._expected_vars
                 )
             )
-        state = self._communicator.tile.gather_state(state, transfer_type=self._transfer_type)
+        state = self._communicator.tile.gather_state(
+            state, transfer_type=self._transfer_type
+        )
         if state is not None:  # we are on root rank
             self._writer.append(state)
 
     def store_constant(self, state: Dict[str, Quantity]) -> None:
-        state = self._communicator.gather_state(state, transfer_type=self._transfer_type)
+        state = self._communicator.gather_state(
+            state, transfer_type=self._transfer_type
+        )
         if state is not None:  # we are on root rank
             constants_filename = str(
                 Path(self._path) / NetCDFMonitor._CONSTANT_FILENAME

--- a/ndsl/monitor/netcdf_monitor.py
+++ b/ndsl/monitor/netcdf_monitor.py
@@ -136,7 +136,7 @@ class NetCDFMonitor:
         self._transfer_type = precision
         if self._transfer_type == np.float32 and get_precision() > 32:
             warn(
-                "NetCDF save: requested 32-bit float but precision of NDSL is {get_precision()}, cast will occur with possible loss of precision"
+                f"NetCDF save: requested 32-bit float but precision of NDSL is {get_precision()}, cast will occur with possible loss of precision"
             )
 
     @property

--- a/ndsl/monitor/netcdf_monitor.py
+++ b/ndsl/monitor/netcdf_monitor.py
@@ -115,7 +115,7 @@ class NetCDFMonitor:
         path: str,
         communicator: Communicator,
         time_chunk_size: int = 1,
-        precision: str = "Float",
+        precision=Float,
     ):
         """Create a NetCDFMonitor.
 
@@ -132,11 +132,11 @@ class NetCDFMonitor:
         self._time_chunk_size = time_chunk_size
         self.__writer: Optional[_ChunkedNetCDFWriter] = None
         self._expected_vars: Optional[Set[str]] = None
-        if precision == "Float":
+        if precision == Float:
             self._transfer_type = Float
-        elif precision == "float32":
+        elif precision == np.float32:
             self._transfer_type = np.float32
-        elif precision == "float64":
+        elif precision == np.float64:
             if np.float32 == Float:
                 raise ValueError(
                     f"Cannot output float64 with PACE_FLOAT_PRECISION set to {Float}"

--- a/ndsl/monitor/netcdf_monitor.py
+++ b/ndsl/monitor/netcdf_monitor.py
@@ -6,6 +6,7 @@ import fsspec
 import numpy as np
 
 from ndsl.comm.communicator import Communicator
+from ndsl.dsl.typing import Float
 from ndsl.filesystem import get_fs
 from ndsl.logging import ndsl_log
 from ndsl.monitor.convert import to_numpy
@@ -164,12 +165,12 @@ class NetCDFMonitor:
                     set(state.keys()), self._expected_vars
                 )
             )
-        state = self._communicator.tile.gather_state(state, transfer_type=np.float32)
+        state = self._communicator.tile.gather_state(state, transfer_type=Float)
         if state is not None:  # we are on root rank
             self._writer.append(state)
 
     def store_constant(self, state: Dict[str, Quantity]) -> None:
-        state = self._communicator.gather_state(state, transfer_type=np.float32)
+        state = self._communicator.gather_state(state, transfer_type=Float)
         if state is not None:  # we are on root rank
             constants_filename = str(
                 Path(self._path) / NetCDFMonitor._CONSTANT_FILENAME


### PR DESCRIPTION
**Description**
This PR enables the precision of data for NetCDF output to be configurable through the `diagnostics_config` section of input config yaml as used by Pace. Precision can be set in the following way:
```
diagnostics_config:
  path: output
  output_format: netcdf
  precision: Float | float32 |float64
 ```
  The `Float` option will use whatever is the current value of the `PACE_FLOAT_PRECISION` environment variable for output precision. 
The `float32` option will set the output precision to be `numpy.float32`. 
The `float64` option will set the output precision to be `numpy.float64`. 
The default option is `Float`. 
The latter two options allow for instances when the desired run precision, as set by `PACE_FLOAT_PRECISION`, will be different than the required output precision. 
If the combination of `float64` is used with `PACE_FLOAT_PRECISION = 32`, an error will be thrown.

**How Has This Been Tested?**
Tested using the current set of unit tests in the CI

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
