### PR TITLE
fix: fully type allocator and fix fallout

### DIFF
--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -314,16 +314,8 @@ class MetricTerms:
                 eta_file, ak, bk  # type: ignore
             )
         else:
-            self._ks = self.quantity_factory.zeros(
-                [],
-                "",
-                dtype=Float,
-            )
-            self._ptop = self.quantity_factory.zeros(
-                [],
-                "Pa",
-                dtype=Float,
-            )
+            self._ks = 0
+            self._ptop = 0
             self._ak = self.quantity_factory.zeros(
                 [Z_INTERFACE_DIM],
                 "Pa",
@@ -669,7 +661,7 @@ class MetricTerms:
         return self._dy_center
 
     @property
-    def ks(self) -> Quantity:
+    def ks(self) -> int:
         """
         number of levels where the vertical coordinate is purely pressure-based
         """
@@ -692,7 +684,7 @@ class MetricTerms:
         return self._bk
 
     @property
-    def ptop(self) -> Quantity:
+    def ptop(self) -> int:
         """
         the pressure of the top of atmosphere level
         """
@@ -2200,17 +2192,7 @@ class MetricTerms:
         eta_file: Path | None = None,
         ak_data: np.ndarray | None = None,
         bk_data: np.ndarray | None = None,
-    ):
-        ks = self.quantity_factory.zeros(
-            [],
-            "",
-            dtype=Float,
-        )
-        ptop = self.quantity_factory.zeros(
-            [],
-            "Pa",
-            dtype=Float,
-        )
+    ) -> tuple[int, int, Quantity, Quantity]:
         ak = self.quantity_factory.zeros(
             [Z_INTERFACE_DIM],
             "Pa",

--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -1,4 +1,6 @@
-from typing import Callable, Optional, Sequence
+from __future__ import annotations
+
+from typing import Callable, Sequence
 
 import numpy as np
 from gt4py import storage as gt_storage
@@ -10,7 +12,7 @@ from ndsl.quantity import Quantity, QuantityHaloSpec
 
 
 class StorageNumpy:
-    def __init__(self, backend: str):
+    def __init__(self, backend: str) -> None:
         """Initialize an object which behaves like the numpy module, but uses
         gt4py storage objects for zeros, ones, and empty.
 
@@ -30,18 +32,18 @@ class StorageNumpy:
 
 
 class QuantityFactory:
-    def __init__(self, sizer: GridSizer, numpy):
+    def __init__(self, sizer: GridSizer, numpy) -> None:
         self.sizer: GridSizer = sizer
         self._numpy = numpy
 
-    def set_extra_dim_lengths(self, **kwargs):
+    def set_extra_dim_lengths(self, **kwargs) -> None:
         """
         Set the length of extra (non-x/y/z) dimensions.
         """
         self.sizer.extra_dim_lengths.update(kwargs)
 
     @classmethod
-    def from_backend(cls, sizer: GridSizer, backend: str):
+    def from_backend(cls, sizer: GridSizer, backend: str) -> QuantityFactory:
         """Initialize a QuantityFactory to use a specific gt4py backend.
 
         Args:
@@ -51,11 +53,11 @@ class QuantityFactory:
         numpy = StorageNumpy(backend)
         return cls(sizer, numpy)
 
-    def _backend(self) -> Optional[str]:
-        try:
+    def _backend(self) -> str | None:
+        if isinstance(self._numpy, StorageNumpy):
             return self._numpy.backend
-        except AttributeError:
-            return None
+
+        return None
 
     def empty(
         self,
@@ -63,7 +65,7 @@ class QuantityFactory:
         units: str,
         dtype: type = Float,
         allow_mismatch_float_precision: bool = False,
-    ):
+    ) -> Quantity:
         return self._allocate(
             self._numpy.empty, dims, units, dtype, allow_mismatch_float_precision
         )
@@ -74,7 +76,7 @@ class QuantityFactory:
         units: str,
         dtype: type = Float,
         allow_mismatch_float_precision: bool = False,
-    ):
+    ) -> Quantity:
         return self._allocate(
             self._numpy.zeros, dims, units, dtype, allow_mismatch_float_precision
         )
@@ -85,7 +87,7 @@ class QuantityFactory:
         units: str,
         dtype: type = Float,
         allow_mismatch_float_precision: bool = False,
-    ):
+    ) -> Quantity:
         return self._allocate(
             self._numpy.ones, dims, units, dtype, allow_mismatch_float_precision
         )
@@ -96,7 +98,7 @@ class QuantityFactory:
         dims: Sequence[str],
         units: str,
         allow_mismatch_float_precision: bool = False,
-    ):
+    ) -> Quantity:
         """
         Create a Quantity from a numpy array.
 
@@ -118,7 +120,7 @@ class QuantityFactory:
         dims: Sequence[str],
         units: str,
         allow_mismatch_float_precision: bool = False,
-    ):
+    ) -> Quantity:
         """
         Create a Quantity from a numpy array.
 
@@ -141,7 +143,7 @@ class QuantityFactory:
         units: str,
         dtype: type = Float,
         allow_mismatch_float_precision: bool = False,
-    ):
+    ) -> Quantity:
         origin = self.sizer.get_origin(dims)
         extent = self.sizer.get_extent(dims)
         shape = self.sizer.get_shape(dims)
@@ -174,7 +176,7 @@ class QuantityFactory:
     def get_quantity_halo_spec(
         self,
         dims: Sequence[str],
-        n_halo: Optional[int] = None,
+        n_halo: int | None = None,
         dtype: type = Float,
     ) -> QuantityHaloSpec:
         """Build memory specifications for the halo update.


### PR DESCRIPTION
# Description

This PR fully types `ndsl/initialization/allocator.py` and fixes fallout in the grid generation because `ks` and `ptop` are supposed to be scalars.

This is the clean version of the second part of PR #222.

## How has this been tested?

`mypy` is happy now :upside_down_face: 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
