### PR TITLE
fix: allow any Comm object in ZarrMonitor

### DIFF
--- a/ndsl/comm/__init__.py
+++ b/ndsl/comm/__init__.py
@@ -5,7 +5,7 @@ from .caching_comm import (
     CachingRequestReader,
     CachingRequestWriter,
 )
-from .comm_abc import Comm, Request
+from .comm_abc import Comm, ReductionOperator, Request
 
 
 __all__ = [
@@ -15,5 +15,6 @@ __all__ = [
     "CachingRequestReader",
     "CachingRequestWriter",
     "Comm",
+    "ReductionOperator",
     "Request",
 ]

--- a/ndsl/monitor/zarr_monitor.py
+++ b/ndsl/monitor/zarr_monitor.py
@@ -7,6 +7,7 @@ import cftime
 import xarray as xr
 
 import ndsl.constants as constants
+from ndsl.comm import Comm, ReductionOperator, Request
 from ndsl.comm.partitioner import Partitioner, subtile_slice
 from ndsl.logging import ndsl_log
 from ndsl.monitor.convert import to_numpy
@@ -19,14 +20,16 @@ __all__ = ["ZarrMonitor"]
 T = TypeVar("T")
 
 
-class DummyComm:
+class DummyComm(Comm[T]):
+    """Dummy comm object that works in single-core mode."""
+
     def Get_rank(self) -> int:
         return 0
 
     def Get_size(self) -> int:
         return 1
 
-    def bcast(self, value: T, root: int = 0) -> T:
+    def bcast(self, value: T | None, root: int = 0) -> T | None:
         assert root == 0, (
             "DummyComm should only be used on a single core, "
             "so root should only ever be 0"
@@ -35,6 +38,47 @@ class DummyComm:
 
     def barrier(self) -> None:
         return
+
+    def Barrier(self) -> None:
+        raise NotImplementedError("DummyComm.Barrier")
+
+    def Scatter(self, sendbuf, recvbuf, root: int = 0, **kwargs: dict):  # type: ignore[no-untyped-def]
+        raise NotImplementedError("DummyComm.Scatter")
+
+    def Gather(self, sendbuf, recvbuf, root: int = 0, **kwargs: dict):  # type: ignore[no-untyped-def]
+        raise NotImplementedError("DummyComm.Gather")
+
+    def allgather(self, sendobj: T) -> list[T]:
+        raise NotImplementedError("DummyComm.allgather")
+
+    def Send(self, sendbuf, dest, tag: int = 0, **kwargs: dict):  # type: ignore[no-untyped-def]
+        raise NotImplementedError("DummyComm.Send")
+
+    def sendrecv(self, sendbuf, dest, **kwargs: dict):  # type: ignore[no-untyped-def]
+        raise NotImplementedError("DummyComm.sendrcv")
+
+    def Isend(self, sendbuf, dest, tag: int = 0, **kwargs: dict) -> Request:  # type: ignore[no-untyped-def]
+        raise NotImplementedError("DummyComm.Isend")
+
+    def Recv(self, recvbuf, source, tag: int = 0, **kwargs: dict):  # type: ignore[no-untyped-def]
+        raise NotImplementedError("DummyComm.Recv")
+
+    def Irecv(self, recvbuf, source, tag: int = 0, **kwargs: dict) -> Request:  # type: ignore[no-untyped-def]
+        raise NotImplementedError("DummyComm.Irecv")
+
+    def Split(self, color, key) -> DummyComm:  # type: ignore[no-untyped-def]
+        raise NotImplementedError("DummyComm.Split")
+
+    def allreduce(
+        self, sendobj: T, op: ReductionOperator = ReductionOperator.NO_OP
+    ) -> T:
+        raise NotImplementedError("DummyComm.allreduce")
+
+    def Allreduce(self, sendobj: T, recvobj: T, op: ReductionOperator) -> T:
+        raise NotImplementedError("DummyComm.Allreduce")
+
+    def Allreduce_inplace(self, obj: T, op: ReductionOperator) -> T:
+        raise NotImplementedError("DummyComm.Allreduce_inplace")
 
 
 class ZarrMonitor:
@@ -47,7 +91,7 @@ class ZarrMonitor:
         store: str | zarr.storage.MutableMapping,
         partitioner: Partitioner,
         mode: str = "w",
-        mpi_comm: DummyComm | None = None,
+        mpi_comm: Comm | None = None,
     ) -> None:
         """Create a ZarrMonitor.
 


### PR DESCRIPTION
# Description

This PR is fallout from adding types in PR #257 and #258. The `ZarrMonitor` provides a `DummyComm` which is instantiated in case no `Comm` object is given. The type of the `Comm` object in `ZarrMonitor` was wrongly limited to that `DummyComm`, which only broke when we attempted to update the submodule in `pace`.

This PR is what @jjuyeonkim proposed in https://github.com/NOAA-GFDL/NDSL/pull/290#discussion_r2471167863. 

## How has this been tested?

Tested locally by updating NDSL in pace and running `pre-commit`. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included
  No new checks added because the `ZarrMonitor` is a bit in limbo, see https://github.com/NOAA-GFDL/NDSL/issues/157. There aren't any `ZarrMonitor` tests now and adding one would mean to add `zarr` as a test dependency, which I think isn't justified just to add two simple tests that would check usage with `DummyComm` and with a regular `Comm` object. 
