### PR TITLE
fix: gpu/mpi synchronization issue with in-place all reduce sum

### DIFF
--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -17,6 +17,7 @@ from ndsl.performance.timer import NullTimer, Timer
 from ndsl.quantity import Quantity, QuantityHaloSpec, QuantityMetadata
 from ndsl.types import NumpyModule
 
+
 def to_numpy(array, dtype=None) -> np.ndarray:
     """
     Input array can be a numpy array or a cupy array. Returns numpy array.

--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -4,6 +4,7 @@ import abc
 from typing import List, Mapping, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
+import cupy as cp
 
 import ndsl.constants as constants
 from ndsl.buffer import array_buffer, device_synchronize, recv_buffer, send_buffer
@@ -16,6 +17,7 @@ from ndsl.optional_imports import cupy
 from ndsl.performance.timer import NullTimer, Timer
 from ndsl.quantity import Quantity, QuantityHaloSpec, QuantityMetadata
 from ndsl.types import NumpyModule
+from ndsl.utils import device_synchronize
 
 
 def to_numpy(array, dtype=None) -> np.ndarray:
@@ -142,6 +144,9 @@ class Communicator(abc.ABC):
     def all_reduce_per_element_in_place(
         self, quantity: Quantity, op: ReductionOperator
     ):
+        # Note that device_synchronization is Cupy/Cuda specific
+        # at the moment.
+        device_synchronize()
         self.comm.Allreduce_inplace(quantity.data, op)
 
     def _Scatter(self, numpy_module, sendbuf, recvbuf, **kwargs):

--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -4,7 +4,6 @@ import abc
 from typing import List, Mapping, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
-import cupy as cp
 
 import ndsl.constants as constants
 from ndsl.buffer import array_buffer, device_synchronize, recv_buffer, send_buffer
@@ -17,8 +16,6 @@ from ndsl.optional_imports import cupy
 from ndsl.performance.timer import NullTimer, Timer
 from ndsl.quantity import Quantity, QuantityHaloSpec, QuantityMetadata
 from ndsl.types import NumpyModule
-from ndsl.utils import device_synchronize
-
 
 def to_numpy(array, dtype=None) -> np.ndarray:
     """


### PR DESCRIPTION
**Description**

We've seen issues with large-scale runs on the GPU cluster. Runs would be stuck in the global sum calculation. Putting a `device_synchronize()` in the MPI in-place all_reduce calls seems fix these issues and let's runs finish.

Note that device_synchronization is Cupy/Cuda specific at the moment.

This PR is work that's being propagated back from the [nasa/milestone2 branch](https://github.com/NOAA-GFDL/NDSL/pull/189).

**How Has This Been Tested?**

@gmao-ckung was running tests on the GPU cluster.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
