### PR TITLE
fix: boilerplate allocation and layout warnings

### DIFF
--- a/ndsl/boilerplate.py
+++ b/ndsl/boilerplate.py
@@ -1,7 +1,3 @@
-from typing import Tuple
-
-import numpy as np
-
 from ndsl import (
     CompilationConfig,
     DaceConfig,
@@ -16,18 +12,17 @@ from ndsl import (
     TileCommunicator,
     TilePartitioner,
 )
-from ndsl.optional_imports import cupy as cp
 
 
 def _get_factories(
     nx: int,
     ny: int,
     nz: int,
-    nhalo,
+    nhalo: int,
     backend: str,
     orchestration: DaCeOrchestration,
     topology: str,
-) -> Tuple[StencilFactory, QuantityFactory]:
+) -> tuple[StencilFactory, QuantityFactory]:
     """Build a Stencil & Quantity factory for a combination of options.
 
     Dev Note: We don't expose this function because we want the boilerplate to remain
@@ -75,16 +70,14 @@ def _get_factories(
 
     grid_indexing = GridIndexing.from_sizer_and_communicator(sizer, comm)
     stencil_factory = StencilFactory(config=stencil_config, grid_indexing=grid_indexing)
-    quantity_factory = QuantityFactory(
-        sizer, cp if stencil_config.is_gpu_backend else np
-    )
+    quantity_factory = QuantityFactory.from_backend(sizer, backend)
 
     return stencil_factory, quantity_factory
 
 
 def get_factories_single_tile_orchestrated(
-    nx, ny, nz, nhalo, on_cpu: bool = True
-) -> Tuple[StencilFactory, QuantityFactory]:
+    nx: int, ny: int, nz: int, nhalo: int, on_cpu: bool = True
+) -> tuple[StencilFactory, QuantityFactory]:
     """Build a Stencil & Quantity factory for orchestrated CPU, on a single tile topology."""
     return _get_factories(
         nx=nx,
@@ -98,8 +91,8 @@ def get_factories_single_tile_orchestrated(
 
 
 def get_factories_single_tile(
-    nx, ny, nz, nhalo, backend: str = "numpy"
-) -> Tuple[StencilFactory, QuantityFactory]:
+    nx: int, ny: int, nz: int, nhalo: int, backend: str = "numpy"
+) -> tuple[StencilFactory, QuantityFactory]:
     return _get_factories(
         nx=nx,
         ny=ny,

--- a/tests/test_boilerplate.py
+++ b/tests/test_boilerplate.py
@@ -42,6 +42,10 @@ def test_boilerplate_import_numpy():
         nx=5, ny=5, nz=2, nhalo=1
     )
 
+    # Ensure backend is propagated to StencilFactory and QuantityFactory
+    assert stencil_factory.backend == "numpy"
+    assert quantity_factory._backend() == "numpy"
+
     _copy_ops(stencil_factory, quantity_factory)
 
 
@@ -56,5 +60,9 @@ def test_boilerplate_import_orchestrated_cpu():
     stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
         nx=5, ny=5, nz=2, nhalo=1
     )
+
+    # Ensure backend is propagated to StencilFactory and QuantityFactory
+    assert stencil_factory.backend == "dace:cpu"
+    assert quantity_factory._backend() == "dace:cpu"
 
     _copy_ops(stencil_factory, quantity_factory)


### PR DESCRIPTION
# Description

`ndsl/boilerplate.py` has two functions to simplify creation of `StencilFactory` and `QuantityFactory`. Both factories depend on the backend where the numpy backend acts a fallback for both. The backend wasn't properly forwarded to the `QuantityFactory` leading to data that wasn't necessarily optimally aligned (except e.g. for the numpy backend). For example, in case of the `dace:cpu` backend, this leads to performance warning messages about improperly aligned memory.

This is what Christopher Harrop was seeing because he specified the `dace:cpu` backend in `get_factories_single_tile()`, which wasn't properly forwarded to the `QuantityFactory` leading to warning messages about improperly aligned memory.

This is the clean version of #222, which got a bit out of hands with the cleanups. This PR is just fixing the issue and a follow-up up will do the suggested refactor of `QuantityFactory`.

## How has this been tested?

Existing tests have been updated to check for the backend.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
