### PR TITLE
Namelist Refactor: Utility functions for namelist to dict + conftest --no_legacy_namelist

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -257,7 +257,10 @@ def sequential_savepoint_cases(metafunc, data_path, namelist_filename, *, backen
     topology_mode = metafunc.config.getoption("topology")
     sort_report = metafunc.config.getoption("sort_report")
     no_report = metafunc.config.getoption("no_report")
+
+    # Temporary flag (Issue#64): TODO Remove once ndsl.Namelist is gone.
     f90nml_namelist_only = metafunc.config.getoption("f90nml_namelist_only")
+
     return _savepoint_cases(
         savepoint_names,
         ranks,
@@ -270,7 +273,7 @@ def sequential_savepoint_cases(metafunc, data_path, namelist_filename, *, backen
         topology_mode,
         sort_report=sort_report,
         no_report=no_report,
-        f90nml_namelist_only=f90nml_namelist_only,
+        f90nml_namelist_only=f90nml_namelist_only,  # Issue#64: tmp flag
     )
 
 
@@ -286,7 +289,7 @@ def _savepoint_cases(
     topology_mode: bool,
     sort_report: str,
     no_report: bool,
-    f90nml_namelist_only: bool,
+    f90nml_namelist_only: bool,  # Issue#64: tmp flag
 ):
     grid_params = grid_params_from_f90nml(namelist)
     return_list = []
@@ -322,8 +325,8 @@ def _savepoint_cases(
             grid_indexing=grid.grid_indexing,
         )
         for test_name in sorted(list(savepoint_names)):
-            # TODO REMOVE this conversion from f90nml.Namelist to ndsl.Namelist
-            # after ndsl.Namelist is removed
+            # Temporary check (Issue#64): TODO Remove check and conversion from
+            # f90nml.Namelist to ndsl.Namelist after ndsl.Namelist is removed
             if not f90nml_namelist_only:
                 if type(namelist) is not NdslNamelist:
                     namelist = NdslNamelist.from_f90nml(namelist)
@@ -376,7 +379,10 @@ def parallel_savepoint_cases(
     savepoint_names = get_parallel_savepoint_names(metafunc, data_path)
     grid_mode = metafunc.config.getoption("grid")
     savepoint_to_replay = get_savepoint_restriction(metafunc)
+
+    # Temporary flag (Issue#64): TODO Remove once ndsl.Namelist is gone.
     f90nml_namelist_only = metafunc.config.getoption("f90nml_namelist_only")
+
     return _savepoint_cases(
         savepoint_names,
         [mpi_rank],
@@ -389,7 +395,7 @@ def parallel_savepoint_cases(
         topology_mode,
         sort_report=sort_report,
         no_report=no_report,
-        f90nml_namelist_only=f90nml_namelist_only,
+        f90nml_namelist_only=f90nml_namelist_only,  # Issue#64: tmp flag
     )
 
 

--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -328,7 +328,7 @@ def _savepoint_cases(
         for test_name in sorted(list(savepoint_names)):
             # Temporary check (Issue#64): TODO Remove check and conversion from
             # f90nml.Namelist to ndsl.Namelist after ndsl.Namelist is removed
-            if not no_legacy_namelist: # This means we use NdslNamelist.
+            if not no_legacy_namelist:  # This means we use NdslNamelist.
                 if not isinstance(namelist, NdslNamelist):
                     namelist = NdslNamelist.from_f90nml(namelist)
 

--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -1,5 +1,6 @@
 import os
 import re
+from pathlib import Path
 from typing import Optional, Tuple
 
 import pytest
@@ -133,9 +134,9 @@ def data_path(pytestconfig):
     return data_path_and_namelist_filename_from_config(pytestconfig)
 
 
-def data_path_and_namelist_filename_from_config(config) -> Tuple[str, str]:
-    data_path = config.getoption("data_path")
-    namelist_filename = os.path.join(data_path, "input.nml")
+def data_path_and_namelist_filename_from_config(config) -> Tuple[Path, Path]:
+    data_path = Path(config.getoption("data_path"))
+    namelist_filename = data_path / "input.nml"
     return data_path, namelist_filename
 
 
@@ -284,7 +285,7 @@ def _savepoint_cases(
     stencil_config,
     namelist: Namelist,
     backend: str,
-    data_path: str,
+    data_path: Path,
     grid_mode: str,
     topology_mode: bool,
     sort_report: str,
@@ -304,9 +305,9 @@ def _savepoint_cases(
                 backend,
             )
         elif grid_mode == "file" or grid_mode == "compute":
-            ds_grid: xr.Dataset = xr.open_dataset(
-                os.path.join(data_path, "Grid-Info.nc")
-            ).isel(savepoint=0)
+            ds_grid: xr.Dataset = xr.open_dataset(data_path / "Grid-Info.nc").isel(
+                savepoint=0
+            )
             grid = TranslateGrid(
                 dataset_to_dict(ds_grid.isel(rank=rank)),
                 rank=rank,
@@ -334,9 +335,9 @@ def _savepoint_cases(
             testobj = get_test_class_instance(
                 test_name, grid, namelist, stencil_factory
             )
-            n_calls = xr.open_dataset(
-                os.path.join(data_path, f"{test_name}-In.nc")
-            ).sizes["savepoint"]
+            n_calls = xr.open_dataset(data_path / f"{test_name}-In.nc").sizes[
+                "savepoint"
+            ]
             if savepoint_to_replay is not None:
                 savepoint_iterator = range(savepoint_to_replay, savepoint_to_replay + 1)
             else:

--- a/ndsl/stencils/testing/parallel_translate.py
+++ b/ndsl/stencils/testing/parallel_translate.py
@@ -7,11 +7,15 @@ import pytest
 
 from ndsl.constants import HORIZONTAL_DIMS, N_HALO_DEFAULT, X_DIMS, Y_DIMS
 from ndsl.dsl import gt4py_utils as utils
+
+# TODO: Remove once ndsl.Namelist is gone (Issue#64)
+from ndsl.namelist import Namelist as NdslNamelist
 from ndsl.quantity import Quantity
 from ndsl.stencils.testing.translate import (
     TranslateFortranData2Py,
     read_serialized_data,
 )
+from ndsl.utils import grid_params_from_f90nml
 
 
 class ParallelTranslate:
@@ -129,7 +133,14 @@ class ParallelTranslate:
 
     @property
     def layout(self):
-        return self.namelist.layout
+        # TODO: Once ndsl.namelist.Namelist is gone (Issue#64),
+        # remove this check in favor of f90nml.namelist.Namelist
+        if type(self.namelist is NdslNamelist):
+            return self.namelist.layout
+
+        # Assumption: namelist is f90nml.namelist.Namelist
+        grid_params = grid_params_from_f90nml(self.namelist)
+        return grid_params["layout"]
 
     def compute_sequential(self, inputs_list, communicator_list):
         """Compute the outputs while iterating over a set of communicator

--- a/ndsl/stencils/testing/parallel_translate.py
+++ b/ndsl/stencils/testing/parallel_translate.py
@@ -135,7 +135,7 @@ class ParallelTranslate:
     def layout(self):
         # TODO: Once ndsl.namelist.Namelist is gone (Issue#64),
         # remove this check in favor of f90nml.namelist.Namelist
-        if type(self.namelist is NdslNamelist):
+        if isinstance(self.namelist, NdslNamelist):
             return self.namelist.layout
 
         # Assumption: namelist is f90nml.namelist.Namelist

--- a/ndsl/utils.py
+++ b/ndsl/utils.py
@@ -161,7 +161,7 @@ def load_f90nml(namelist_path: Path) -> f90nml.Namelist:
 def load_f90nml_as_dict(
     namelist_path: Path,
     flatten: bool = True,
-    target_groups:list[str] | None = None,
+    target_groups: list[str] | None = None,
 ) -> dict:
     """Loads a Fortran namelist given its path and returns a
     dict representation. If target_groups are specified, then
@@ -183,7 +183,7 @@ def load_f90nml_as_dict(
 def f90nml_as_dict(
     nml: f90nml.Namelist,
     flatten: bool = True,
-    target_groups:list[str] | None = None,
+    target_groups: list[str] | None = None,
 ) -> dict:
     """Uses a f90nml.Namelist and returns a dict representation.
     If target_groups are specified, then the dict is created using only those

--- a/ndsl/utils.py
+++ b/ndsl/utils.py
@@ -119,6 +119,7 @@ def safe_mpi_allocate(
 # Helpers for loading and working with Fortran Namelists
 # TODO: Consider moving these to a separate utils/namelist.py
 
+
 DEFAULT_GRID_NML_GROUPS = ["fv_core_nml"]
 
 
@@ -146,6 +147,8 @@ def flatten_nml_to_dict(nml: f90nml.Namelist) -> dict:
     return flatter_namelist
 
 
+# TODO: Consider a more universal loader, e.g., load_config(path),
+#       rather than a f90nml-specific loader (See PR#246).
 def load_f90nml(namelist_path: Path) -> f90nml.Namelist:
     """Loads a Fortran namelist given its path and return a f90nml.Namelist
 
@@ -158,7 +161,7 @@ def load_f90nml(namelist_path: Path) -> f90nml.Namelist:
 def load_f90nml_as_dict(
     namelist_path: Path,
     flatten: bool = True,
-    target_groups=None,
+    target_groups=list[str] | None,
 ) -> dict:
     """Loads a Fortran namelist given its path and returns a
     dict representation. If target_groups are specified, then
@@ -180,7 +183,7 @@ def load_f90nml_as_dict(
 def f90nml_as_dict(
     nml: f90nml.Namelist,
     flatten: bool = True,
-    target_groups=None,
+    target_groups=list[str] | None,
 ) -> dict:
     """Uses a f90nml.Namelist and returns a dict representation.
     If target_groups are specified, then the dict is created using only those
@@ -188,7 +191,7 @@ def f90nml_as_dict(
     information or keep the group information.
 
     Args:
-        namelist_path: Path to the Fortran namelist file
+        nml: f90nml.Namelist
         flatten: If True, flattens the loaded namelist (without groups) before
                  returning it. (Default: True) Otherwise, it returns the f90nml.Namelist
                  dict representation.
@@ -199,7 +202,7 @@ def f90nml_as_dict(
     if target_groups is not None:
         extracted_groups = f90nml.Namelist()
         for group in target_groups:
-            if group in nml:
+            if group in nml.keys():
                 extracted_groups[group] = nml[group]
     else:
         extracted_groups = nml
@@ -209,5 +212,15 @@ def f90nml_as_dict(
     return extracted_groups.todict()
 
 
-def grid_params_from_f90nml(nml):
+def grid_params_from_f90nml(nml: f90nml.Namelist) -> dict:
+    """Uses a f90nml.Namelist and returns a dict representation
+    of parameters useful for grid generation. The return dict
+    will be flattened with key-value pairs from the nml's
+    DEFAULT_GRID_NML_GROUPS.
+
+    Args:
+        nml: f90nml.Namelist
+    """
+    # TODO: Consider returning a {Cartesian,CubeSphere}GridParameters class
+    #       rather than a dict (See PR#246).
     return f90nml_as_dict(nml, flatten=True, target_groups=DEFAULT_GRID_NML_GROUPS)

--- a/ndsl/utils.py
+++ b/ndsl/utils.py
@@ -161,7 +161,7 @@ def load_f90nml(namelist_path: Path) -> f90nml.Namelist:
 def load_f90nml_as_dict(
     namelist_path: Path,
     flatten: bool = True,
-    target_groups=list[str] | None,
+    target_groups:list[str] | None = None,
 ) -> dict:
     """Loads a Fortran namelist given its path and returns a
     dict representation. If target_groups are specified, then
@@ -183,7 +183,7 @@ def load_f90nml_as_dict(
 def f90nml_as_dict(
     nml: f90nml.Namelist,
     flatten: bool = True,
-    target_groups=list[str] | None,
+    target_groups:list[str] | None = None,
 ) -> dict:
     """Uses a f90nml.Namelist and returns a dict representation.
     If target_groups are specified, then the dict is created using only those

--- a/ndsl/utils.py
+++ b/ndsl/utils.py
@@ -1,4 +1,5 @@
 from enum import EnumMeta
+from pathlib import Path
 from typing import Iterable, Sequence, Tuple, TypeVar, Union
 
 import f90nml
@@ -145,7 +146,7 @@ def flatten_nml_to_dict(nml: f90nml.Namelist) -> dict:
     return flatter_namelist
 
 
-def load_f90nml(namelist_path: str) -> f90nml.Namelist:
+def load_f90nml(namelist_path: Path) -> f90nml.Namelist:
     """Loads a Fortran namelist given its path and return a f90nml.Namelist
 
     Args:
@@ -155,7 +156,7 @@ def load_f90nml(namelist_path: str) -> f90nml.Namelist:
 
 
 def load_f90nml_as_dict(
-    namelist_path: str,
+    namelist_path: Path,
     flatten: bool = True,
     target_groups=None,
 ) -> dict:

--- a/ndsl/utils.py
+++ b/ndsl/utils.py
@@ -1,6 +1,7 @@
 from enum import EnumMeta
 from typing import Iterable, Sequence, Tuple, TypeVar, Union
 
+import f90nml
 import numpy as np
 
 import ndsl.constants as constants
@@ -111,3 +112,101 @@ def safe_mpi_allocate(
         if __debug__ and cp and isinstance(array, cp.ndarray):
             raise RuntimeError("cupy allocation might not be MPI-safe")
     return array
+
+
+########################################################
+# Helpers for loading and working with Fortran Namelists
+# TODO: Consider moving these to a separate utils/namelist.py
+
+DEFAULT_GRID_NML_GROUPS = ["fv_core_nml"]
+
+
+def flatten_nml_to_dict(nml: f90nml.Namelist) -> dict:
+    """Returns a flattened dict version of a f90nml.namelist.Namelist
+
+    Args:
+        nml: f90nml.Namelist
+    """
+    nml_dict = dict(nml)
+    for name, value in nml_dict.items():
+        if isinstance(value, f90nml.Namelist):
+            nml_dict[name] = flatten_nml_to_dict(value)
+    flatter_namelist = {}
+    for key, value in nml_dict.items():
+        if isinstance(value, dict):
+            for subkey, subvalue in value.items():
+                if subkey in flatter_namelist:
+                    raise ValueError(
+                        "Cannot flatten this namelist, duplicate keys: " + subkey
+                    )
+                flatter_namelist[subkey] = subvalue
+        else:
+            flatter_namelist[key] = value
+    return flatter_namelist
+
+
+def load_f90nml(namelist_path: str) -> f90nml.Namelist:
+    """Loads a Fortran namelist given its path and return a f90nml.Namelist
+
+    Args:
+        namelist_path: Path to the Fortran namelist file
+    """
+    return f90nml.read(namelist_path)
+
+
+def load_f90nml_as_dict(
+    namelist_path: str,
+    flatten: bool = True,
+    target_groups=None,
+) -> dict:
+    """Loads a Fortran namelist given its path and returns a
+    dict representation. If target_groups are specified, then
+    the dict is created using only those groups.
+
+    Args:
+        namelist_path: Path to the Fortran namelist file
+        flatten: If True, flattens the loaded namelist (without groups) before
+                 returning it. (Default: True) Otherwise, it returns the f90nml.Namelist
+                 dict representation.
+        target_groups: If 'None' is specified, then all groups are
+                       considered. (Default: None) Otherwise, only parameters
+                       from the specified groups are considered.
+    """
+    nml = load_f90nml(namelist_path)
+    return f90nml_as_dict(nml, flatten=flatten, target_groups=target_groups)
+
+
+def f90nml_as_dict(
+    nml: f90nml.Namelist,
+    flatten: bool = True,
+    target_groups=None,
+) -> dict:
+    """Uses a f90nml.Namelist and returns a dict representation.
+    If target_groups are specified, then the dict is created using only those
+    groups. The return dicts can be flattened further to remove the group
+    information or keep the group information.
+
+    Args:
+        namelist_path: Path to the Fortran namelist file
+        flatten: If True, flattens the loaded namelist (without groups) before
+                 returning it. (Default: True) Otherwise, it returns the f90nml.Namelist
+                 dict representation.
+        target_groups: If 'None' is specified, then all groups are
+                       considered. (Default: None) Otherwise, only parameters
+                       from the specified groups are considered.
+    """
+    if target_groups is not None:
+        extracted_groups = f90nml.Namelist()
+        for group in target_groups:
+            if group in nml:
+                extracted_groups[group] = nml[group]
+    else:
+        extracted_groups = nml
+
+    if flatten:
+        return flatten_nml_to_dict(extracted_groups)
+    return extracted_groups.todict()
+
+
+def grid_params_from_f90nml(nml):
+    return f90nml_as_dict(nml, flatten=True, target_groups=DEFAULT_GRID_NML_GROUPS)


### PR DESCRIPTION
# Description

Partial work addressing issue #64  

Adding helper functions for loading `f90nml.Namelist` from file and converting to dict.

There is a slight complication with the translate tests. We need to be able to turn on and off the usage of `ndsl.Namelists`. So, I'm proposing a new temporary flag `--no_legacy_namelist` in `conftest.py` to toggle between two options in the tests:
  1. Use only f90nml.Namelist (Long-term desired goal) within the translate tests
  2. Continue using f90nml.Namelist and the soon-to-be legacy ndsl.Namelist (Interim solution to facilitate checking in changes one submodule at a time)

Also, I'm modifying ParallelTranslate's layout() to rely more on f90nml.Namelist or ndsl.Namelist temporarily as we work on this issue.

These changes will facilitate the eventual removal of ndsl.Namelist in PyFV3 and PySHiELD in subsequent PRs.

Fixes #64 (partially)

## How has this been tested?
Existing unit tests still pass and translate tests pass as expected when compared to the develop branch.

(I have also a proposed set of changes in [PyFV3](https://github.com/jjuyeonkim/PyFV3/tree/20250925_namelist_helper) that use these modifications to get rid of ndsl.Namelist, where the tests all pass as expected. I can hopefully put together a PR relatively quickly if this PR's changes look good.)

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
