### PR TITLE
[Fix] Multimodal override fix for Absolute Epsilon

### DIFF
--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -79,7 +79,9 @@ def process_override(threshold_overrides, testobj, test_name, backend):
             if "multimodal" in match:
                 parsed_multimodal = match["multimodal"]
                 if "absolute_epsilon" in parsed_multimodal:
-                    testobj.mmr_absolute_eps = float(parsed_multimodal["absolute_eps"])
+                    testobj.mmr_absolute_eps = float(
+                        parsed_multimodal["absolute_epsilon"]
+                    )
                 if "relative_fraction" in parsed_multimodal:
                     testobj.mmr_relative_fraction = float(
                         parsed_multimodal["relative_fraction"]

--- a/ndsl/testing/README.md
+++ b/ndsl/testing/README.md
@@ -112,7 +112,7 @@ where fields other than `var1` and `var2` will use `global_value`.
 Stencil_name:
  - backend: <backend>
    multimodal:
-    absolute_eps: <value>
+    absolute_epsilon: <value>
     relative_fraction: <value>
     ulp_threshold: <value>
 ```


### PR DESCRIPTION
**Description**
Use full keyword "absolute_epsilon", update docs.
