### PR TITLE
BREAKING CHANGE: removal of extra_dim_lengths

### DIFF
--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -47,18 +47,6 @@ class QuantityFactory:
 
         self._allocator = _Allocator(self.backend)
 
-    def set_extra_dim_lengths(self, **kwargs: Any) -> None:
-        """
-        Set the length of extra (non-x/y/z) dimensions.
-        """
-        warnings.warn(
-            "`QuantityFactory.set_extra_dim_lengths` is deprecated. "
-            "Use `add_data_dimensions` or `update_data_dimensions`.",
-            DeprecationWarning,
-            2,
-        )
-        self.sizer.data_dimensions.update(kwargs)
-
     def update_data_dimensions(
         self,
         data_dimension_descriptions: dict[str, int],

--- a/ndsl/initialization/grid_sizer.py
+++ b/ndsl/initialization/grid_sizer.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -15,15 +14,6 @@ class GridSizer:
     """Number of horizontal halo points for produced arrays."""
     data_dimensions: dict[str, int]
     """Name/Lengths pair of any non-x/y/z dimensions, such as land or radiation dimensions."""
-
-    @property
-    def extra_dim_lengths(self) -> dict[str, int]:
-        warnings.warn(
-            "`GridSizer.extra_dim_lengths` is a deprecated API, use `GridSizer.data_dimensions`.",
-            DeprecationWarning,
-            2,
-        )
-        return self.data_dimensions
 
     def get_origin(self, dims: Sequence[str]) -> tuple[int, ...]:
         raise NotImplementedError()


### PR DESCRIPTION
# Description

`extra_dim_lengths` on the `GridSizer` was replaced by `data_dimensions` in the `2025.10.00` release. Now that the release is out, let's clean up and remove the deprecated API. This also includes `set_extra_dim_lengths()` in the `QuantityFactory`.

## How has this been tested?

I've checked usage in upstream repos and now that https://github.com/NOAA-GFDL/PySHiELD/pull/71 is merged, it should be safe to merge. CI will tell us if not.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
