### PR TITLE
BREAKING CHANGE: orchestration boilerplate options

### DIFF
--- a/ndsl/boilerplate.py
+++ b/ndsl/boilerplate.py
@@ -76,15 +76,19 @@ def _get_factories(
 
 
 def get_factories_single_tile_orchestrated(
-    nx: int, ny: int, nz: int, nhalo: int, on_cpu: bool = True
+    nx: int, ny: int, nz: int, nhalo: int, backend: str = "dace:cpu"
 ) -> tuple[StencilFactory, QuantityFactory]:
-    """Build a Stencil & Quantity factory for orchestrated CPU, on a single tile topology."""
+    """Build the pair of (StencilFactory, QuantityFactory) for orchestrated code on a single tile topology."""
+
+    if backend is not None and not backend.startswith("dace"):
+        raise ValueError("Only `dace:*` backends can be orchestrated.")
+
     return _get_factories(
         nx=nx,
         ny=ny,
         nz=nz,
         nhalo=nhalo,
-        backend="dace:cpu" if on_cpu else "dace:gpu",
+        backend=backend,
         orchestration=DaCeOrchestration.BuildAndRun,
         topology="tile",
     )
@@ -93,6 +97,7 @@ def get_factories_single_tile_orchestrated(
 def get_factories_single_tile(
     nx: int, ny: int, nz: int, nhalo: int, backend: str = "numpy"
 ) -> tuple[StencilFactory, QuantityFactory]:
+    """Build the pair of (StencilFactory, QuantityFactory) for stencils on a single tile topology."""
     return _get_factories(
         nx=nx,
         ny=ny,

--- a/tests/test_boilerplate.py
+++ b/tests/test_boilerplate.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
@@ -66,3 +67,12 @@ def test_boilerplate_import_orchestrated_cpu():
     assert quantity_factory._backend() == "dace:cpu"
 
     _copy_ops(stencil_factory, quantity_factory)
+
+
+def test_boilerplate_non_dace_based_orchestration_raises():
+    from ndsl.boilerplate import get_factories_single_tile_orchestrated
+
+    with pytest.raises(ValueError, match="Only .* backends can be orchestrated."):
+        get_factories_single_tile_orchestrated(
+            nx=5, ny=5, nz=2, nhalo=1, backend="numpy"
+        )


### PR DESCRIPTION
# Description

This PR introduces a breaking change in the orchestration boilerplate funtions that sets up `StencilFactory` and `QuantityFactory`. The option `on_cpu` is replaced by a `backend` option. The backend option defaults to `dace:cpu` mimicking the current default behavior.

This change is in anticipation of the `dace:cpu_kfirst` backend that we already have in the `nasa/milestone2` branch. With that backend, we will have three backends that can be orchestrated, two of which are cpu-based. A boolean `on_cpu` is thus not enough anymore to map out all the options.

Not all backends can be orchestrated. A check is put in place to catch people to try to orchestrate a non dace-based backend.

## How has this been tested?

New test is added.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
