### PR TITLE
Deprecation warning for QuantityFactory constructor

### DIFF
--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Callable, Sequence
 
 import numpy as np
@@ -32,7 +33,17 @@ class StorageNumpy:
 
 
 class QuantityFactory:
-    def __init__(self, sizer: GridSizer, numpy) -> None:
+    def __init__(
+        self, sizer: GridSizer, numpy, *, silence_deprecation_warning: bool = False
+    ) -> None:
+        if not silence_deprecation_warning:
+            warnings.warn(
+                "Usage of QuantityFactory(sizer, numpy) is discouraged and will change "
+                "in the next release. Use QuantityFactory.from_backend(sizer, backend) "
+                "instead for a stable experience across the release.",
+                DeprecationWarning,
+                2,
+            )
         self.sizer: GridSizer = sizer
         self._numpy = numpy
 
@@ -51,7 +62,8 @@ class QuantityFactory:
             backend: gt4py backend
         """
         numpy = StorageNumpy(backend)
-        return cls(sizer, numpy)
+        # Don't print the deprecation warning in this case
+        return cls(sizer, numpy, silence_deprecation_warning=True)
 
     def _backend(self) -> str | None:
         if isinstance(self._numpy, StorageNumpy):

--- a/tests/initialization/test_allocator.py
+++ b/tests/initialization/test_allocator.py
@@ -1,0 +1,19 @@
+import warnings
+
+import numpy as np
+import pytest
+
+from ndsl import QuantityFactory
+
+
+def test_QuantityFactory_constructor_warns() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match="Usage of QuantityFactory.* is discouraged and will change",
+    ):
+        QuantityFactory(None, np)
+
+    # Make sure no warnings are emitted if users use `QuantityFactory.from_backend()`
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        QuantityFactory.from_backend(None, "numpy")

--- a/tests/test_dimension_sizer.py
+++ b/tests/test_dimension_sizer.py
@@ -191,7 +191,7 @@ def test_subtile_dimension_sizer_shape(sizer, dim_case):
 
 
 def test_allocator_zeros(numpy, sizer, dim_case, units, dtype):
-    allocator = QuantityFactory(sizer, numpy)
+    allocator = QuantityFactory.from_backend(sizer, "numpy")
     quantity = allocator.zeros(dim_case.dims, units, dtype=dtype)
     assert quantity.units == units
     assert quantity.dims == dim_case.dims
@@ -202,7 +202,7 @@ def test_allocator_zeros(numpy, sizer, dim_case, units, dtype):
 
 
 def test_allocator_ones(numpy, sizer, dim_case, units, dtype):
-    allocator = QuantityFactory(sizer, numpy)
+    allocator = QuantityFactory.from_backend(sizer, "numpy")
     quantity = allocator.ones(dim_case.dims, units, dtype=dtype)
     assert quantity.units == units
     assert quantity.dims == dim_case.dims
@@ -212,8 +212,8 @@ def test_allocator_ones(numpy, sizer, dim_case, units, dtype):
     assert numpy.all(quantity.data == 1)
 
 
-def test_allocator_empty(numpy, sizer, dim_case, units, dtype):
-    allocator = QuantityFactory(sizer, numpy)
+def test_allocator_empty(sizer, dim_case, units, dtype):
+    allocator = QuantityFactory.from_backend(sizer, "numpy")
     quantity = allocator.empty(dim_case.dims, units, dtype=dtype)
     assert quantity.units == units
     assert quantity.dims == dim_case.dims


### PR DESCRIPTION
# Description

The constructor of `QuantityFactory` is scheduled to change after the next release. See https://github.com/NOAA-GFDL/NDSL/pull/228 for context. To give our users a heads-up, let's merge a deprecation warning now.

## How has this been tested?

New tests have been added.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
  No, but that's kind of the point here.
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
