### PR TITLE
[Translate] Allow slicing of N-Dimensions fields

### DIFF
--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -3,6 +3,7 @@ from functools import wraps
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 from gt4py import storage as gt_storage
 from gt4py.cartesian import backend as gt_backend
 
@@ -10,10 +11,6 @@ from ndsl.constants import N_HALO_DEFAULT
 from ndsl.dsl.typing import DTypes, Float
 from ndsl.logging import ndsl_log
 from ndsl.optional_imports import cupy as cp
-
-
-if cp is None:
-    import numpy as cp
 
 
 # If True, automatically transfers memory between CPU and GPU (see gt4py.storage)
@@ -84,7 +81,7 @@ def _translate_origin(origin: Sequence[int], mask: tuple[bool, ...]) -> Sequence
 
 
 def make_storage_data(
-    data: np.ndarray | cp.ndarray,
+    data: npt.NDArray,
     shape: tuple[int, ...] | None = None,
     origin: tuple[int, ...] = origin,
     *,
@@ -96,7 +93,7 @@ def make_storage_data(
     axis: int = 2,
     max_dim: int = 3,
     read_only: bool = True,
-) -> np.ndarray | cp.ndarray:
+) -> npt.NDArray:
     """Create a new gt4py storage from the given data.
 
     Args:
@@ -201,7 +198,7 @@ def make_storage_data(
 
 
 def _make_storage_data_1d(
-    data: np.ndarray | cp.ndarray,
+    data: npt.NDArray,
     shape: tuple[int, ...],
     start: tuple[int, ...] = (0, 0, 0),
     dummy: tuple[int, ...] | None = None,
@@ -210,7 +207,7 @@ def _make_storage_data_1d(
     *,
     dtype: DTypes = Float,
     backend: str,
-) -> np.ndarray | cp.ndarray:
+) -> npt.NDArray:
     # axis refers to a repeated axis, dummy refers to a singleton axis
     axis = min(axis, len(shape) - 1)
     buffer = zeros(shape[axis], dtype=dtype, backend=backend)
@@ -238,7 +235,7 @@ def _make_storage_data_1d(
 
 
 def _make_storage_data_2d(
-    data: np.ndarray | cp.ndarray,
+    data: npt.NDArray,
     shape: tuple[int, ...],
     start: tuple[int, ...] = (0, 0, 0),
     dummy: tuple[int, ...] | None = None,
@@ -247,7 +244,7 @@ def _make_storage_data_2d(
     *,
     dtype: DTypes = Float,
     backend: str,
-) -> np.ndarray | cp.ndarray:
+) -> npt.NDArray:
     # axis refers to which axis should be repeated (when making a full 3d data),
     # dummy refers to a singleton axis
     do_reshape = dummy or axis != 2
@@ -275,13 +272,13 @@ def _make_storage_data_2d(
 
 
 def _make_storage_data_3d(
-    data: np.ndarray | cp.ndarray,
+    data: npt.NDArray,
     shape: tuple[int, ...],
     start: tuple[int, ...] = (0, 0, 0),
     *,
     dtype: DTypes = Float,
     backend: str,
-) -> np.ndarray | cp.ndarray:
+) -> npt.NDArray:
     istart, jstart, kstart = start
     isize, jsize, ksize = data.shape
     buffer = zeros(shape, dtype=dtype, backend=backend)
@@ -294,13 +291,13 @@ def _make_storage_data_3d(
 
 
 def _make_storage_data_Nd(
-    data: np.ndarray | cp.ndarray,
+    data: npt.NDArray,
     shape: tuple[int, ...],
     start: tuple[int, ...] | None = None,
     *,
     dtype: DTypes = Float,
     backend: str,
-) -> np.ndarray | cp.ndarray:
+) -> npt.NDArray:
     if start is None:
         start = tuple([0] * data.ndim)
     buffer = zeros(shape, dtype=dtype, backend=backend)
@@ -316,7 +313,7 @@ def make_storage_from_shape(
     backend: str,
     dtype: DTypes = Float,
     mask: tuple[bool, ...] | None = None,
-) -> np.ndarray | cp.ndarray:
+) -> npt.NDArray:
     """Create a new gt4py storage of a given shape filled with zeros.
 
     Args:
@@ -353,7 +350,7 @@ def make_storage_from_shape(
 
 
 def make_storage_dict(
-    data: np.ndarray | cp.ndarray,
+    data: npt.NDArray,
     shape: tuple[int, ...] | None = None,
     origin: tuple[int, ...] = origin,
     start: tuple[int, ...] = (0, 0, 0),
@@ -363,11 +360,11 @@ def make_storage_dict(
     *,
     backend: str,
     dtype: DTypes = Float,
-) -> dict[str, np.ndarray | cp.ndarray]:
+) -> dict[str, npt.NDArray]:
     assert names is not None, "for 4d variable storages, specify a list of names"
     if shape is None:
         shape = data.shape
-    data_dict: dict[str, np.ndarray | cp.ndarray] = dict()
+    data_dict: dict[str, npt.NDArray] = dict()
     for i in range(data.shape[3]):
         data_dict[names[i]] = make_storage_data(
             squeeze(data[:, :, :, i]),

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl.dsl.stencil import StencilFactory
@@ -10,9 +11,6 @@ from ndsl.quantity import Quantity
 from ndsl.stencils.testing.grid import Grid  # type: ignore
 from ndsl.stencils.testing.savepoint import DataLoader
 
-
-if cp is None:
-    import numpy as cp
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +135,7 @@ class TranslateFortranData2Py:
         names_4d: list[str] | None = None,
         read_only: bool = False,
         full_shape: bool = False,
-    ) -> np.ndarray | cp.ndarray:
+    ) -> dict[str, npt.NDArray] | npt.NDArray:
         """Copy input data into a gt4py.storage with given shape.
 
         `array` is copied. Takes care of the device upload if necessary.


### PR DESCRIPTION
# Description

We introduce a proper split between cartesian and data dimensions for slicing of N dimensions field in the input marshaling of translate data.

This completes the support for N dimensional inputs/outputs in the translate test.

+ Better type hints

## How has this been tested?

This doesn't touch the original behavior of "tracers as dictionary" which was the way to do 4D fields. This new feature is tested locally on the GEOS v11 version of dynamics.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
