### PR TITLE
RFC: Deprecate `PACE_*` environment variables in favor of `NDSL_*`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ Configurations for Pace to use NDSL with different backend:
 
   - Run: load pre-compiled program and execute, fail if the .so is not present (_no hash check!_) (backend must be `dace:gpu` or `dace:cpu`)
 
-- PACE_FLOAT_PRECISION=64 control the floating point precision throughout the program.
+- NDSL_FLOAT_PRECISION=64 control the floating point precision throughout the program.
 
 Install Pace with different NDSL backend:
 

--- a/ndsl/constants.py
+++ b/ndsl/constants.py
@@ -1,5 +1,6 @@
 import os
 from enum import Enum
+from typing import Literal
 
 import numpy as np
 
@@ -16,13 +17,29 @@ class ConstantVersions(Enum):
     GEOS = "GEOS"  # Constant as defined in GEOS v11.4.2
 
 
-CONST_VERSION_AS_STR = os.environ.get("PACE_CONSTANTS", "UFS")
+def _get_constant_version(
+    default: Literal["GFDL", "UFS", "GEOS"] = "UFS",
+) -> Literal["GFDL", "UFS", "GEOS"]:
+    if os.getenv("PACE_CONSTANTS", ""):
+        ndsl_log.warning("PACE_CONSTANTS is deprecated. Use NDSL_CONSTANTS instead.")
+        if os.getenv("NDSL_CONSTANTS", ""):
+            ndsl_log.warning(
+                "PACE_CONSTANTS and NDSL_CONSTANTS were both specified. NDSL_CONSTANTS will take precedence."
+            )
 
-try:
-    CONST_VERSION = ConstantVersions[CONST_VERSION_AS_STR]
-    ndsl_log.info(f"Constant selected: {CONST_VERSION}")
-except KeyError as e:
-    raise RuntimeError(f"Constants {CONST_VERSION_AS_STR} is not implemented, abort.")
+    constants_as_str = os.getenv("NDSL_CONSTANTS", os.getenv("PACE_CONSTANTS", default))
+    expected: list[Literal["GFDL", "UFS", "GEOS"]] = ["GFDL", "UFS", "GEOS"]
+
+    if constants_as_str not in expected:
+        raise RuntimeError(
+            f"Constants '{constants_as_str}' is not implemented, abort. Valid values are {expected}."
+        )
+
+    return constants_as_str  # type: ignore
+
+
+CONST_VERSION = ConstantVersions[_get_constant_version()]
+ndsl_log.info(f"Constant selected: {CONST_VERSION}")
 
 #####################
 # Common constants

--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -1,8 +1,9 @@
-import os
 from typing import Tuple, TypeAlias, Union, cast
 
 import numpy as np
 from gt4py.cartesian import gtscript
+
+from ndsl.dsl import NDSL_GLOBAL_PRECISION
 
 
 # A Field
@@ -23,7 +24,7 @@ DTypes = Union[bool, np.bool_, int, np.int32, np.int64, float, np.float32, np.fl
 
 
 def get_precision() -> int:
-    return int(os.getenv("PACE_FLOAT_PRECISION", "64"))
+    return NDSL_GLOBAL_PRECISION
 
 
 # We redefine the type as a way to distinguish

--- a/ndsl/logging.py
+++ b/ndsl/logging.py
@@ -8,8 +8,6 @@ from typing import Annotated
 from mpi4py import MPI
 
 
-LOGLEVEL = os.environ.get("PACE_LOGLEVEL", "INFO").lower()
-
 # Python log levels are hierarchical, therefore setting INFO
 # means DEBUG and everything lower will be logged.
 AVAILABLE_LOG_LEVELS = {
@@ -19,6 +17,28 @@ AVAILABLE_LOG_LEVELS = {
     "error": logging.ERROR,
     "critical": logging.CRITICAL,
 }
+
+
+def _get_log_level(default: str = "info"):
+    if os.getenv("PACE_LOGLEVEL", ""):
+        ndsl_log.warning("PACE_LOGLEVEL is deprecated. Use NDSL_LOGLEVEL instead.")
+        if os.getenv("NDSL_LOGLEVEL", ""):
+            ndsl_log.warning(
+                "PACE_LOGLEVEL and NDSL_LOGLEVEL were both specified. NDSL_LOGLEVEL will take precedence."
+            )
+
+    loglevel = os.getenv("NDSL_LOGLEVEL", os.getenv("PACE_LOGLEVEL", default)).lower()
+
+    if loglevel in AVAILABLE_LOG_LEVELS.keys():
+        return loglevel
+
+    ndsl_log.warning(
+        f"Unknown log level '{loglevel}', falling back to '{default}'. Valid values are: {AVAILABLE_LOG_LEVELS.keys()}."
+    )
+    return default
+
+
+LOGLEVEL = _get_log_level()
 
 
 def _ndsl_logger() -> logging.Logger:


### PR DESCRIPTION
**Description**

This PR suggests to rename the following environment variables:

- `PACE_DACE_DEBUG` -> `NDSL_DACE_DEBUG`
- `PACE_LOGLEVEL` -> `NDSL_LOGLEVEL`
- `PACE_FLOAT_PRECISION` -> `NDSL_LITERAL_PRECISION`
- `PACE_CONSTANTS` -> `NDSL_CONSTANTS`

All changes are made backwards compatible (for now) with deprecation warnings when using `PACE_*` environment variables. `NDSL_*` variables will take precedence in case both variants are defined.

This PR should be merged after https://github.com/NOAA-GFDL/NDSL/pull/192 because we touch `PACE_FLOAT_PRECISION` there too.

**How Has This Been Tested?**

By self-review of code changes and by running the CI.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
  No, but that's kind of the point here :wink: 
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
