### PR TITLE
ci: Add cache for pre-commit environments

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5


### PR DESCRIPTION
**Description**

Caching the `pre-commit` environments. I realized this wasn't done. It's not breaking the bank, but it saves like 10 seconds on the linting workflow. Once merged to `develop`, all branches merging into develop can re-use the cache that is on `develop`, which never changes unless we update one of the environments (which we rarely do).

We can save another 10 seconds by not pulling submodules. NDSL has submodules of `gt4py` and `dace`. Both are external code that we aren't linting. We thus don't need to pull those in the linting workflow.

**How Has This Been Tested?**

By running the linting workflow of this branch multiple times and observing the workflow's output. The cache is properly restored and pre-commit environments don't need to be re-initialized in the second run.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
