### PR TITLE
Change deprecated `np.product()` to `np.prod()`

### DIFF
--- a/tests/quantity/test_deepcopy.py
+++ b/tests/quantity/test_deepcopy.py
@@ -17,9 +17,7 @@ def test_deepcopy_copy_is_editable_by_view():
     )
     quantity_copy = copy.deepcopy(quantity)
     # assertion below is only valid if we're overwriting the entire data through view
-    assert np.product(quantity_copy.view[:].shape) == np.product(
-        quantity_copy.data.shape
-    )
+    assert np.prod(quantity_copy.view[:].shape) == np.prod(quantity_copy.data.shape)
     quantity_copy.view[:] = 1.0
     np.testing.assert_array_equal(quantity.data, 0.0)
     np.testing.assert_array_equal(quantity_copy.data, 1.0)


### PR DESCRIPTION
**Description**

Starting with numpy v1.25.0[^1], `np.product()` is deprecated and `np.prod()` should be used instead.

**How Has This Been Tested?**

Covered by existing tests.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A

[^1]: https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations