### PR TITLE
Optional and non-optional dependencies

### DIFF
--- a/ndsl/checkpointer/snapshots.py
+++ b/ndsl/checkpointer/snapshots.py
@@ -1,10 +1,10 @@
 import collections
 
 import numpy as np
+import xarray as xr
 
 from ndsl.checkpointer.base import Checkpointer
 from ndsl.optional_imports import cupy as cp
-from ndsl.optional_imports import xarray as xr
 
 
 def make_dims(savepoint_dim, label, data_list):
@@ -39,11 +39,6 @@ class _Snapshots:
             data_vars[f"{variable_name}"] = make_dims(
                 savepoint_dim, variable_name, self._arrays[variable_name]
             )
-        if xr is None:
-            raise ModuleNotFoundError(
-                "xarray must be installed to use Snapshots.dataset"
-            )
-        else:
             return xr.Dataset(data_vars=data_vars)
 
 
@@ -54,10 +49,6 @@ class SnapshotCheckpointer(Checkpointer):
     """
 
     def __init__(self, rank: int):
-        if xr is None:
-            raise ModuleNotFoundError(
-                "xarray must be installed to use SnapshotCheckpointer"
-            )
         self._rank = rank
         self._snapshots = _Snapshots()
 

--- a/ndsl/checkpointer/snapshots.py
+++ b/ndsl/checkpointer/snapshots.py
@@ -39,7 +39,7 @@ class _Snapshots:
             data_vars[f"{variable_name}"] = make_dims(
                 savepoint_dim, variable_name, self._arrays[variable_name]
             )
-            return xr.Dataset(data_vars=data_vars)
+        return xr.Dataset(data_vars=data_vars)
 
 
 class SnapshotCheckpointer(Checkpointer):

--- a/ndsl/checkpointer/thresholds.py
+++ b/ndsl/checkpointer/thresholds.py
@@ -9,12 +9,6 @@ from ndsl.checkpointer.base import Checkpointer
 from ndsl.quantity import Quantity
 
 
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
-
-
 SavepointName = str
 VariableName = str
 ArrayLike = Union[Quantity, np.ndarray]

--- a/ndsl/checkpointer/validation.py
+++ b/ndsl/checkpointer/validation.py
@@ -4,6 +4,7 @@ import os.path
 from typing import MutableMapping, Tuple
 
 import numpy as np
+import xarray as xr
 
 from ndsl.checkpointer.base import Checkpointer
 from ndsl.checkpointer.thresholds import (
@@ -12,7 +13,6 @@ from ndsl.checkpointer.thresholds import (
     SavepointThresholds,
     cast_to_ndarray,
 )
-from ndsl.optional_imports import xarray as xr
 
 
 def _clip_pace_array_to_target(
@@ -109,8 +109,6 @@ class ValidationCheckpointer(Checkpointer):
         Raises:
             AssertionError: if the thresholds on any variable are not met
         """
-        if xr is None:
-            raise ModuleNotFoundError("xarray is not installed")
         nc_file = os.path.join(self._savepoint_data_path, savepoint_name + ".nc")
         ds = xr.open_dataset(nc_file)
 

--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -10,15 +10,10 @@ from ndsl.comm.comm_abc import Comm as CommABC
 from ndsl.comm.comm_abc import ReductionOperator
 from ndsl.comm.partitioner import CubedSpherePartitioner, Partitioner, TilePartitioner
 from ndsl.halo.updater import HaloUpdater, HaloUpdateRequest, VectorInterfaceHaloUpdater
+from ndsl.optional_imports import cupy
 from ndsl.performance.timer import NullTimer, Timer
 from ndsl.quantity import Quantity, QuantityHaloSpec, QuantityMetadata
 from ndsl.types import NumpyModule
-
-
-try:
-    import cupy
-except ImportError:
-    cupy = None
 
 
 def to_numpy(array, dtype=None) -> np.ndarray:

--- a/ndsl/comm/mpi.py
+++ b/ndsl/comm/mpi.py
@@ -1,9 +1,6 @@
-try:
-    import mpi4py
-    from mpi4py import MPI
-except ImportError:
-    MPI = None
 from typing import Dict, List, Optional, TypeVar, cast
+
+from mpi4py import MPI
 
 from ndsl.comm.comm_abc import Comm, ReductionOperator, Request
 
@@ -12,22 +9,22 @@ T = TypeVar("T")
 
 
 class MPIComm(Comm):
-    _op_mapping: Dict[ReductionOperator, mpi4py.MPI.Op] = {
-        ReductionOperator.OP_NULL: mpi4py.MPI.OP_NULL,
-        ReductionOperator.MAX: mpi4py.MPI.MAX,
-        ReductionOperator.MIN: mpi4py.MPI.MIN,
-        ReductionOperator.SUM: mpi4py.MPI.SUM,
-        ReductionOperator.PROD: mpi4py.MPI.PROD,
-        ReductionOperator.LAND: mpi4py.MPI.LAND,
-        ReductionOperator.BAND: mpi4py.MPI.BAND,
-        ReductionOperator.LOR: mpi4py.MPI.LOR,
-        ReductionOperator.BOR: mpi4py.MPI.BOR,
-        ReductionOperator.LXOR: mpi4py.MPI.LXOR,
-        ReductionOperator.BXOR: mpi4py.MPI.BXOR,
-        ReductionOperator.MAXLOC: mpi4py.MPI.MAXLOC,
-        ReductionOperator.MINLOC: mpi4py.MPI.MINLOC,
-        ReductionOperator.REPLACE: mpi4py.MPI.REPLACE,
-        ReductionOperator.NO_OP: mpi4py.MPI.NO_OP,
+    _op_mapping: Dict[ReductionOperator, MPI.Op] = {
+        ReductionOperator.OP_NULL: MPI.OP_NULL,
+        ReductionOperator.MAX: MPI.MAX,
+        ReductionOperator.MIN: MPI.MIN,
+        ReductionOperator.SUM: MPI.SUM,
+        ReductionOperator.PROD: MPI.PROD,
+        ReductionOperator.LAND: MPI.LAND,
+        ReductionOperator.BAND: MPI.BAND,
+        ReductionOperator.LOR: MPI.LOR,
+        ReductionOperator.BOR: MPI.BOR,
+        ReductionOperator.LXOR: MPI.LXOR,
+        ReductionOperator.BXOR: MPI.BXOR,
+        ReductionOperator.MAXLOC: MPI.MAXLOC,
+        ReductionOperator.MINLOC: MPI.MINLOC,
+        ReductionOperator.REPLACE: MPI.REPLACE,
+        ReductionOperator.NO_OP: MPI.NO_OP,
     }
 
     def __init__(self):
@@ -84,4 +81,4 @@ class MPIComm(Comm):
         return self._comm.Allreduce(sendobj_or_inplace, recvobj, self._op_mapping[op])
 
     def Allreduce_inplace(self, recvobj: T, op: ReductionOperator) -> T:
-        return self._comm.Allreduce(mpi4py.MPI.IN_PLACE, recvobj, self._op_mapping[op])
+        return self._comm.Allreduce(MPI.IN_PLACE, recvobj, self._op_mapping[op])

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -32,12 +32,7 @@ from ndsl.dsl.dace.utils import (
     report_memory_static_analysis,
 )
 from ndsl.logging import ndsl_log
-
-
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
+from ndsl.optional_imports import cupy as cp
 
 
 def dace_inhibitor(func: Callable) -> Callable:

--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -7,12 +7,8 @@ import numpy as np
 from ndsl.constants import N_HALO_DEFAULT
 from ndsl.dsl.typing import DTypes, Field, Float
 from ndsl.logging import ndsl_log
+from ndsl.optional_imports import cupy as cp
 
-
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
 
 # If True, automatically transfers memory between CPU and GPU (see gt4py.storage)
 managed_memory = True

--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -1,8 +1,9 @@
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
-import gt4py
 import numpy as np
+from gt4py import storage as gt_storage
+from gt4py.cartesian import backend as gt_backend
 
 from ndsl.constants import N_HALO_DEFAULT
 from ndsl.dsl.typing import DTypes, Field, Float
@@ -184,7 +185,7 @@ def make_storage_data(
             backend=backend,
         )
 
-    storage = gt4py.storage.from_array(
+    storage = gt_storage.from_array(
         data,
         dtype,
         backend=backend,
@@ -336,7 +337,7 @@ def make_storage_from_shape(
             mask = (False, False, True)  # Assume 1D is a k-field
         else:
             mask = (n_dims * (True,)) + ((3 - n_dims) * (False,))
-    storage = gt4py.storage.zeros(
+    storage = gt_storage.zeros(
         shape,
         dtype,
         backend=backend,
@@ -444,7 +445,7 @@ def asarray(array, to_type=np.ndarray, dtype=None, order=None):
 
 
 def is_gpu_backend(backend: str) -> bool:
-    return gt4py.cartesian.backend.from_name(backend).storage_info["device"] == "gpu"
+    return gt_backend.from_name(backend).storage_info["device"] == "gpu"
 
 
 def zeros(shape, dtype=Float, *, backend: str):

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -17,8 +17,9 @@ from typing import (
 )
 
 import dace
-import gt4py
 import numpy as np
+from gt4py.cartesian import config as gt_config
+from gt4py.cartesian import definitions as gt_definitions
 from gt4py.cartesian import gtscript
 from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline, OirPipeline
 from gt4py.cartesian.stencil_object import StencilObject
@@ -303,8 +304,8 @@ class FrozenStencil(SDFGConvertible):
             dace.Config.set(
                 "default_build_folder",
                 value="{gt_root}/{gt_cache}/dacecache".format(
-                    gt_root=gt4py.cartesian.config.cache_settings["root_path"],
-                    gt_cache=gt4py.cartesian.config.cache_settings["dir_name"],
+                    gt_root=gt_config.cache_settings["root_path"],
+                    gt_cache=gt_config.cache_settings["dir_name"],
                 ),
             )
 
@@ -493,7 +494,7 @@ class FrozenStencil(SDFGConvertible):
             if field_info[field_name]
             and bool(
                 field_info[field_name].access
-                & gt4py.cartesian.definitions.AccessKind.WRITE  # type: ignore
+                & gt_definitions.AccessKind.WRITE  # type: ignore
             )
         ]
         return write_fields

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -39,12 +39,6 @@ from ndsl.quantity.field_bundle import FieldBundleType, MarkupFieldBundleType
 from ndsl.testing.comparison import LegacyMetric
 
 
-try:
-    import cupy as cp
-except ImportError:
-    cp = np
-
-
 def report_difference(args, kwargs, args_copy, kwargs_copy, function_name, gt_id):
     report_head = f"comparing against numpy for func {function_name}, gt_id {gt_id}:"
     report_segments = []

--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -1,8 +1,8 @@
 import os
 from typing import Tuple, TypeAlias, Union, cast
 
-import gt4py.cartesian.gtscript as gtscript
 import numpy as np
+from gt4py.cartesian import gtscript
 
 
 # A Field

--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional, Sequence
 
-import gt4py
 import numpy as np
+from gt4py import storage as gt_storage
 
 from ndsl.constants import SPATIAL_DIMS
 from ndsl.dsl.typing import Float
@@ -20,13 +20,13 @@ class StorageNumpy:
         self.backend = backend
 
     def empty(self, *args, **kwargs) -> np.ndarray:
-        return gt4py.storage.empty(*args, backend=self.backend, **kwargs)
+        return gt_storage.empty(*args, backend=self.backend, **kwargs)
 
     def ones(self, *args, **kwargs) -> np.ndarray:
-        return gt4py.storage.ones(*args, backend=self.backend, **kwargs)
+        return gt_storage.ones(*args, backend=self.backend, **kwargs)
 
     def zeros(self, *args, **kwargs) -> np.ndarray:
-        return gt4py.storage.zeros(*args, backend=self.backend, **kwargs)
+        return gt_storage.zeros(*args, backend=self.backend, **kwargs)
 
 
 class QuantityFactory:

--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -1,11 +1,11 @@
 from typing import Callable, Optional, Sequence
 
+import gt4py
 import numpy as np
 
 from ndsl.constants import SPATIAL_DIMS
 from ndsl.dsl.typing import Float
 from ndsl.initialization.sizer import GridSizer
-from ndsl.optional_imports import gt4py
 from ndsl.quantity import Quantity, QuantityHaloSpec
 
 

--- a/ndsl/io.py
+++ b/ndsl/io.py
@@ -1,9 +1,9 @@
 from typing import TextIO
 
 import cftime
+import xarray as xr
 
 import ndsl.filesystem as filesystem
-from ndsl.optional_imports import xarray as xr
 from ndsl.quantity import Quantity
 
 

--- a/ndsl/monitor/netcdf_monitor.py
+++ b/ndsl/monitor/netcdf_monitor.py
@@ -5,13 +5,13 @@ from warnings import warn
 
 import fsspec
 import numpy as np
+import xarray as xr
 
 from ndsl.comm.communicator import Communicator
 from ndsl.dsl.typing import Float, get_precision
 from ndsl.filesystem import get_fs
 from ndsl.logging import ndsl_log
 from ndsl.monitor.convert import to_numpy
-from ndsl.optional_imports import xarray as xr
 from ndsl.quantity import Quantity
 
 

--- a/ndsl/monitor/zarr_monitor.py
+++ b/ndsl/monitor/zarr_monitor.py
@@ -2,14 +2,13 @@ from datetime import datetime, timedelta
 from typing import List, Tuple, Union
 
 import cftime
+import xarray as xr
 
 import ndsl.constants as constants
 from ndsl.comm.partitioner import Partitioner, subtile_slice
 from ndsl.logging import ndsl_log
 from ndsl.monitor.convert import to_numpy
-from ndsl.optional_imports import cupy
-from ndsl.optional_imports import xarray as xr
-from ndsl.optional_imports import zarr
+from ndsl.optional_imports import cupy, zarr
 from ndsl.utils import list_by_dims
 
 

--- a/ndsl/optional_imports.py
+++ b/ndsl/optional_imports.py
@@ -15,11 +15,6 @@ except ModuleNotFoundError as err:
     zarr = RaiseWhenAccessed(err)
 
 try:
-    import xarray
-except ModuleNotFoundError as err:
-    xarray = None
-
-try:
     import cupy
 except ImportError:
     cupy = None

--- a/ndsl/optional_imports.py
+++ b/ndsl/optional_imports.py
@@ -25,8 +25,3 @@ if cupy is not None:
         cupy.cuda.runtime.deviceSynchronize()
     except cupy.cuda.runtime.CUDARuntimeError:
         cupy = None
-
-try:
-    import dace
-except ImportError:
-    dace = None

--- a/ndsl/optional_imports.py
+++ b/ndsl/optional_imports.py
@@ -26,12 +26,6 @@ if cupy is not None:
     except cupy.cuda.runtime.CUDARuntimeError:
         cupy = None
 
-
-try:
-    import gt4py
-except ImportError:
-    gt4py = None
-
 try:
     import dace
 except ImportError:

--- a/ndsl/quantity/field_bundle.py
+++ b/ndsl/quantity/field_bundle.py
@@ -7,7 +7,7 @@ from ndsl.initialization.allocator import QuantityFactory
 from ndsl.quantity.quantity import Quantity
 
 
-import gt4py.cartesian.gtscript as gtscript  # isort: skip
+from gt4py.cartesian import gtscript  # isort: skip
 
 
 # ToDo: This is 4th dimensions restricted. We need a concept
@@ -44,7 +44,7 @@ class FieldBundle:
             bundle_name: name of the bundle, accessible via `name`.
             quantity: data inputs as a nD array.
             mapping: sparse dict of [name, index] to be able to call tracers by name.
-            register_type: boolean to register the type as part of initilization.
+            register_type: boolean to register the type as part of initialization.
         """
         if len(quantity.shape) != 4:
             raise NotImplementedError("FieldBundle implementation restricted to 4D")

--- a/ndsl/quantity/field_bundle.py
+++ b/ndsl/quantity/field_bundle.py
@@ -2,12 +2,11 @@ import copy
 from dataclasses import dataclass
 from typing import Any
 
+from gt4py.cartesian import gtscript
+
 from ndsl.dsl.typing import Float
 from ndsl.initialization.allocator import QuantityFactory
 from ndsl.quantity.quantity import Quantity
-
-
-from gt4py.cartesian import gtscript  # isort: skip
 
 
 # ToDo: This is 4th dimensions restricted. We need a concept

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -1,6 +1,7 @@
 import warnings
 from typing import Any, Iterable, Optional, Sequence, Tuple, Union, cast
 
+import dace
 import gt4py
 import matplotlib.pyplot as plt
 import numpy as np
@@ -9,7 +10,7 @@ from mpi4py import MPI
 
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float, is_float
-from ndsl.optional_imports import cupy, dace
+from ndsl.optional_imports import cupy
 from ndsl.quantity.bounds import BoundedArrayView
 from ndsl.quantity.metadata import QuantityHaloSpec, QuantityMetadata
 from ndsl.types import NumpyModule
@@ -303,13 +304,7 @@ class Quantity:
         If the internal data given doesn't follow the protocol it will most likely
         fail.
         """
-        if dace:
-            return dace.data.create_datadescriptor(self.data)
-        else:
-            raise ImportError(
-                "Attempt to use DaCe orchestrated backend but "
-                "DaCe module is not available."
-            )
+        return dace.data.create_datadescriptor(self.data)
 
     def transpose(
         self,

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -1,6 +1,7 @@
 import warnings
 from typing import Any, Iterable, Optional, Sequence, Tuple, Union, cast
 
+import gt4py
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
@@ -8,7 +9,7 @@ from mpi4py import MPI
 
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float, is_float
-from ndsl.optional_imports import cupy, dace, gt4py
+from ndsl.optional_imports import cupy, dace
 from ndsl.quantity.bounds import BoundedArrayView
 from ndsl.quantity.metadata import QuantityHaloSpec, QuantityMetadata
 from ndsl.types import NumpyModule

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -3,12 +3,12 @@ from typing import Any, Iterable, Optional, Sequence, Tuple, Union, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
+import xarray as xr
 from mpi4py import MPI
 
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float, is_float
 from ndsl.optional_imports import cupy, dace, gt4py
-from ndsl.optional_imports import xarray as xr
 from ndsl.quantity.bounds import BoundedArrayView
 from ndsl.quantity.metadata import QuantityHaloSpec, QuantityMetadata
 from ndsl.types import NumpyModule

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -2,10 +2,11 @@ import warnings
 from typing import Any, Iterable, Optional, Sequence, Tuple, Union, cast
 
 import dace
-import gt4py
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
+from gt4py import storage as gt_storage
+from gt4py.cartesian import backend as gt_backend
 from mpi4py import MPI
 
 import ndsl.constants as constants
@@ -79,7 +80,7 @@ class Quantity:
             )
 
         if gt4py_backend is not None:
-            gt4py_backend_cls = gt4py.cartesian.backend.from_name(gt4py_backend)
+            gt4py_backend_cls = gt_backend.from_name(gt4py_backend)
             assert gt4py_backend_cls is not None
             is_optimal_layout = gt4py_backend_cls.storage_info["is_optimal_layout"]
 
@@ -201,7 +202,7 @@ class Quantity:
 
     def _initialize_data(self, data, origin, gt4py_backend: str, dimensions: Tuple):
         """Allocates an ndarray with optimal memory layout, and copies the data over."""
-        storage = gt4py.storage.from_array(
+        storage = gt_storage.from_array(
             data,
             data.dtype,
             backend=gt4py_backend,

--- a/ndsl/restart/_legacy_restart.py
+++ b/ndsl/restart/_legacy_restart.py
@@ -2,12 +2,13 @@ import copy
 import os
 from typing import BinaryIO, Generator, Iterable
 
+import xarray as xr
+
 import ndsl.constants as constants
 import ndsl.filesystem as filesystem
 import ndsl.io as io
 from ndsl.comm.communicator import Communicator
 from ndsl.comm.partitioner import get_tile_index
-from ndsl.optional_imports import xarray as xr
 from ndsl.quantity import Quantity
 from ndsl.restart._properties import RESTART_PROPERTIES, RestartProperties
 

--- a/ndsl/stencils/basic_operations.py
+++ b/ndsl/stencils/basic_operations.py
@@ -1,6 +1,4 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import FORWARD, PARALLEL, computation, interval
-
+from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, function, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, IntField, IntFieldIJ
 
 
@@ -18,11 +16,8 @@ def copy_defn(q_in: FloatField, q_out: FloatField):
 
 def adjustmentfactor_stencil_defn(adjustment: FloatFieldIJ, q_out: FloatField):
     """
-    Multiplies every element of q_out
-    by every element of the adjustment
-    field over the interval, replacing
-    the elements of q_out by the result
-    of the multiplication.
+    Multiplies every element of q_out by every element of the adjustment field over the
+    interval, replacing the elements of q_out by the result of the multiplication.
 
     Args:
         adjustment: adjustment field
@@ -34,8 +29,7 @@ def adjustmentfactor_stencil_defn(adjustment: FloatFieldIJ, q_out: FloatField):
 
 def set_value_defn(q_out: FloatField, value: Float):
     """
-    Sets every element of q_out to the
-    value specified by value argument.
+    Sets every element of q_out to the value specified by value argument.
 
     Args:
         q_out: output field
@@ -47,11 +41,8 @@ def set_value_defn(q_out: FloatField, value: Float):
 
 def adjust_divide_stencil(adjustment: FloatField, q_out: FloatField):
     """
-    Divides every element of q_out
-    by every element of the adjustment
-    field over the interval, replacing
-    the elements of q_out by the result
-    of the multiplication.
+    Divides every element of q_out by every element of the adjustment field over the
+    interval, replacing the elements of q_out by the result of the multiplication.
 
     Args:
         adjustment: adjustment field
@@ -68,9 +59,8 @@ def select_k(
     k_select: IntFieldIJ,
 ):
     """
-    Saves a specific k-index of a 3D field to a
-    new 2D array. The k-value can be different
-    for each i,j point.
+    Saves a specific k-index of a 3D field to a new 2D array. The k-value can be
+    different for each i,j point.
 
     Args:
         in_field: A 3D array to select from
@@ -86,51 +76,37 @@ def select_k(
 
 def average_in(
     q_out: FloatField,
-    adjustement: FloatField,
+    adjustment: FloatField,
 ):
     """
-    Averages every element of q_out
-    with every element of the adjustment
-    field, overwriting q_out.
+    Averages every element of q_out with every element of the adjustment field,
+    overwriting q_out.
 
     Args:
         adjustment: adjustment field
         q_out: output field
     """
     with computation(PARALLEL), interval(...):
-        q_out = (q_out + adjustement) * 0.5
+        q_out = (q_out + adjustment) * 0.5
 
 
-@gtscript.function
+@function
 def sign(a, b):
     """
-    Defines asignb as the absolute value
-    of a, and checks if b is positive
-    or negative, assigning the analogus
-    sign value to asignb. asignb is returned
+    Defines a_sign_b as the absolute value of a, and checks if b is positive or
+    negative, assigning the analogous sign value to a_sign_b. a_sign_b is returned.
 
     Args:
         a: A number
         b: A number
     """
-    asignb = abs(a)
-    if b > 0:
-        asignb = asignb
-    else:
-        asignb = -asignb
-    return asignb
+    a_sign_b = abs(a)
+    return a_sign_b if b > 0 else -a_sign_b
 
 
-@gtscript.function
+@function
 def dim(a, b):
     """
-    Performs a check on the difference
-    between the values in arguments
-    a and b. The variable diff is set
-    to the difference between a and b
-    when the difference is positive,
-    otherwise it is set to zero. The
-    function returns the diff variable.
+    Calculates a - b, camped to 0, i.e. max(a - b, 0).
     """
-    diff = a - b if a - b > 0 else 0
-    return diff
+    return max(a - b, 0)

--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -12,7 +12,7 @@ try:
     import serialbox
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        "Serialbox couldn't be imported, make sure it's in your PYTHONPATH or you env"
+        "Serialbox couldn't be imported, make sure it's in your PYTHONPATH or your env"
     )
 
 

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -6,10 +6,10 @@ from typing import Any, Dict, List
 import numpy as np
 import pytest
 
-import ndsl.dsl.gt4py_utils as gt_utils
 from ndsl.comm.communicator import CubedSphereCommunicator, TileCommunicator
 from ndsl.comm.mpi import MPI, MPIComm
 from ndsl.comm.partitioner import CubedSpherePartitioner, TilePartitioner
+from ndsl.dsl import gt4py_utils as gt_utils
 from ndsl.dsl.dace.dace_config import DaceConfig
 from ndsl.dsl.stencil import CompilationConfig, StencilConfig
 from ndsl.quantity import Quantity

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -6,15 +6,11 @@ import numpy as np
 import ndsl.dsl.gt4py_utils as utils
 from ndsl.dsl.stencil import StencilFactory
 from ndsl.dsl.typing import Field, Float, Int  # noqa: F401
+from ndsl.optional_imports import cupy as cp
 from ndsl.quantity import Quantity
 from ndsl.stencils.testing.grid import Grid  # type: ignore
 from ndsl.stencils.testing.savepoint import DataLoader
 
-
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
 
 logger = logging.getLogger(__name__)
 

--- a/tests/checkpointer/test_snapshot.py
+++ b/tests/checkpointer/test_snapshot.py
@@ -1,20 +1,14 @@
 import numpy as np
-import pytest
+import xarray as xr
 
 from ndsl.checkpointer import SnapshotCheckpointer
-from ndsl.optional_imports import xarray as xr
 
 
-requires_xarray = pytest.mark.skipif(xr is None, reason="xarray is not installed")
-
-
-@requires_xarray
 def test_snapshot_checkpointer_no_data():
     checkpointer = SnapshotCheckpointer(rank=0)
     xr.testing.assert_identical(checkpointer.dataset, xr.Dataset())
 
 
-@requires_xarray
 def test_snapshot_checkpointer_one_snapshot():
     checkpointer = SnapshotCheckpointer(rank=0)
     val1 = np.random.randn(2, 3, 4)
@@ -33,7 +27,6 @@ def test_snapshot_checkpointer_one_snapshot():
     )
 
 
-@requires_xarray
 def test_snapshot_checkpointer_multiple_snapshots():
     checkpointer = SnapshotCheckpointer(rank=0)
     val1 = np.random.randn(2, 2, 3, 4)

--- a/tests/checkpointer/test_validation.py
+++ b/tests/checkpointer/test_validation.py
@@ -3,13 +3,10 @@ import tempfile
 
 import numpy as np
 import pytest
+import xarray as xr
 
 from ndsl.checkpointer import SavepointThresholds, Threshold, ValidationCheckpointer
 from ndsl.checkpointer.validation import _clip_pace_array_to_target
-from ndsl.optional_imports import xarray as xr
-
-
-requires_xarray = pytest.mark.skipif(xr is None, reason="xarray is not installed")
 
 
 def get_dataset(
@@ -30,7 +27,6 @@ def get_dataset(
     return xr.Dataset(data_vars=data_vars)
 
 
-@requires_xarray
 def test_validation_validates_onevar_onecall():
     temp_dir = tempfile.TemporaryDirectory()
     nx_compute = 12
@@ -65,7 +61,6 @@ def test_validation_validates_onevar_onecall():
         pytest.param(1.0, 0.99, id="absolute_failure"),
     ],
 )
-@requires_xarray
 def test_validation_asserts_onevar_onecall(relative_threshold, absolute_threshold):
     temp_dir = tempfile.TemporaryDirectory()
     nx_compute = 12
@@ -110,7 +105,6 @@ def test_validation_asserts_onevar_onecall(relative_threshold, absolute_threshol
         pytest.param(1.0, 0.99, id="absolute_threshold"),
     ],
 )
-@requires_xarray
 def test_validation_passes_onevar_two_calls(relative_threshold, absolute_threshold):
     temp_dir = tempfile.TemporaryDirectory()
     nx_compute = 12
@@ -161,7 +155,6 @@ def test_validation_passes_onevar_two_calls(relative_threshold, absolute_thresho
         pytest.param(1.0, 0.99, id="absolute_failure"),
     ],
 )
-@requires_xarray
 def test_validation_asserts_onevar_two_calls(relative_threshold, absolute_threshold):
     temp_dir = tempfile.TemporaryDirectory()
     nx_compute = 12
@@ -214,7 +207,6 @@ def test_validation_asserts_onevar_two_calls(relative_threshold, absolute_thresh
         pytest.param(1.0, 0.99, id="absolute_failure"),
     ],
 )
-@requires_xarray
 def test_validation_asserts_twovar_onecall(relative_threshold, absolute_threshold):
     temp_dir = tempfile.TemporaryDirectory()
     nx_compute = 12

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,6 @@ try:
 except ModuleNotFoundError:
     raise ModuleNotFoundError("NDSL cannot be loaded")
 try:
-    import gt4py
-except ModuleNotFoundError:
-    gt4py = None
-try:
     import cupy
 except ModuleNotFoundError:
     cupy = None
@@ -23,8 +19,6 @@ def backend(request):
             raise ModuleNotFoundError("cupy must be installed to run gpu tests")
         else:
             pytest.skip("cupy is not available for GPU backend")
-    elif gt4py is None and request.param.startswith("gt4py"):
-        pytest.skip("gt4py backend is not available")
     elif request.config.getoption("--gpu-only") and not request.param.endswith("cupy"):
         pytest.skip("running gpu tests only")
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,11 @@ import pytest
 
 try:
     import ndsl.dsl  # noqa: F401
-except ModuleNotFoundError:
-    raise ModuleNotFoundError("NDSL cannot be loaded")
-try:
-    import cupy
-except ModuleNotFoundError:
-    cupy = None
+except ModuleNotFoundError as error:
+    error.msg = f"NDSL cannot be loaded because {error.msg}"
+    raise error
+
+from ndsl.optional_imports import cupy
 
 
 @pytest.fixture(params=["numpy", "cupy"])
@@ -17,8 +16,7 @@ def backend(request):
     if cupy is None and request.param.endswith("cupy"):
         if request.config.getoption("--gpu-only"):
             raise ModuleNotFoundError("cupy must be installed to run gpu tests")
-        else:
-            pytest.skip("cupy is not available for GPU backend")
+        pytest.skip("cupy is not available for GPU backend")
     elif request.config.getoption("--gpu-only") and not request.param.endswith("cupy"):
         pytest.skip("running gpu tests only")
     else:

--- a/tests/dsl/test_caches.py
+++ b/tests/dsl/test_caches.py
@@ -1,4 +1,8 @@
+import os
+import shutil
+
 import pytest
+from gt4py.cartesian import config as gt_config
 from gt4py.storage import empty, ones
 
 from ndsl import (
@@ -83,11 +87,6 @@ class OrchestratedProgram:
     MPI is not None, reason="relocatibility checked with a one-rank setup"
 )
 def test_relocatability_orchestration(backend):
-    import os
-    import shutil
-
-    from gt4py.cartesian import config as gt_config
-
     original_root_directory = gt_config.cache_settings["root_path"]
     working_dir = str(os.getcwd())
 
@@ -142,14 +141,8 @@ def test_relocatability_orchestration(backend):
     MPI is not None, reason="relocatibility checked with a one-rank setup"
 )
 def test_relocatability(backend: str):
-    import os
-    import shutil
-
-    import gt4py
-    from gt4py.cartesian import config as gt_config
-
     # Restore original dir name
-    gt4py.cartesian.config.cache_settings["dir_name"] = os.environ.get(
+    gt_config.cache_settings["dir_name"] = os.environ.get(
         "GT_CACHE_DIR_NAME", f".gt_cache_{MPI.COMM_WORLD.Get_rank():06}"
     )
 

--- a/tests/mpi/mpi_comm.py
+++ b/tests/mpi/mpi_comm.py
@@ -1,8 +1,6 @@
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None
+from mpi4py import MPI
 
-if MPI is not None and MPI.COMM_WORLD.Get_size() == 1:
+
+if MPI.COMM_WORLD.Get_size() == 1:
     # not run as a parallel test, disable MPI tests
     MPI = None

--- a/tests/quantity/test_quantity.py
+++ b/tests/quantity/test_quantity.py
@@ -5,14 +5,6 @@ from ndsl import Quantity
 from ndsl.quantity.bounds import _shift_slice
 
 
-try:
-    import xarray as xr
-except ModuleNotFoundError:
-    xr = None
-
-requires_xarray = pytest.mark.skipif(xr is None, reason="xarray is not installed")
-
-
 @pytest.fixture(params=["empty", "one", "five"])
 def extent_1d(request, backend, n_halo):
     if request.param == "empty":
@@ -260,7 +252,6 @@ def test_shift_slice(slice_in, shift, extent, slice_out):
         ),
     ],
 )
-@requires_xarray
 def test_to_data_array(quantity):
     assert quantity.field_as_xarray.attrs == quantity.attrs
     assert quantity.field_as_xarray.dims == quantity.dims

--- a/tests/quantity/test_storage.py
+++ b/tests/quantity/test_storage.py
@@ -2,12 +2,7 @@ import numpy as np
 import pytest
 
 from ndsl import Quantity
-
-
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
+from ndsl.optional_imports import cupy as cp
 
 
 @pytest.fixture

--- a/tests/quantity/test_storage.py
+++ b/tests/quantity/test_storage.py
@@ -5,10 +5,6 @@ from ndsl import Quantity
 
 
 try:
-    import gt4py
-except ImportError:
-    gt4py = None
-try:
     import cupy as cp
 except ImportError:
     cp = None
@@ -72,7 +68,6 @@ def test_numpy(quantity, backend):
         assert quantity.np is np
 
 
-@pytest.mark.skipif(gt4py is None, reason="requires gt4py")
 def test_modifying_numpy_data_modifies_view_and_field():
     shape = (6, 6)
     data = np.zeros(shape, dtype=float)
@@ -99,7 +94,6 @@ def test_modifying_numpy_data_modifies_view_and_field():
     assert quantity.data[4, 4] == 3
 
 
-@pytest.mark.skipif(gt4py is None, reason="requires gt4py")
 def test_data_and_field_access_right_full_array_and_compute_domain():
     """Test halo read/write align with data (full array) and field (compute domain)"""
     shape = (6, 6)

--- a/tests/test_cube_scatter_gather.py
+++ b/tests/test_cube_scatter_gather.py
@@ -23,12 +23,6 @@ from ndsl.constants import (
 from ndsl.performance import Timer
 
 
-try:
-    import gt4py
-except ImportError:
-    gt4py = None
-
-
 @pytest.fixture(params=[(1, 1), (3, 3)])
 def layout(request):
     return request.param

--- a/tests/test_g2g_communication.py
+++ b/tests/test_g2g_communication.py
@@ -16,13 +16,8 @@ from ndsl import (
     TilePartitioner,
 )
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.optional_imports import cupy as cp
 from ndsl.performance import Timer
-
-
-try:
-    import cupy as cp
-except ModuleNotFoundError:
-    cp = None
 
 
 @pytest.fixture(params=[(1, 1), (3, 3)])

--- a/tests/test_legacy_restart.py
+++ b/tests/test_legacy_restart.py
@@ -2,14 +2,9 @@ import os
 import tempfile
 
 import cftime
-
-
-try:
-    import xarray as xr
-except ModuleNotFoundError:
-    xr = None
 import numpy as np
 import pytest
+import xarray as xr
 
 import ndsl.io as io
 from ndsl import (
@@ -28,8 +23,6 @@ from ndsl.restart._legacy_restart import (
 )
 
 
-requires_xarray = pytest.mark.skipif(xr is None, reason="xarray is not installed")
-
 TEST_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 DATA_DIRECTORY = os.path.join(TEST_DIRECTORY, "data")
 
@@ -39,7 +32,6 @@ def layout(request):
     return request.param
 
 
-@requires_xarray
 def get_c12_restart_state_list(layout, only_names, tracer_properties):
     total_ranks = 6 * layout[0] * layout[1]
     shared_buffer = {}
@@ -65,7 +57,6 @@ def get_c12_restart_state_list(layout, only_names, tracer_properties):
 
 @pytest.mark.parametrize("layout", [(1, 1), (3, 3)])
 @pytest.mark.cpu_only
-@requires_xarray
 def test_open_c12_restart(layout):
     tracer_properties = {}
     only_names = None
@@ -133,7 +124,6 @@ def test_open_c12_restart(layout):
         },
     ],
 )
-@requires_xarray
 @pytest.mark.cpu_only
 def test_open_c12_restart_tracer_properties(layout, tracer_properties):
     only_names = None
@@ -150,7 +140,6 @@ def test_open_c12_restart_tracer_properties(layout, tracer_properties):
 
 @pytest.mark.parametrize("layout", [(1, 1), (3, 3)])
 @pytest.mark.cpu_only
-@requires_xarray
 def test_open_c12_restart_empty_to_state_without_crashing(layout):
     total_ranks = 6 * layout[0] * layout[1]
     ny = 12 / layout[0]
@@ -193,7 +182,6 @@ def test_open_c12_restart_empty_to_state_without_crashing(layout):
 
 @pytest.mark.parametrize("layout", [(1, 1), (3, 3)])
 @pytest.mark.cpu_only
-@requires_xarray
 def test_open_c12_restart_to_allocated_state_without_crashing(layout):
     total_ranks = 6 * layout[0] * layout[1]
     ny = 12 / layout[0]
@@ -288,7 +276,6 @@ def result_dims(data_array, new_dims):
 
 
 @pytest.mark.cpu_only
-@requires_xarray
 def test_apply_dims(data_array, new_dims, result_dims):
     result = _apply_dims(data_array, new_dims)
     np.testing.assert_array_equal(result.values, data_array.values)
@@ -381,7 +368,6 @@ def test_get_rank_suffix_invalid_total_ranks(invalid_total_ranks):
 
 
 @pytest.mark.cpu_only
-@requires_xarray
 def test_read_state_incorrectly_encoded_time():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".nc") as file:
         state_ds = xr.DataArray(0.0, name="time").to_dataset()
@@ -391,7 +377,6 @@ def test_read_state_incorrectly_encoded_time():
 
 
 @pytest.mark.cpu_only
-@requires_xarray
 def test_read_state_non_scalar_time():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".nc") as file:
         state_ds = xr.DataArray([0.0, 1.0], dims=["T"], name="time").to_dataset()
@@ -405,7 +390,6 @@ def test_read_state_non_scalar_time():
     [["time", "air_temperature"], ["air_temperature"]],
     ids=lambda x: f"{x}",
 )
-@requires_xarray
 def test_open_c12_restart_only_names(layout, only_names):
     tracer_properties = {}
     c12_restart_state_list = get_c12_restart_state_list(

--- a/tests/test_netcdf_monitor.py
+++ b/tests/test_netcdf_monitor.py
@@ -5,6 +5,7 @@ from typing import List
 import cftime
 import numpy as np
 import pytest
+import xarray as xr
 
 from ndsl import (
     CubedSphereCommunicator,
@@ -14,10 +15,7 @@ from ndsl import (
     Quantity,
     TilePartitioner,
 )
-from ndsl.optional_imports import xarray as xr
 
-
-requires_xarray = pytest.mark.skipif(xr is None, reason="xarray is not installed")
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +35,6 @@ logger = logging.getLogger(__name__)
         pytest.param((5, 4, 4), 0, 1, ("z", "y", "x_interface"), id="cell_edge"),
     ],
 )
-@requires_xarray
 def test_monitor_store_multi_rank_state(
     layout, nt, time_chunk_size, tmpdir, shape, ny_rank_add, nx_rank_add, dims, numpy
 ):

--- a/tests/test_tile_scatter_gather.py
+++ b/tests/test_tile_scatter_gather.py
@@ -15,12 +15,6 @@ from ndsl.constants import (
 )
 
 
-try:
-    import gt4py
-except ImportError:
-    gt4py = None
-
-
 @pytest.fixture(params=[(1, 1), (3, 3)])
 def layout(request):
     return request.param

--- a/tests/test_zarr_monitor.py
+++ b/tests/test_zarr_monitor.py
@@ -1,16 +1,17 @@
+import copy
+import logging
 import tempfile
+from datetime import datetime, timedelta
+
+import cftime
+import pytest
+import xarray as xr
 
 
 try:
     import zarr
 except ModuleNotFoundError:
     zarr = None
-import copy
-import logging
-from datetime import datetime, timedelta
-
-import cftime
-import pytest
 
 from ndsl import CubedSpherePartitioner, DummyComm, Quantity, TilePartitioner
 from ndsl.constants import (
@@ -23,11 +24,9 @@ from ndsl.constants import (
     Z_DIM,
 )
 from ndsl.monitor.zarr_monitor import ZarrMonitor, array_chunks, get_calendar
-from ndsl.optional_imports import xarray as xr
 
 
 requires_zarr = pytest.mark.skipif(zarr is None, reason="zarr is not installed")
-requires_xarray = pytest.mark.skipif(xr is None, reason="xarray is not installed")
 
 logger = logging.getLogger("test_zarr_monitor")
 
@@ -144,7 +143,6 @@ def state_list(base_state, n_times, start_time, time_step, numpy):
 
 
 @requires_zarr
-@requires_xarray
 def test_monitor_file_store(state_list, cube_partitioner, numpy, start_time):
     with tempfile.TemporaryDirectory(suffix=".zarr") as tempdir:
         monitor = ZarrMonitor(tempdir, cube_partitioner)
@@ -155,14 +153,12 @@ def test_monitor_file_store(state_list, cube_partitioner, numpy, start_time):
 
 
 @requires_zarr
-@requires_xarray
 def validate_xarray_can_open(dirname):
     # just checking there are no crashes, validate_group checks data
     xr.open_zarr(dirname)
 
 
 @requires_zarr
-@requires_xarray
 def validate_store(states, filename, numpy, start_time):
     nt = len(states)
     calendar = get_calendar(start_time)
@@ -225,7 +221,6 @@ def validate_store(states, filename, numpy, start_time):
     ],
 )
 @requires_zarr
-@requires_xarray
 def test_monitor_file_store_multi_rank_state(
     layout, nt, tmpdir_factory, shape, ny_rank_add, nx_rank_add, dims, numpy
 ):
@@ -327,7 +322,6 @@ def test_monitor_file_store_multi_rank_state(
     ],
 )
 @requires_zarr
-@requires_xarray
 def test_array_chunks(layout, tile_array_shape, array_dims, target):
     result = array_chunks(layout, tile_array_shape, array_dims)
     assert result == target
@@ -344,7 +338,6 @@ def _assert_no_nulls(dataset: "xr.Dataset"):
 
 @pytest.mark.parametrize("mask_and_scale", [True, False])
 @requires_zarr
-@requires_xarray
 def test_open_zarr_without_nans(cube_partitioner, numpy, backend, mask_and_scale):
     store = {}
 
@@ -359,7 +352,6 @@ def test_open_zarr_without_nans(cube_partitioner, numpy, backend, mask_and_scale
 
 
 @requires_zarr
-@requires_xarray
 def test_values_preserved(cube_partitioner, numpy):
     dims = ("y", "x")
     units = "m"
@@ -395,7 +387,6 @@ def state_list_with_inconsistent_calendars(base_state, numpy):
 
 
 @requires_zarr
-@requires_xarray
 def test_monitor_file_store_inconsistent_calendars(
     state_list_with_inconsistent_calendars, cube_partitioner, numpy
 ):
@@ -444,7 +435,6 @@ def zarr_monitor_single_rank(zarr_store, cube_partitioner):
 
 
 @requires_zarr
-@requires_xarray
 def test_transposed_diags_write_across_ranks(diag, cube_partitioner, zarr_store):
     layout = (1, 1)
     total_ranks = 6 * layout[0] * layout[1]
@@ -470,7 +460,6 @@ def test_transposed_diags_write_across_ranks(diag, cube_partitioner, zarr_store)
 
 
 @requires_zarr
-@requires_xarray
 def test_transposed_diags_write_across_timesteps(diag, zarr_monitor_single_rank):
     # verify that we can store transposed diags across time
     time_1 = cftime.DatetimeJulian(2010, 6, 20, 6, 0, 0)
@@ -486,7 +475,6 @@ def test_transposed_diags_write_across_timesteps(diag, zarr_monitor_single_rank)
 
 
 @requires_zarr
-@requires_xarray
 def test_diags_fail_different_dim_set(diag, numpy, zarr_monitor_single_rank):
     time_1 = cftime.DatetimeJulian(2010, 6, 20, 6, 0, 0)
     time_2 = cftime.DatetimeJulian(2010, 6, 20, 6, 15, 0)
@@ -504,7 +492,6 @@ def test_diags_fail_different_dim_set(diag, numpy, zarr_monitor_single_rank):
 
 
 @requires_zarr
-@requires_xarray
 def test_diags_only_consistent_units_attrs_required(diag, zarr_monitor_single_rank):
     time_1 = cftime.DatetimeJulian(2010, 6, 20, 6, 0, 0)
     time_2 = cftime.DatetimeJulian(2010, 6, 20, 6, 15, 0)

--- a/tests/test_zarr_monitor.py
+++ b/tests/test_zarr_monitor.py
@@ -7,12 +7,6 @@ import cftime
 import pytest
 import xarray as xr
 
-
-try:
-    import zarr
-except ModuleNotFoundError:
-    zarr = None
-
 from ndsl import CubedSpherePartitioner, DummyComm, Quantity, TilePartitioner
 from ndsl.constants import (
     X_DIM,
@@ -24,9 +18,12 @@ from ndsl.constants import (
     Z_DIM,
 )
 from ndsl.monitor.zarr_monitor import ZarrMonitor, array_chunks, get_calendar
+from ndsl.optional_imports import RaiseWhenAccessed, zarr
 
 
-requires_zarr = pytest.mark.skipif(zarr is None, reason="zarr is not installed")
+requires_zarr = pytest.mark.skipif(
+    isinstance(zarr, RaiseWhenAccessed), reason="zarr is not installed"
+)
 
 logger = logging.getLogger("test_zarr_monitor")
 


### PR DESCRIPTION
**Description**

It looks like in earlier versions, a couple packages were optional. In particular this includes the following packages

`dace`, `gt4py`, `mpi4py`, and `xarray`

which are now all installed by default given the current `setup.py`. We can thus simplify their imports (in case they were still imported conditionally). In addition, a couple code paths didn't import `cupy` from `ndsl.optional_imports`. This has been corrected too.

Doing all this, I discovered a bug in `ndsl/checkpointer/snapshots.py`, where a snapshot's dataset would only ever contain the first `savepoint`. This was unearthed by tests in `tests/checkpointer/test_snapshot.py`, which suddenly started failing after cleaning up the imports.

As a follow-up, PR https://github.com/NOAA-GFDL/NDSL/pull/156 will look into re-enabling tests with `zarr` installed. Looks like these tests will need some love/work before we can re-enable them.

**How Has This Been Tested?**

Covered by existing test cases.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
