### PR TITLE
cleanup: backends raise if not defined

### DIFF
--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -83,7 +83,6 @@ class Quantity:
 
         if gt4py_backend is not None:
             gt4py_backend_cls = gt_backend.from_name(gt4py_backend)
-            assert gt4py_backend_cls is not None
             is_optimal_layout = gt4py_backend_cls.storage_info["is_optimal_layout"]
 
             dimensions: Tuple[Union[str, int], ...] = tuple(


### PR DESCRIPTION
# Description

Starting with https://github.com/GridTools/gt4py/pull/1544, `gt_backend.from_name()` will raise an exception if no backend with that name is registred. No need to assert for `backend is not None` because that never happens anymore. Besides, it's not safe for production anyway.

## How has this been tested?

By self-reviewing code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
