### PR TITLE
Packaging: Use of pyproject.toml and move to minimal setup.py for modernization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ndsl"
+version = "2025.05.00"
+dynamic = ["dependencies"]
+requires-python = ">=3.11"
+authors = [{name = "NOAA/NASA"}]
+readme = "README.md"
+license = {file = "LICENSE.txt"}
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+]
+
+[project.optional-dependencies]
+docs = ["mkdocs-material"]
+demos = ["ipython", "ipykernel"]
+test = ["pytest", "pytest-subtests", "coverage"]
+develop = [
+    "ndsl[docs]", 
+    "ndsl[demos]", 
+    "ndsl[test]", 
+    "pre-commit"
+]
+extras = [
+    "ndsl[docs]",
+    "ndsl[demos]",
+    "ndsl[test]",
+    "ndsl[develop]",
+]
+
+[project.scripts]
+ndsl-serialbox_to_netcdf = "ndsl.stencils.testing.serialbox_to_netcdf:entry_point"
+
+[project.urls]
+Repository = "https://github.com/NOAA-GFDL/NDSL"
+
+[tool.setuptools.packages.find]
+include = ["ndsl", "ndsl.*"]
+
+[tool.setuptools]
+include-package-data = true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import List
 
-from setuptools import find_namespace_packages, setup
+from setuptools import setup
 
 
 def local_pkg(name: str, relative_path: str) -> str:
@@ -10,19 +10,6 @@ def local_pkg(name: str, relative_path: str) -> str:
     path = f"{name} @ file://{Path(os.path.abspath(__file__)).parent / relative_path}"
     return path
 
-
-docs_requirements = ["mkdocs-material"]
-demos_requirements = ["ipython", "ipykernel"]
-test_requirements = ["pytest", "pytest-subtests", "coverage"]
-
-develop_requirements = test_requirements + docs_requirements + ["pre-commit"]
-
-extras_requires = {
-    "demos": demos_requirements,
-    "develop": develop_requirements,
-    "docs": docs_requirements,
-    "test": test_requirements,
-}
 
 requirements: List[str] = [
     local_pkg("gt4py", "external/gt4py"),
@@ -43,28 +30,5 @@ requirements: List[str] = [
 
 
 setup(
-    author="NOAA/NASA",
-    python_requires=">=3.11",
-    classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
-        "Natural Language :: English",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.11",
-    ],
     install_requires=requirements,
-    extras_require=extras_requires,
-    name="ndsl",
-    license="Apache 2.0 license",
-    packages=find_namespace_packages(include=["ndsl", "ndsl.*"]),
-    include_package_data=True,
-    url="https://github.com/NOAA-GFDL/NDSL",
-    version="2025.03.00",
-    zip_safe=False,
-    entry_points={
-        "console_scripts": [
-            "ndsl-serialbox_to_netcdf = ndsl.stencils.testing.serialbox_to_netcdf:entry_point",
-        ]
-    },
 )


### PR DESCRIPTION
**Description**
This PR moves the metadata and configuration for the package to a `pyproject.toml` file, as is prescribed by [Deprecate legacy setup.py develop mechanism for pip install --editable  #11457](https://github.com/pypa/pip/issues/11457). The previous `setup.py` file is now minimal. `

**How Has This Been Tested?**
Tested using the current CI workflow

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
