### PR TITLE
Expose stencil from gt4py

### DIFF
--- a/ndsl/dsl/gt4py/__init__.py
+++ b/ndsl/dsl/gt4py/__init__.py
@@ -45,6 +45,7 @@ from gt4py.cartesian.gtscript import (
     sin,
     sinh,
     sqrt,
+    stencil,
     tan,
     tanh,
     trunc,


### PR DESCRIPTION
**Description**

We forgot to expose `stencil` from `GT4Py` in the new interface.

**How Has This Been Tested?**

Will be covered by pace tests once https://github.com/NOAA-GFDL/pace/pull/114 is merged.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
