### PR TITLE
tests: remove an unused arguments in stencil definition

### DIFF
--- a/tests/dsl/test_caches.py
+++ b/tests/dsl/test_caches.py
@@ -41,7 +41,7 @@ def restore_cache_dir():
     gt_config.cache_settings["dir_name"] = cache_dir
 
 
-def _stencil(inp: Field[float], out: Field[float], scalar: float):
+def _stencil(inp: Field[float], out: Field[float]):
     with computation(PARALLEL), interval(...):
         out = inp
 
@@ -83,7 +83,7 @@ class OrchestratedProgram:
         self.out = utils.make_storage(empty, grid_indexing, stencil_config, dtype=float)
 
     def __call__(self):
-        self.stencil(self.inp, self.out, self.inp[0, 0, 0])
+        self.stencil(self.inp, self.out)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
**Description**

This test doesn't need the third scalar argument and the test doesn't rely on having extra arguments. We can thus safely delete this argument.

This PR is work that's being propagated back from the [nasa/milestone2 branch](https://github.com/NOAA-GFDL/NDSL/pull/189).

**How Has This Been Tested?**

By self-review. All good as long as the test is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
