### PR TITLE
Grid metrics terms: mixed precision & GPU readiness

### DIFF
--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -297,6 +297,7 @@ class MetricTerms:
         self._dx_center = None
         self._dy_center = None
         self._area = None
+        self._area64 = None
         self._area_c = None
         if eta_file is not None or ak is not None or bk is not None:
             (
@@ -1490,8 +1491,17 @@ class MetricTerms:
         the area of each a-grid cell
         """
         if self._area is None:
-            self._area = self._compute_area()
+            self._area, self._area64 = self._compute_area()
         return self._area
+
+    @property
+    def area64(self) -> Quantity:
+        """
+        the area of each a-grid cell, at 64-bit precision
+        """
+        if self._area64 is None:
+            self._area, self._area64 = self._compute_area()
+        return self._area64
 
     @property
     def area_c(self) -> Quantity:
@@ -2089,7 +2099,7 @@ class MetricTerms:
 
         return dx_center, dy_center
 
-    def _compute_area_cube_sphere(self):
+    def _compute_area_cube_sphere(self) -> tuple[Quantity, Quantity]:
         area_64 = self.quantity_factory.zeros(
             [X_DIM, Y_DIM],
             "m^2",
@@ -2106,9 +2116,9 @@ class MetricTerms:
         )
         self._comm.halo_update(area_64, n_points=self._halo)
 
-        return quantity_cast_to_model_float(self.quantity_factory, area_64)
+        return quantity_cast_to_model_float(self.quantity_factory, area_64), area_64
 
-    def _compute_area_cartesian(self):
+    def _compute_area_cartesian(self) -> tuple[Quantity, Quantity]:
         area_64 = self.quantity_factory.zeros(
             [X_DIM, Y_DIM],
             "m^2",
@@ -2116,7 +2126,7 @@ class MetricTerms:
             allow_mismatch_float_precision=True,
         )
         area_64.data[:, :] = self._dx_const * self._dy_const
-        return quantity_cast_to_model_float(self.quantity_factory, area_64)
+        return quantity_cast_to_model_float(self.quantity_factory, area_64), area_64
 
     def _compute_area_c_cube_sphere(self):
         area_cgrid_64 = self.quantity_factory.zeros(

--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -296,8 +296,8 @@ class MetricTerms:
         self._dy_agrid = None
         self._dx_center = None
         self._dy_center = None
-        self._area = None
-        self._area64 = None
+        self._area: Optional[Quantity] = None
+        self._area64: Optional[Quantity] = None
         self._area_c = None
         if eta_file is not None or ak is not None or bk is not None:
             (

--- a/ndsl/grid/helper.py
+++ b/ndsl/grid/helper.py
@@ -7,7 +7,7 @@ import xarray as xr
 # TODO: if we can remove translate tests in favor of checkpointer tests,
 # we can remove this "disallowed" import (ndsl.util does not depend on ndsl.dsl)
 try:
-    from ndsl.dsl.gt4py_utils import split_cartesian_into_storages
+    from ndsl.dsl.gt4py_utils import is_gpu_backend, split_cartesian_into_storages
 except ImportError:
     split_cartesian_into_storages = None
 import ndsl.constants as constants
@@ -93,7 +93,7 @@ class HorizontalGridData:
             lon_agrid=metric_terms.lon_agrid,
             lat_agrid=metric_terms.lat_agrid,
             area=metric_terms.area,
-            area_64=metric_terms.area,
+            area_64=metric_terms.area64,
             rarea=metric_terms.rarea,
             rarea_c=metric_terms.rarea_c,
             dx=metric_terms.dx,
@@ -233,7 +233,10 @@ class VerticalGridData:
         """
         if self.bk.view[0] != 0:
             raise ValueError("ptop is not well-defined when top-of-atmosphere bk != 0")
-        return Float(self.ak.view[0])
+        if is_gpu_backend(self.ak.gt4py_backend):
+            return Float(self.ak.view[0].get())
+        else:
+            return Float(self.ak.view[0])
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
**Description**
Small changes coming from Dynamics up-skill to mixed precision

- Make `area64` available for 32-bit or mixed code versions
- Make `ptop` available to GPU for orchestration (by properly de-ferencing `cupy` memory)

**How Has This Been Tested?**
Ongoing work for pyFV3

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
