### PR TITLE
Fix deprecation warning when reading model state

### DIFF
--- a/ndsl/io.py
+++ b/ndsl/io.py
@@ -69,7 +69,8 @@ def read_state(filename: str) -> dict:
     """
     out_dict = {}
     with filesystem.open(filename, "rb") as f:
-        ds = xr.open_dataset(f, use_cftime=True)
+        time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+        ds = xr.open_dataset(f, decode_times=time_coder)
         for name, value in ds.data_vars.items():
             if name == "time":
                 out_dict[name] = _extract_time(value)


### PR DESCRIPTION
**Description**

NDSL tests were logging the following deprecation warning for using `use_cftime=True` when opening a dataset (e.g. model state)

```none
 tests/test_legacy_restart.py::test_read_state_non_scalar_time
  /__w/NDSL/NDSL/ndsl/io.py:72: DeprecationWarning: Usage of 'use_cftime' as a kwarg is deprecated. Please pass a 'CFDatetimeCoder' instance initialized with 'use_cftime' to the 'decode_times' kwarg instead.
  Example usage:
      time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
      ds = xr.open_dataset(decode_times=time_coder)
  
    ds = xr.open_dataset(f, use_cftime=True)
```

(as see in e.g. [this run](https://github.com/NOAA-GFDL/NDSL/actions/runs/15280269813/job/42977231218#step:6:784))

**How Has This Been Tested?**

By running tests and confirming that the warning isn't in the logs anymore.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
