### PR TITLE
[Fix] DaCe build system should be tied more closely to existing configuration

### DIFF
--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -175,7 +175,7 @@ class DaceConfig:
         # have the configuration at NDSL level, but we do use the GT4Py
         # level
         # TODO: if GT4PY opt level is funneled via NDSL - use it here
-        optimization_level = GT4PY_COMPILE_OPT_LEVEL
+        optimization_level = int(GT4PY_COMPILE_OPT_LEVEL)
 
         # Set the configuration of DaCe to a rigid & tested set of divergence
         # from the defaults when orchestrating
@@ -188,7 +188,13 @@ class DaceConfig:
                 == b"NVIDIA GH200 480GB"
             )
 
-            dace.config.Config.set("compiler", "build_type", value="Release")
+            if optimization_level == 0:
+                dace.config.Config.set("compiler", "build_type", value="Debug")
+            elif optimization_level == 2 or optimization_level == 1:
+                dace.config.Config.set("compiler", "build_type", value="RelWithDebInfo")
+            else:
+                dace.config.Config.set("compiler", "build_type", value="Release")
+
             # Required to True for gt4py storage/memory
             dace.config.Config.set(
                 "compiler",


### PR DESCRIPTION
# Description

GT4Py as a flag `GT4PY_COMPILE_OPT_LEVEL` that directs `-O` compiler flags. We have tied it in to the compilation level for DaCe within their CMake system. But we haven't tied it fully and this PR fixes that.

In a subsequent PR we should introduce a NDSL level configuration for optimization that drives both the GT4Py and DaCe sub-configuration.
