### PR TITLE
Change xarray.Dataset.{dims -> sizes}

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -317,7 +317,7 @@ def _savepoint_cases(
             )
             n_calls = xr.open_dataset(
                 os.path.join(data_path, f"{test_name}-In.nc")
-            ).dims["savepoint"]
+            ).sizes["savepoint"]
             if savepoint_to_replay is not None:
                 savepoint_iterator = range(savepoint_to_replay, savepoint_to_replay + 1)
             else:


### PR DESCRIPTION
**Description**

In newer versions of `xarray`, `Dataset.dims` will be changed to return a set of dimension names. The mapping from dimension names to lengths will move (and is already available) in `Dataset.sizes`.

This will make a warning go away that we currently see in pyFV3 translate tests, e.g. [here](https://github.com/NOAA-GFDL/NDSL/actions/runs/15735178930/job/44345871490).

![image](https://github.com/user-attachments/assets/d0db145c-1b16-4e00-ae87-cf83c6035705)

**How Has This Been Tested?**

Running pyFV3's XPPM translate test locally.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
