### PR TITLE
ci|docs: automatic docs deployment when merging into develop

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -1,0 +1,35 @@
+name: "NDSL documentation"
+
+# Documentation gets automatically deployed upon merge to develop
+on:
+  push:
+    branches:
+      - develop
+
+# Security: Restrict permissions of this workflow to whats needed.
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: pip install mkdocs-material mkdocstrings[python]
+
+      - name: Deploy docs to GitHub Pages
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
# Description

This PR adds the automatic deployment of documentation from the `docs/` folder to https://noaa-gfdl.github.io/NDSL with every merge into develop.

@fmalatino: we might need configuration changes (in the repo settings) for this to work. It should be the same as for PyFV3, where we already automatically deploy docs to https://noaa-gfdl.github.io/PyFV3/.

@FlorianDeconinck this will deploy the whole contents of `docs/`, not just the docstrings. I remember a discussion to bring some of the contents from SMT (e.g. [the tutorials](https://geos-esm.github.io/SMT-Nebulae/tutorials/)) over here before we publish docs. Should we do a pass at the `docs/` folder first, before we deploy docs?

## How has this been tested?

With #268 merged, we at know that the docs will build. The deployment is untested. However, it's a standard building block and I just copied the workflow from PyFV3 where it already works. If anything fails, then it's likely a configuration issue (and I don't have access rights to check if anything needs to be configured or if things are okay).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
  N/A
