### PR TITLE
Add versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools >= 77.0.3", "setuptools-scm>=8"]
+requires = ["setuptools >= 80", "setuptools-scm>=8"]
 
 [project]
 authors = [{name = "NOAA/NASA"}]


### PR DESCRIPTION
# Description

We discussed the need for versioning of the codebase before the next release. This PR adds a solution that works off git tags to determine the version of the code.

This PR leverages `setuptools-scm` to read the tag and sets up the versioning accordingly. The version can be fetched in-code using 
```python
from importlib.metadata import version
print(version('ndsl'))
```


## How has this been tested?

Created a tag on the local fork and ran the code above.
Additionally tried to build the repo locally (`$ python -m build`) and seeing what `.whl` (appended with what version) lands in `dist`

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
