### PR TITLE
ci: create cache for translate test data

### DIFF
--- a/.github/workflows/create-cache.yaml
+++ b/.github/workflows/create-cache.yaml
@@ -47,5 +47,6 @@ jobs:
   pyFV3_test_data:
     uses: NOAA-GFDL/pyFV3/.github/workflows/create_cache.yml@develop
 
+  # GitHub Actions cache of pySHiELD test data
   pySHiELD_test_data:
     uses: NOAA-GFDL/pySHiELD/.github/workflows/create_cache.yml@develop


### PR DESCRIPTION
# Description

Recent (planned) downtime of NCCS portal showed a whole in our translate test data caching strategy. When we run pyFV3 or pySHiELD tests as re-usable workflow in e.g. NDSL tests, we don't cache the translate test data. This PR suggests to change that. The PR depends on

- https://github.com/NOAA-GFDL/PySHiELD/pull/69
- https://github.com/NOAA-GFDL/PyFV3/pull/91

to provide re-usable workflows for translate test data caching.

## How has this been tested?

Tested on my fork, e.g. https://github.com/romanc/NDSL/pull/5.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
  See dependencies above
- [ ] New check tests, if applicable, are included: N/A
