### PR TITLE
refactor: remove workaround in fill_corners_dgrid

### DIFF
--- a/ndsl/stencils/corners.py
+++ b/ndsl/stencils/corners.py
@@ -1001,9 +1001,6 @@ def fill_corners_dgrid_defn(
     from __externals__ import i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
-        # this line of code is used to fix the missing symbol crash due to the node visitor depth limitation
-        acoef = mysign
-        x_out = x_out
         # sw corner
         with horizontal(region[i_start - 1, j_start - 1]):
             x_out = mysign * y_in[0, 1, 0]


### PR DESCRIPTION
**Description**

Due to a gt4py-dace bridge around argument lists and pruning unused arguments/statements, we introduced nonsensical code in this stencil to avoid the stencil being completely empty, which would trigger "missing" arguments.

See PRs / issues https://github.com/NOAA-GFDL/NDSL/pull/60, https://github.com/NOAA-GFDL/NDSL/pull/69, https://github.com/NOAA-GFDL/NDSL/issues/42, https://github.com/NOAA-GFDL/NDSL/issues/70 for context.

Since the re-write of the gt4py-dace bridge (based on "schedule trees"), we don't have this limitation anymore and the workaround can be removed again.

**How Has This Been Tested?**

Local runs of `DivergenceDamping` / `D_SW` translate test (in PyFV3) with the AI2 data.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
