### PR TITLE
perf: Optimize cpu compiler flags for dace:cpu

### DIFF
--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -215,7 +215,7 @@ class DaceConfig:
                 "compiler",
                 "cpu",
                 "args",
-                value=f"-std=c++14 -fPIC -Wall -Wextra -O{optimization_level}",
+                value=f"-march=native -std=c++17 -fPIC -Wall -Wextra -O{optimization_level}",
             )
             # Potentially buggy - deactivate
             dace.config.Config.set(


### PR DESCRIPTION
**Description**

Initial work on performance showed that we could still optimize performance by tuning compiler flags. Let's do so :rocket: 

This PR is work that's being propagated back from the [nasa/milestone2 branch](https://github.com/NOAA-GFDL/NDSL/pull/189).

**How Has This Been Tested?**

Tested by running benchmarks locally.

@gmao-ckung / @FlorianDeconinck can someone check on a GH box that `--march=native` is actually working there or if we need the same workaround as for the gpu compiler?

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
