### PR TITLE
ci: Effective cache sharing between PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
-**Description**
+# Description
+
 Include a summary of the change and which issue is fixed. Please also include
 relevant motivation and context. List any dependencies that are required for
 this change.
@@ -6,12 +7,14 @@ this change.
 Fixes # (issue)
 If this is a hotfix to a released version, please specify it.
 
-**How Has This Been Tested?**
+## How has this been tested?
+
 Please describe the tests that you ran to verify your changes. Please also note
 any relevant details for your test configuration (e.g. compiler, OS).  Include
 enough information so someone can reproduce your tests.
 
-**Checklist:**
+## Checklist
+
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas

--- a/.github/workflows/create-cache.yaml
+++ b/.github/workflows/create-cache.yaml
@@ -1,0 +1,44 @@
+name: "Create GHA cache"
+
+# GitHub puts the following restrictions on cache sharing. PRs can access
+#
+# - caches that were created by the PR / earlier runs of the PR
+# - caches that were created on the target branch
+#
+# To get effective cache sharing between PRs, we create caches on the `develop`
+# branch (which is where almost all PRs merge into).
+
+on:
+  push:
+    branches: [develop]
+
+# Cancel running jobs if there's a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # GitHub Actions cache of the pre-commit environment
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit_${{ env.pythonLocation }}_${{ hashFiles('.pre-commit-config.yaml') }}
+          lookup-only: true  # don't actually download the cache
+
+      - name: Populate pre-commit environment (if not cached)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          pip install pre-commit
+          pre-commit install --install-hooks

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,9 @@ jobs:
         with:
           python-version: '3.11'
 
-      - uses: actions/cache@v4
+      # Only restore (don't save) caches on PRs. New caches created from PRs won't be
+      # accessible from other PRs, see workflows/create-cache.yaml.
+      - uses: actions/cache/restore@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit_${{ env.pythonLocation }}_${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
# Description

As mentioned in https://github.com/NOAA-GFDL/NDSL/pull/186#issuecomment-3113772569, our caching is currently sub-optimal and only really works for subsequent runs on the same PR.

Ideally, we'd like to share caches between PRs such that not every PR has to first build a cache. The way GHA caches work is that they can only be accessed if they were created by the same PR or by the target branch. I've thus added a workflow to (re-)create the pre-commit cache whenever we merge into the `develop` branch. The linting workflow (running on PRs) will just restore the cache (and not attempt to upload a new one).

Caching the test_data needs to be done in the workflow that creates the cache (e.g., for the "PyFV3 translate tests" we need to modify the workflow(s) in the PyFV3 repo).

We could cache the pip cache for "NDSL unit tests". However, since we (mostly) aren't pinning python package dependencies to specific version numbers (in `setup.py` and `pyproject.toml`), this cache would get out of date soon. And since the runtime of NDSL unit tests are governed by the test runtime, I don't see a need for that right now. Once we pin package dependencies with a lock file, we can re-evaluate.

The changes in the pull request template are unrelated. They just stop my editor from complaining about invalid markdown syntax in that file. The changes are due to the following rules

- every markdown starts with a `# Header`
- don't use `**bold font**`  as headers
- headers are followed by an empty line

## How Has This Been Tested?

Tested the new workflow on my fork of NDSL.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
