### PR TITLE
Fix warning in tests

### DIFF
--- a/ndsl/halo/data_transformer.py
+++ b/ndsl/halo/data_transformer.py
@@ -225,9 +225,12 @@ class HaloDataTransformer(abc.ABC):
         self.synchronize()
 
         # Push the buffers back in the cache
-        Buffer.push_to_cache(self._pack_buffer)
+        if self._pack_buffer is not None:
+            Buffer.push_to_cache(self._pack_buffer)
         self._pack_buffer = None
-        Buffer.push_to_cache(self._unpack_buffer)
+
+        if self._unpack_buffer is not None:
+            Buffer.push_to_cache(self._unpack_buffer)
         self._unpack_buffer = None
 
     @staticmethod


### PR DESCRIPTION
**Description**

Fixes 

```none
tests/test_halo_update.py::test_halo_updater_stability[interface_3d-numpy-layout0-2-more-0]
  [...]/NDSL/.venv/lib/python3.11/site-packages/_pytest/unraisableexception.py:85: PytestUnraisableExceptionWarning: Exception ignored in: <function HaloUpdater.__del__ at 0x7f74b5b91260>
  
  Traceback (most recent call last):
    File "[...]/NDSL/ndsl/halo/updater.py", line 88, in __del__
      transformer.finalize()
    File "[...]/NDSL/ndsl/halo/data_transformer.py", line 228, in finalize
      Buffer.push_to_cache(self._pack_buffer)
    File "[...]/NDSL/ndsl/buffer.py", line 70, in push_to_cache
      BUFFER_CACHE[buffer._key].append(buffer)
                   ^^^^^^^^^^^
  AttributeError: 'NoneType' object has no attribute '_key'
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```

as seen e.g. in https://github.com/NOAA-GFDL/NDSL/actions/runs/15278670407/job/42971686345?pr=150#step:6:773

A bit more context on when/why this happens: The key error comes from `test_halo_updater_stability()` manually calling `transformer.finalize()` before `finalize()` is called again from the `HaloUpdater`'s `__del__` function. In "normal" execution mode, this shouldn't be a problem because developers aren't supposed to manually call `finalize()` on the transformers.

An alternative way to avoid the error could be to add a `finalized: bool` state to `HaloDataTransformer` and exit early in `finalize()` in case the transformer has already been finalized.

**How Has This Been Tested?**

Running tests locally

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
