### PR TITLE
Translate tests: no threshold analysis by default

### DIFF
--- a/ndsl/stencils/testing/README.md
+++ b/ndsl/stencils/testing/README.md
@@ -83,4 +83,4 @@ Upon failure, the test will drop a `netCDF` file in a `./.translate-errors` dire
 
 ## Environment variables
 
-- `PACE_TEST_N_THRESHOLD_SAMPLES`: Upon failure the system will try to perturb the output in an attempt to check for numerical instability. This means re-running the test for N samples. Default is `10`, `0` or less turns this feature off.
+- `NDSL_TEST_N_THRESHOLD_SAMPLES`: Upon failure the system will try to perturb the output in an attempt to check for numerical instability. This means re-running the test for N samples. Default is `0`, which turns this feature off.

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -98,7 +98,7 @@ def process_override(threshold_overrides, testobj, test_name, backend):
             )
 
 
-N_THRESHOLD_SAMPLES = int(os.getenv("PACE_TEST_N_THRESHOLD_SAMPLES", 10))
+N_THRESHOLD_SAMPLES = int(os.getenv("PACE_TEST_N_THRESHOLD_SAMPLES", 0))
 
 
 def get_thresholds(testobj, input_data):

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -89,7 +89,7 @@ def process_override(threshold_overrides, testobj, test_name, backend):
                 testobj.skip_test = bool(match["skip_test"])
         elif len(matches) > 1:
             raise Exception(
-                "misconfigured threshold overrides file, more than 1 specification for "
+                "Misconfigured threshold overrides file, more than 1 specification for "
                 + test_name
                 + " with backend="
                 + backend
@@ -158,7 +158,7 @@ def test_sequential_savepoint(
 ):
     if case.testobj is None:
         pytest.xfail(
-            f"no translate object available for savepoint {case.savepoint_name}"
+            f"No translate object available for savepoint {case.savepoint_name}."
         )
     stencil_config = StencilConfig(
         compilation_config=CompilationConfig(backend=backend),
@@ -178,7 +178,7 @@ def test_sequential_savepoint(
     if case.testobj.skip_test:
         return
     if not case.exists:
-        pytest.skip(f"Data at rank {case.grid.rank} does not exists")
+        pytest.skip(f"Data at rank {case.grid.rank} does not exist.")
     input_data = dataset_to_dict(case.ds_in)
     input_names = (
         case.testobj.serialnames(case.testobj.in_vars["data_vars"])
@@ -188,7 +188,7 @@ def test_sequential_savepoint(
         input_data = {name: input_data[name] for name in input_names}
     except KeyError as e:
         raise KeyError(
-            f"Variable {e} was described in the translate test but cannot be found in the NetCDF"
+            f"Variable {e} was described in the translate test but cannot be found in the NetCDF."
         )
     original_input_data = copy.deepcopy(input_data)
     # give the user a chance to load data from other savepoints to allow
@@ -208,7 +208,7 @@ def test_sequential_savepoint(
         try:
             ref_data = all_ref_data[varname]
         except KeyError:
-            raise KeyError(f"Output {varname} couldn't be found in output data")
+            raise KeyError(f"Output {varname} couldn't be found in output data.")
         if hasattr(case.testobj, "subset_output"):
             ref_data = case.testobj.subset_output(varname, ref_data)
         with subtests.test(varname=varname):

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -25,6 +25,7 @@ np.set_printoptions(threshold=4096)
 OUTDIR = "./.translate-outputs"
 GPU_MAX_ERR = 1e-10
 GPU_NEAR_ZERO = 1e-15
+N_THRESHOLD_SAMPLES = int(os.getenv("NDSL_TEST_N_THRESHOLD_SAMPLES", 0))
 
 
 def platform():
@@ -96,9 +97,6 @@ def process_override(threshold_overrides, testobj, test_name, backend):
                 + ", platform="
                 + platform()
             )
-
-
-N_THRESHOLD_SAMPLES = int(os.getenv("PACE_TEST_N_THRESHOLD_SAMPLES", 0))
 
 
 def get_thresholds(testobj, input_data):

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -85,14 +85,14 @@ class TranslateFortranData2Py:
 
     def compute_func(self, **inputs) -> Optional[dict[str, Any]]:
         """Compute function to transform the dictionary of `inputs`.
-        Must return a dictionnary of updated variables"""
+        Must return a dictionary of updated variables"""
         raise NotImplementedError("Implement a child class compute method")
 
     def compute(self, inputs) -> dict[str, Any]:
-        """Transform inputs from NetCDF to gt4py.storagers, run compute_func then slice
+        """Transform inputs from NetCDF to gt4py.storages, run compute_func then slice
         the outputs based on specifications.
 
-        Return: Dictonnary of storages reshaped for comparison
+        Return: Dictionary of storages reshaped for comparison
         """
         self.setup(inputs)
         return self.slice_output(self.compute_from_storage(inputs))
@@ -201,7 +201,7 @@ class TranslateFortranData2Py:
     def make_storage_data_input_vars(
         self, inputs, storage_vars=None, dict_4d=True
     ) -> None:
-        """From a set of raw inputs (straight from NetCDF), use the `in_vars` dictionnary to update inputs to
+        """From a set of raw inputs (straight from NetCDF), use the `in_vars` dictionary to update inputs to
         their configured shape.
 
         Return: None


### PR DESCRIPTION
**Description**

Currently, when translate tests fail, we run 10 (by default) times the same translate test/savepoint again with slightly perturbed inputs. The outputs are then analyzed to give developers an indication on whether errors that they are seeing are in the expected range of "noise propagation" or if this is more likely to be an error in porting.

This goes back to https://github.com/ai2cm/pace/pull/222, which was never finished. Issue https://github.com/NOAA-GFDL/NDSL/issues/133 was created to re-evaluate that system.

**How Has This Been Tested?**

Tested locally by setting the environment variable to 0.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
