### PR TITLE
ci: configure tests to run on merge-queue

### DIFF
--- a/.github/workflows/fv3_translate_tests.yaml
+++ b/.github/workflows/fv3_translate_tests.yaml
@@ -1,6 +1,11 @@
 name: "FV3 translate tests"
+
+# Run these these whenever ...
 on:
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  branches:
+    - main # ... when merging into the main branch
 
 jobs:
   fv3_translate_tests:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,11 @@
 name: "Lint"
+
+# Run these these whenever ...
 on:
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  branches:
+    - main # ... when merging into the main branch
 
 # cancel running jobs if theres a newer push
 concurrency:

--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -1,6 +1,11 @@
 name: "pace main tests"
+
+# Run these these whenever ...
 on:
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  branches:
+    - main # ... when merging into the main branch
 
 jobs:
   pace_main_tests:

--- a/.github/workflows/shield_tests.yaml
+++ b/.github/workflows/shield_tests.yaml
@@ -1,6 +1,11 @@
 name: "SHiELD Translate tests"
+
+# Run these these whenever ...
 on:
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  branches:
+    - main # ... when merging into the main branch
 
 jobs:
   shield_translate_tests:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,6 +1,11 @@
 name: "NDSL unit tests"
+
+# Run these these whenever ...
 on:
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  branches:
+    - main # ... when merging into the main branch
 
 # cancel running jobs if theres a newer push
 concurrency:


### PR DESCRIPTION
**Description**

This PR adds support for merging with merge queues. According to [this guide](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) it's a combination of adding the `merge_group` trigger and configuration in the admin interface. I can do the first part.

Using merge queues was talked about in the pace meeting in August. No concerns were raised. This PR supersedes https://github.com/NOAA-GFDL/NDSL/pull/186. 

**How Has This Been Tested?**

Will be tested with either this merge or the next one that goes in.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
