### PR TITLE
Remove deprecated `floating_point_precision()`

### DIFF
--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -22,11 +22,6 @@ K = gtscript.K  # noqa: E741
 DTypes = Union[bool, np.bool_, int, np.int32, np.int64, float, np.float32, np.float64]
 
 
-# Depreciated version of get_precision, but retained for a PACE dependency
-def floating_point_precision() -> int:
-    return int(os.getenv("PACE_FLOAT_PRECISION", "64"))
-
-
 def get_precision() -> int:
     return int(os.getenv("PACE_FLOAT_PRECISION", "64"))
 


### PR DESCRIPTION
**Description**

Remove deprecated function as discussed in https://github.com/NOAA-GFDL/PyFV3/pull/54#issuecomment-2866552075. The function was replaced with `get_precision()` in 2025.03.00.

**How Has This Been Tested?**

Fixed (upstream) PyFV3 in https://github.com/NOAA-GFDL/PyFV3/pull/54. Found no occurrences in pace and PySHiELD. Updated [NDSL](https://github.com/NOAA-GFDL/pace/pull/120) & [PyFV3](https://github.com/NOAA-GFDL/pace/pull/121) versions of pace.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
