### PR TITLE
[Serialbox to NetCDF] Allow variables to not be saved in non zero ranks

### DIFF
--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -95,7 +95,7 @@ def main(
 
     savepoint_names = get_all_savepoint_names(serializer_0)
     for savepoint_name in sorted(list(savepoint_names)):
-        rank_list = []
+        rank_list: list[dict[str, Any]] = []
         names_list = list(
             serializer_0.fields_at_savepoint(
                 serializer_0.get_savepoint(savepoint_name)[0]


### PR DESCRIPTION
We continue to evolve the tool to move serialbox data into netcdf, by allowing non-zero ranks to not have data for certain variables. We copy NaN in place.