### PR TITLE
No boost dependency anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ For CPU backends:
 - 3.11.x >= Python < 3.12.x
 - Compilers:
   - GNU 11.2+
-- Libraries:
-  - Boost headers 1.76+ (no lib installed, just headers)
 
 For GPU backends (the above plus):
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,8 +25,6 @@ For CPU backends:
 - 3.11.x >= Python < 3.12.x
 - Compilers:
   - GNU 11.2+
-- Libraries:
-  - Boost headers 1.76+ (no lib installed, just headers)
 
 For GPU backends (the above plus):
 
@@ -88,18 +86,6 @@ git submodule update --init --recursive
 ```
 
 - Pace requires GCC > 9.2, MPI, and Python 3.8 on your system, and CUDA is required to run with a GPU backend.
-You will also need the headers of the boost libraries in your `$PATH` (boost itself does not need to be installed).
-If installed outside the standard header locations, gt4py requires that `$BOOST_ROOT` be set:
-
-```bash
-cd BOOST/ROOT
-wget https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz
-tar -xzf boost_1_79_0.tar.gz
-mkdir -p boost_1_79_0/include
-mv boost_1_79_0/boost boost_1_79_0/include/
-export BOOST_ROOT=BOOST/ROOT/boost_1_79_0
-```
-
 - We recommend creating a python `venv` or conda environment specifically for Pace.
 
 ```bash


### PR DESCRIPTION
**Description**

This is a follow-up from https://github.com/NOAA-GFDL/NDSL/pull/150. The one boost header that gt4py uses, comes now bundled with gt4py. We can thus remove boost (headers) from the list of dependencies.

The docs were the only place left - as far as a quick search could see.

**How Has This Been Tested?**

By looking at the changed files.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: /A
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings: N/A
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
