### PR TITLE
quick fix for 2D fields

### DIFF
--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -28,6 +28,9 @@ class BaseMetric:
     ):
         self.references = np.atleast_1d(reference_values)
         self.computed = np.atleast_1d(computed_values)
+        if len(self.computed.shape) == 2 and len(self.references.shape) == 3:
+            if self.references.shape[-1] == 1:
+                self.references = self.references[:, :, 0]
         self.check = False
 
     def __str__(self) -> str: ...


### PR DESCRIPTION
**Description**
Sometimes we serialize data with shape (x, y, 1) and want to compare to a 2D ndsl field, this removes the extra dimension on the comparison field by default.

**How Has This Been Tested?**
Translate tests run with this.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
