### PR TITLE
Remove `FrozenCompiledSDFG` to avert the hidden behavior on orchestration call

### DIFF
--- a/ndsl/__init__.py
+++ b/ndsl/__init__.py
@@ -6,7 +6,7 @@ from .comm.null_comm import NullComm
 from .comm.partitioner import CubedSpherePartitioner, TilePartitioner
 from .constants import ConstantVersions
 from .dsl.caches.codepath import FV3CodePath
-from .dsl.dace.dace_config import DaceConfig, DaCeOrchestration, FrozenCompiledSDFG
+from .dsl.dace.dace_config import DaceConfig, DaCeOrchestration
 from .dsl.dace.orchestration import orchestrate, orchestrate_function
 from .dsl.dace.utils import (
     ArrayReport,

--- a/ndsl/dsl/dace/build.py
+++ b/ndsl/dsl/dace/build.py
@@ -128,6 +128,7 @@ def set_distributed_caches(config: DaceConfig):
 
     # Set read/write caches to the target rank
     from gt4py.cartesian import config as gt_config
+    import dace
 
     if config.do_compile:
         verb = "reading/writing"
@@ -135,6 +136,14 @@ def set_distributed_caches(config: DaceConfig):
         verb = "reading"
 
     gt_config.cache_settings["dir_name"] = get_cache_directory(config.code_path)
+
+    dace.Config.set(
+        "default_build_folder",
+        value="{gt_root}/{gt_cache}/dacecache".format(
+            gt_root=gt_config.cache_settings["root_path"],
+            gt_cache=gt_config.cache_settings["dir_name"],
+        ),
+    )
     ndsl_log.info(
         f"[{orchestration_mode}] Rank {config.my_rank} "
         f"{verb} cache {gt_config.cache_settings['dir_name']}"

--- a/ndsl/dsl/dace/build.py
+++ b/ndsl/dsl/dace/build.py
@@ -127,8 +127,8 @@ def set_distributed_caches(config: DaceConfig):
             )
 
     # Set read/write caches to the target rank
-    from gt4py.cartesian import config as gt_config
     import dace
+    from gt4py.cartesian import config as gt_config
 
     if config.do_compile:
         verb = "reading/writing"

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -179,7 +179,7 @@ class DaceConfig:
         # Recording SDFG loaded for fast re-access
         # ToDo: DaceConfig becomes a bit more than a read-only config
         #       with this. Should be refactored into a DaceExecutor carrying a config
-        self.loaded_precompiled_SDFG: dict[DaceProgram, FrozenCompiledSDFG] = {}
+        self.loaded_precompiled_SDFG: dict[DaceProgram, dace.CompiledSDFG] = {}
 
         # Temporary. This is a bit too out of the ordinary for the common user.
         # We should refactor the architecture to allow for a `gtc:orchestrated:dace:X`

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -5,7 +5,6 @@ import os
 from typing import Any
 
 import dace.config
-from dace.codegen.compiled_sdfg import CompiledSDFG
 from dace.frontend.python.parser import DaceProgram
 from gt4py.cartesian.config import GT4PY_COMPILE_OPT_LEVEL
 
@@ -143,28 +142,6 @@ class DaCeOrchestration(enum.Enum):
     Build = 1
     BuildAndRun = 2
     Run = 3
-
-
-class FrozenCompiledSDFG:
-    """
-    Cache transform args to allow direct execution of the CSDFG
-
-    Args:
-        csdfg: compiled SDFG, e.g. loaded .so
-        sdfg_args: transformed args to align for CSDFG direct execution
-
-    WARNING: No checks are done on arguments, any memory swap (free/realloc)
-    will lead to difficult to debug misbehavior
-    """
-
-    def __init__(
-        self, daceprog: DaceProgram, csdfg: CompiledSDFG, args, kwargs
-    ) -> None:
-        self.csdfg = csdfg
-        self.sdfg_args = daceprog._create_sdfg_args(csdfg.sdfg, args, kwargs)
-
-    def __call__(self):
-        return self.csdfg(**self.sdfg_args)
 
 
 class DaceConfig:

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
-from dace import SDFG
+from dace import SDFG, CompiledSDFG
 from dace import compiletime as DaceCompiletime
 from dace import dtypes
 from dace import method as dace_method
@@ -25,7 +25,6 @@ from ndsl.dsl.dace.dace_config import (
     DEACTIVATE_DISTRIBUTED_DACE_COMPILE,
     DaceConfig,
     DaCeOrchestration,
-    FrozenCompiledSDFG,
 )
 from ndsl.dsl.dace.sdfg_debug_passes import (
     negative_delp_checker,
@@ -197,7 +196,10 @@ def _build_sdfg(
     # On Build: all ranks sync, then exit.
     # On BuildAndRun: all ranks sync, then load the SDFG from
     #                 the expected path (made available by build).
-    # We use a "FrozenCompiledSDFG" to minimize re-entry cost at call time
+    # We use a "CompiledSDFG" which keep the `so` online but _won't_
+    # do the marshalling of the arguments at call time. For this we call
+    # `dace_program._create_sdfg_args`. There's optimization potential for
+    # re-entry cost there.
 
     mode = config.get_orchestrate()
     # DEV NOTE: we explicitly use MPI.COMM_WORLD here because it is
@@ -241,7 +243,7 @@ def _call_sdfg(dace_program: DaceProgram, sdfg: SDFG, config: DaceConfig, args, 
             # NOTE: this will go over declared arguments and closure arguments.
             # It is a very slow piece of code. Compiled SDFG comes with a "fast_call"
             # function that expects all pointers to have been made C worthy. This is
-            # something we did with "FrozenSDFG" but we undid because it meant that
+            # something we did with "FrozenCompileSDFG" but we undid because it meant that
             # external changing memory (reallocation...) would quietly fail
             current_sdfg_args = dace_program._create_sdfg_args(
                 config.loaded_precompiled_SDFG[dace_program].sdfg, args, kwargs
@@ -271,7 +273,7 @@ def _parse_sdfg(
     config: DaceConfig,
     *args,
     **kwargs,
-) -> Optional[SDFG]:
+) -> Optional[SDFG | CompiledSDFG]:
     """Return an SDFG depending on cache existence.
     Either parses, load a .sdfg or load .so (as a compiled sdfg)
 
@@ -313,9 +315,7 @@ def _parse_sdfg(
 
     with DaCeProgress(config, "Load precompiled .sdfg (.so)"):
         compiledSDFG, _ = dace_program.load_precompiled_sdfg(sdfg_path, *args, **kwargs)
-        config.loaded_precompiled_SDFG[dace_program] = FrozenCompiledSDFG(
-            dace_program, compiledSDFG, args, kwargs
-        )
+        config.loaded_precompiled_SDFG[dace_program] = compiledSDFG
     return compiledSDFG
 
 

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -220,9 +220,7 @@ def _build_sdfg(
             compiledSDFG, _ = dace_program.load_precompiled_sdfg(
                 sdfg_path, *args, **kwargs
             )
-            config.loaded_precompiled_SDFG[dace_program] = FrozenCompiledSDFG(
-                dace_program, compiledSDFG, args, kwargs
-            )
+            config.loaded_precompiled_SDFG[dace_program] = compiledSDFG
 
         return _call_sdfg(dace_program, sdfg, config, args, kwargs)
 
@@ -237,7 +235,10 @@ def _call_sdfg(dace_program: DaceProgram, sdfg: SDFG, config: DaceConfig, args, 
         with DaCeProgress(config, "Run"):
             if config.is_gpu_backend():
                 _upload_to_device(list(args) + list(kwargs.values()))
-            res = config.loaded_precompiled_SDFG[dace_program]()
+            current_sdfg_args = dace_program._create_sdfg_args(
+                config.loaded_precompiled_SDFG[dace_program].sdfg, args, kwargs
+            )
+            res = config.loaded_precompiled_SDFG[dace_program](**current_sdfg_args)
             res = _download_results_from_dace(
                 config, res, list(args) + list(kwargs.values())
             )

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -302,6 +302,9 @@ class FrozenStencil(SDFGConvertible):
 
         self._argument_names = tuple(inspect.getfullargspec(func).args)
 
+        # NOTE: this is also down in `dace/build.py` for orchestration
+        # This is still needed for non-orchestrated used of DaCe.
+        # A better build system would take care of BOTH of those at the same time
         if "dace" in self.stencil_config.compilation_config.backend:
             dace.Config.set(
                 "default_build_folder",
@@ -500,8 +503,7 @@ class FrozenStencil(SDFGConvertible):
             for field_name in field_info
             if field_info[field_name]
             and bool(
-                field_info[field_name].access
-                & gt_definitions.AccessKind.WRITE  # type: ignore
+                field_info[field_name].access & gt_definitions.AccessKind.WRITE  # type: ignore
             )
         ]
         return write_fields

--- a/tests/dsl/orchestration/test_call.py
+++ b/tests/dsl/orchestration/test_call.py
@@ -1,13 +1,10 @@
 import pytest
-from ndsl import (
-    StencilFactory,
-    QuantityFactory,
-)
+
+from ndsl import QuantityFactory, StencilFactory
+from ndsl.boilerplate import get_factories_single_tile_orchestrated
+from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.gt4py import PARALLEL, Field, computation, interval
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
-
-from ndsl.boilerplate import get_factories_single_tile_orchestrated
 
 
 def _stencil(out: Field[float]):

--- a/tests/dsl/orchestration/test_call.py
+++ b/tests/dsl/orchestration/test_call.py
@@ -12,7 +12,7 @@ def _stencil(out: Field[float]):
         out = out + 1
 
 
-# @pytest.fixture
+@pytest.fixture
 def factories() -> tuple[StencilFactory, QuantityFactory]:
     stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
         5, 5, 2, 0
@@ -48,7 +48,3 @@ def test_memory_reallocation(factories):
     code(qty_B)
     assert (qty_A.field[0, 0, :] == 3).all()
     assert (qty_B.field[0, 0, :] == 2).all()
-
-
-if __name__ == "__main__":
-    test_memory_reallocation(factories())

--- a/tests/dsl/orchestration/test_call.py
+++ b/tests/dsl/orchestration/test_call.py
@@ -1,5 +1,3 @@
-import pytest
-
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.boilerplate import get_factories_single_tile_orchestrated
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
@@ -10,14 +8,6 @@ from ndsl.dsl.gt4py import PARALLEL, Field, computation, interval
 def _stencil(out: Field[float]):
     with computation(PARALLEL), interval(...):
         out = out + 1
-
-
-@pytest.fixture
-def factories() -> tuple[StencilFactory, QuantityFactory]:
-    stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
-        5, 5, 2, 0
-    )
-    return (stencil_factory, quantity_factory)
 
 
 class OrchestratedProgram:
@@ -33,11 +23,13 @@ class OrchestratedProgram:
         self.stencil(out_qty)
 
 
-def test_memory_reallocation(factories):
-    qty_factory = factories[1]
-    code = OrchestratedProgram(factories[0], qty_factory)
-    qty_A = qty_factory.ones([X_DIM, Y_DIM, Z_DIM], "A")
-    qty_B = qty_factory.ones([X_DIM, Y_DIM, Z_DIM], "B")
+def test_memory_reallocation():
+    stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
+        5, 5, 2, 0
+    )
+    code = OrchestratedProgram(stencil_factory, quantity_factory)
+    qty_A = quantity_factory.ones([X_DIM, Y_DIM, Z_DIM], "A")
+    qty_B = quantity_factory.ones([X_DIM, Y_DIM, Z_DIM], "B")
 
     code(qty_A)
     assert (qty_A.field[0, 0, :] == 2).all()

--- a/tests/dsl/orchestration/test_call.py
+++ b/tests/dsl/orchestration/test_call.py
@@ -1,0 +1,57 @@
+import pytest
+from ndsl import (
+    StencilFactory,
+    QuantityFactory,
+)
+from ndsl.dsl.dace.orchestration import orchestrate
+from ndsl.dsl.gt4py import PARALLEL, Field, computation, interval
+from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+
+from ndsl.boilerplate import get_factories_single_tile_orchestrated
+
+
+def _stencil(out: Field[float]):
+    with computation(PARALLEL), interval(...):
+        out = out + 1
+
+
+# @pytest.fixture
+def factories() -> tuple[StencilFactory, QuantityFactory]:
+    stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
+        5, 5, 2, 0
+    )
+    return (stencil_factory, quantity_factory)
+
+
+class OrchestratedProgram:
+    def __init__(
+        self,
+        stencil_factory: StencilFactory,
+        quantity_factory: QuantityFactory,
+    ):
+        orchestrate(obj=self, config=stencil_factory.config.dace_config)
+        self.stencil = stencil_factory.from_dims_halo(_stencil, [X_DIM, Y_DIM, Z_DIM])
+
+    def __call__(self, out_qty):
+        self.stencil(out_qty)
+
+
+def test_memory_reallocation(factories):
+    qty_factory = factories[1]
+    code = OrchestratedProgram(factories[0], qty_factory)
+    qty_A = qty_factory.ones([X_DIM, Y_DIM, Z_DIM], "A")
+    qty_B = qty_factory.ones([X_DIM, Y_DIM, Z_DIM], "B")
+
+    code(qty_A)
+    assert (qty_A.field[0, 0, :] == 2).all()
+
+    code(qty_A)
+    assert (qty_A.field[0, 0, :] == 3).all()
+
+    code(qty_B)
+    assert (qty_A.field[0, 0, :] == 3).all()
+    assert (qty_B.field[0, 0, :] == 2).all()
+
+
+if __name__ == "__main__":
+    test_memory_reallocation(factories())


### PR DESCRIPTION
The `FrozenCompiledSDFG` was created to cache in the C pointers of the data with an eye of getting the most speed for online code into larger Fortran models. This creates a hidden (nearly undocumented) behavior in which swapping memory (by reallocation or else) is prohibited and will result in wrong answers.

We revert to the previous behavior which is safe (but slow) and test properly for future optimization.

Side quest: we fix the (rare) case where orchestration doesn't touch any `stencils`, where the `dace` build folder set in the frozen stencil call is not enough. Documented the lackluster system in code.