### PR TITLE
Mixed Precision fixes and QOL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ dmypy.json
 
 # GT4Py
 **/.gt_cache*/
+**/.gt4py_cache/
 
 # Tests
 .my_cache_path/*

--- a/ndsl/constants.py
+++ b/ndsl/constants.py
@@ -161,9 +161,8 @@ DZ_MIN = Float(2.0)
 CV_AIR = CP_AIR - RDGAS
 """Heat capacity of dry air at constant volume"""
 RDG = -RDGAS / GRAV
-CNST_0P20 = Float(0.2)
 K1K = RDGAS / CV_AIR
-CNST_0P20 = Float(0.2)
+CNST_0P20 = np.float64(0.2)
 CV_VAP = Float(3.0) * RVGAS
 """Heat capacity of water vapor at constant volume"""
 ZVIR = RVGAS / RDGAS - Float(1)

--- a/ndsl/stencils/testing/savepoint.py
+++ b/ndsl/stencils/testing/savepoint.py
@@ -16,7 +16,7 @@ def dataset_to_dict(ds: xr.Dataset) -> Dict[str, Union[np.ndarray, float, int]]:
 
 def _process_if_scalar(value: np.ndarray) -> Union[np.ndarray, float, int]:
     if len(value.shape) == 0:
-        return value.item()
+        return value.max()  # trick to make sure we get the right type back
     else:
         return value
 

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -211,7 +211,7 @@ class TranslateFortranData2Py:
         if storage_vars is None:
             storage_vars = self.storage_vars()
         for p in self.in_vars["parameters"]:
-            inputs_out[p] = int(inputs_in[p])
+            inputs_out[p] = inputs_in[p]
         for d, info in storage_vars.items():
             serialname = info["serialname"] if "serialname" in info else d
             self.update_info(info, inputs_in)

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -211,12 +211,7 @@ class TranslateFortranData2Py:
         if storage_vars is None:
             storage_vars = self.storage_vars()
         for p in self.in_vars["parameters"]:
-            if type(inputs_in[p]) in [int, np.int64, np.int32]:
-                inputs_out[p] = int(inputs_in[p])
-            elif type(inputs_in[p]) is bool:
-                inputs_out[p] = inputs_in[p]
-            else:
-                inputs_out[p] = Float(inputs_in[p])
+            inputs_out[p] = int(inputs_in[p])
         for d, info in storage_vars.items():
             serialname = info["serialname"] if "serialname" in info else d
             self.update_info(info, inputs_in)

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -350,6 +350,8 @@ class MultiModalFloatMetric(BaseMetric):
             )
         for iFlat in indices_flatten[::-1]:
             fi = np.unravel_index(iFlat, shape=self.ulp_distance.shape)
+            if np.isnan(self.computed[fi]) and np.isnan(self.references[fi]):
+                continue
             ulp_dist = (
                 self.ulp_distance[fi]
                 if np.isnan(self.ulp_distance[fi])


### PR DESCRIPTION
Mixed precision fixes:
- Translate: read parameters with the correct type, get rid of workaround
- Constants: CNST_OP20 is a true 64-bit 

Quality of Life
- Update `gitignore` to skip `gt4py.next` caches
- MutiModalMetric now doesn't report the expected NaNs


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
