### PR TITLE
Fixes for external grid data read-in method

### DIFF
--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -482,6 +482,12 @@ class MetricTerms:
         terms._grid_64.view[:, :, 0] = rad_conv * x
         terms._grid_64.view[:, :, 1] = rad_conv * y
 
+        terms._comm.halo_update(terms._grid_64, n_points=terms._halo)
+
+        fill_corners_2d(
+            terms._grid_64.data, terms._grid_indexing, gridtype="B", direction="x"
+        )
+
         terms._init_agrid()
 
         return terms


### PR DESCRIPTION
**Description**
This PR introduces fixes to the external grid data read-in method in `generation.py`. The method previously lacked a halo update and a call to `fill_corners_2d`.

**How Has This Been Tested?**
These changes have been tested outside the CI via the test located in Pace at `pace/tests/mpi/ext_grid`, as well as with a comparison of the output from a c12 baroclinic run using internally generated grid data and the external data.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
