### PR TITLE
Adding a test for indexing 4-dimensional fields

### DIFF
--- a/tests/test_4d_fields.py
+++ b/tests/test_4d_fields.py
@@ -1,6 +1,4 @@
-import pytest
-
-from ndsl import QuantityFactory, StencilFactory
+from ndsl import StencilFactory
 from ndsl.boilerplate import (
     get_factories_single_tile,
     get_factories_single_tile_orchestrated,
@@ -10,7 +8,11 @@ from ndsl.dsl.gt4py import PARALLEL, computation, interval, max
 from ndsl.dsl.typing import Float, FloatField, set_4d_field_size
 
 
+TRACER_DIM = "n_tracers"
 FloatFieldTracer = set_4d_field_size(9, Float)
+ntracers = 9
+ntke = 8
+fill_value = 42.0
 
 
 def sample_4d_stencil(q_in: FloatFieldTracer, q_out: FloatField):
@@ -34,29 +36,14 @@ class SampleCalculation:
         self._test_calc(q_in, q_out)
 
 
-@pytest.mark.parametrize(
-    "stencil_factory,quantity_factory",
-    [
-        pytest.param(*get_factories_single_tile(24, 24, 91, 3), id="4d-field_stencil"),
-        pytest.param(
-            *get_factories_single_tile_orchestrated(24, 24, 91, 3),
-            id="4d-field_orchestration",
-        ),
-    ],
-)
-def test_4d_stencil_call(
-    stencil_factory: StencilFactory, quantity_factory: QuantityFactory
-) -> None:
-    TRACER_DIM = "n_tracers"
-    ntracers = 9
-    ntke = 8
-    fill_value = 42.0
-
+def test_non_orchestrated_call() -> None:
+    stencil_factory, quantity_factory = get_factories_single_tile(24, 24, 91, 3)
     quantity_factory.set_extra_dim_lengths(
         **{
             TRACER_DIM: ntracers,
         }
     )
+
     q_out = quantity_factory.zeros(
         [X_DIM, Y_DIM, Z_DIM],
         units="unknown",
@@ -66,8 +53,32 @@ def test_4d_stencil_call(
         units="unknown",
     )
     q_in.field[:, :, :, ntke] = fill_value
+
     calc = SampleCalculation(stencil_factory, ntke=ntke)
-
     calc(q_in, q_out)
+    assert (q_out.field[:, :, :] == fill_value).all()
 
+
+def test_orchestrated_call() -> None:
+    stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
+        24, 24, 91, 3
+    )
+    quantity_factory.set_extra_dim_lengths(
+        **{
+            TRACER_DIM: ntracers,
+        }
+    )
+
+    q_out = quantity_factory.zeros(
+        [X_DIM, Y_DIM, Z_DIM],
+        units="unknown",
+    )
+    q_in = quantity_factory.zeros(
+        [X_DIM, Y_DIM, Z_DIM, TRACER_DIM],
+        units="unknown",
+    )
+    q_in.field[:, :, :, ntke] = fill_value
+
+    calc = SampleCalculation(stencil_factory, ntke=ntke)
+    calc(q_in, q_out)
     assert (q_out.field[:, :, :] == fill_value).all()


### PR DESCRIPTION
# Description

This PR adds a test for 4D fields to ensure they can be indexed correctly inside a stencil

## How has this been tested?

This test reproduces calls (and errors) encountered in porting physics code to stencils

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
