### PR TITLE
ci: Run tests when pushing to protected branches

### DIFF
--- a/.github/workflows/fv3_translate_tests.yaml
+++ b/.github/workflows/fv3_translate_tests.yaml
@@ -1,6 +1,11 @@
 name: "FV3 translate tests"
 on:
   pull_request:
+  push:
+    # We don't use a merge queue and allow to merge outdated branches for practical reasons,
+    # because pyFV3 and pace tests take a long time to run. The "safety net" is thus to run
+    # tests when pushing to protected branches.
+    branches: [develop, main]
 
 jobs:
   fv3_translate_tests:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,14 @@
 name: "Lint"
 on:
   pull_request:
+  push:
+    # We don't use a merge queue and allow to merge outdated branches for practical reasons,
+    # because pyFV3 and pace tests take a long time to run. The "safety net" is thus to run
+    # tests when pushing to protected branches.
+    branches: [develop, main]
 
-# cancel running jobs if theres a newer push
 concurrency:
+  # Cancel running jobs if theres a newer push.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -1,6 +1,11 @@
 name: "pace main tests"
 on:
   pull_request:
+  push:
+    # We don't use a merge queue and allow to merge outdated branches for practical reasons,
+    # because pyFV3 and pace tests take a long time to run. The "safety net" is thus to run
+    # tests when pushing to protected branches.
+    branches: [develop, main]
 
 jobs:
   pace_main_tests:

--- a/.github/workflows/shield_tests.yaml
+++ b/.github/workflows/shield_tests.yaml
@@ -1,6 +1,11 @@
 name: "SHiELD Translate tests"
 on:
   pull_request:
+  push:
+    # We don't use a merge queue and allow to merge outdated branches for practical reasons,
+    # because pyFV3 and pace tests take a long time to run. The "safety net" is thus to run
+    # tests when pushing to protected branches.
+    branches: [develop, main]
 
 jobs:
   shield_translate_tests:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,9 +1,14 @@
 name: "NDSL unit tests"
 on:
   pull_request:
+  push:
+    # We don't use a merge queue and allow to merge outdated branches for practical reasons,
+    # because pyFV3 and pace tests take a long time to run. The "safety net" is thus to run
+    # tests when pushing to protected branches.
+    branches: [develop, main]
 
-# cancel running jobs if theres a newer push
 concurrency:
+  # Cancel running jobs if theres a newer push.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 


### PR DESCRIPTION
**Description**

We don't use a merge queue and we allow to merge outdated branches for practical reasons (because in particular pyFV3 and pace tests take a long time to run). It could thus happen that we get a bad merge. In that unlikely case, we'd like to know and thus run tests when pushing to protected branches (`main` and `develop`) as a safety net.

**How Has This Been Tested?**

CI would complain if the yaml formatting was off. We only know for sure that this works once this PR is merged.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
