### PR TITLE
tests: Don't exit on first failure

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -23,14 +23,13 @@ jobs:
           run: pip3 install .[test]
 
         - name: prepare input eta files
-          run: |
-            python tests/grid/generate_eta_files.py
+          run: python tests/grid/generate_eta_files.py
 
         - name: Run serial-cpu tests
-          run: coverage run --rcfile=setup.cfg -m pytest -x tests
+          run: coverage run --rcfile=setup.cfg -m pytest tests
 
         - name: Run parallel-cpu tests
-          run: mpiexec -np 6 --oversubscribe coverage run --rcfile=setup.cfg -m mpi4py -m pytest -x tests/mpi
+          run: mpiexec -np 6 --oversubscribe coverage run --rcfile=setup.cfg -m mpi4py -m pytest tests/mpi
 
         - name: Output code coverage
           run: |


### PR DESCRIPTION
**Description**

Tests currently exist as soon as one test fails. Other tests don't even run. Imo this doesn't make sense on the CI. I'd rather see all the failing tests at once.

**How Has This Been Tested?**

As part of PR https://github.com/NOAA-GFDL/NDSL/pull/154, which had failing tests.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
