### PR TITLE
Upgrade `mpi4py` to >4 

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -10,14 +10,20 @@ concurrency:
 jobs:
   ndsl_unit_tests:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/noaa-gfdl/miniforge:mpich
     steps:
 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install mpi (MPICH flavor)
+        run: pip3 install mpich
 
       - name: Install Python packages
         run: pip3 install .[test]
@@ -26,7 +32,7 @@ jobs:
         run: coverage run --rcfile=pyproject.toml -m pytest tests
 
       - name: Run parallel-cpu tests
-        run: mpiexec -np 6 --oversubscribe coverage run --rcfile=pyproject.toml -m mpi4py -m pytest tests/mpi
+        run: mpiexec -np 6 coverage run --rcfile=pyproject.toml -m mpi4py -m pytest tests/mpi
 
       - name: Output code coverage
         run: |

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def local_pkg(name: str, relative_path: str) -> str:
 requirements: list[str] = [
     local_pkg("gt4py", "external/gt4py"),
     local_pkg("dace", "external/dace"),
-    "mpi4py>4.1",
+    "mpi4py>=4.1",
     "cftime",
     "xarray>=2025.01.2",  # datatree + fixes
     "f90nml>=1.1.0",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def local_pkg(name: str, relative_path: str) -> str:
 requirements: list[str] = [
     local_pkg("gt4py", "external/gt4py"),
     local_pkg("dace", "external/dace"),
-    "mpi4py>4",
+    "mpi4py>4.1",
     "cftime",
     "xarray>=2025.01.2",  # datatree + fixes
     "f90nml>=1.1.0",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def local_pkg(name: str, relative_path: str) -> str:
 requirements: list[str] = [
     local_pkg("gt4py", "external/gt4py"),
     local_pkg("dace", "external/dace"),
-    "mpi4py==3.1.5",
+    "mpi4py>4",
     "cftime",
     "xarray>=2025.01.2",  # datatree + fixes
     "f90nml>=1.1.0",


### PR DESCRIPTION
The current work to run at scale on Grace Hopper unified silicon ARM64 hardware as showcased the need to move `mpi4py` above 4x.

The original restriction to `3.1.5` was done out of an abundance of caution in a moment where halo exchange  were questioned.

Alas, the new allocator that ships with cuda 12.5 for GH boxes especially trips the old `mpi4py`. We need to move up.

The risk is limited as `4.1` showcase a very large amount of fixes to main version 4.