### PR TITLE
Deprecate usage of ndsl.Namelist

### DIFF
--- a/ndsl/namelist.py
+++ b/ndsl/namelist.py
@@ -1,4 +1,5 @@
 import dataclasses
+import warnings
 from typing import Any, Self
 
 import f90nml
@@ -616,6 +617,15 @@ class Namelist:
             if key in cls.__dataclass_fields__
         }
         return cls(**namelist_dict)
+
+    def __post_init__(self) -> None:
+        warnings.warn(
+            "Usage of `ndsl.Namelist` is discouraged. The class will be "
+            "removed in the next version together with `NamelistDefaults`, see "
+            "https://github.com/NOAA-GFDL/NDSL/issues/64.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
 
 def namelist_to_flatish_dict(nml_input: Any) -> dict:

--- a/tests/test_namelist.py
+++ b/tests/test_namelist.py
@@ -1,0 +1,8 @@
+import pytest
+
+from ndsl import Namelist
+
+
+def test_ndsl_namelist_deprecation() -> None:
+    with pytest.deprecated_call():
+        my_namelist = Namelist()


### PR DESCRIPTION
# Description

This PR deprecates usage of `ndsl.Namelist`. I also tried to deprecate `ndsl.NamelistDefaults` but since we don't use it as a class (i.e. it's not a dataclass and we just have it as class to group things), there's no static constructor to (easily) intercept.

Context for the deprecation is issue #64 and @jjuyeonkim continued work in pyFV3, pySHiELD, and pace to get rid of the class. If we deprecate now (before the "M2 release"), we can remove the class as soon as it is not needed anymore in any of the downstream repositories.

## How has this been tested?

New unit test checking for the deprecation message.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
  N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
  N/A
- [ ] My changes generate no new warnings
  No, but that's the point here.
- [ ] Any dependent changes have been merged and published in downstream modules
  N/A
- [x] New check tests, if applicable, are included
