### PR TITLE
ci: specialize concurrency group per repo

### DIFF
--- a/.github/workflows/create-cache.yaml
+++ b/.github/workflows/create-cache.yaml
@@ -45,8 +45,8 @@ jobs:
 
   # GitHub Actions cache of pyFV3 test data
   pyFV3_test_data:
-    uses: NOAA-GFDL/pyFV3/.github/workflows/create_cache.yml@develop
+    uses: NOAA-GFDL/pyFV3/.github/workflows/create_cache.yaml@develop
 
   # GitHub Actions cache of pySHiELD test data
   pySHiELD_test_data:
-    uses: NOAA-GFDL/pySHiELD/.github/workflows/create_cache.yml@develop
+    uses: NOAA-GFDL/pySHiELD/.github/workflows/create_cache.yaml@develop


### PR DESCRIPTION
# Description

Quick follow-up from #91: specialize concurrency group per repository. Otherwise, we'll have deadlocks for concurrency groups and the cache won't be built:

<img width="2452" height="1367" alt="image" src="https://github.com/user-attachments/assets/ebc15e3e-37a1-4e06-ba6b-594aeb1b4ec1" />

Link to the above [workflow](https://github.com/NOAA-GFDL/NDSL/actions/runs/18853870614).

Note: using `${{ github.repository }}` sounds like a good idea. In practice, that doesn't play nice when the workflow is called from another repository because in that case, `github.repository` resolves to the calling repository.

Related PRs:

- https://github.com/NOAA-GFDL/PySHiELD/pull/70
- https://github.com/NOAA-GFDL/PyFV3/pull/93

## How has this been tested?

By staring at the code. I'll verify post-merge that this works as expected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
