### PR TITLE
Remove ndsl.Namelist

### DIFF
--- a/.github/workflows/create-cache.yaml
+++ b/.github/workflows/create-cache.yaml
@@ -14,7 +14,7 @@ on:
 
 # Cancel running jobs if there's a newer push
 concurrency:
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  group: ndsl-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -45,8 +45,8 @@ jobs:
 
   # GitHub Actions cache of pyFV3 test data
   pyFV3_test_data:
-    uses: NOAA-GFDL/pyFV3/.github/workflows/create_cache.yml@develop
+    uses: NOAA-GFDL/pyFV3/.github/workflows/create_cache.yaml@develop
 
   # GitHub Actions cache of pySHiELD test data
   pySHiELD_test_data:
-    uses: NOAA-GFDL/pySHiELD/.github/workflows/create_cache.yml@develop
+    uses: NOAA-GFDL/pySHiELD/.github/workflows/create_cache.yaml@develop

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -12,13 +12,13 @@ NDSL tries to have sensible defaults. In cases you want tweak something, here ar
 
 ### Literal precision (float/int)
 
-Unspecified integer and floating point literals (e.g. `42` and `3.1415`) default to 64-bit precision. This can be changed with the environment variable `PACE_FLOAT_PRECISION`.
+Unspecified integer and floating point literals (e.g. `42` and `3.1415`) default to 64-bit precision. This can be changed with the environment variable `NDSL_LITERAL_PRECISION`.
 
 For mixed precision code, you can specify the "hard coded" precision with type hints and casts, e.g.
 
 ```python
 with computation(PARALLEL), interval(...):
-    # Either 32-bit or 64-bit depending on `PACE_FLOAT_PRECISION`
+    # Either 32-bit or 64-bit depending on `NDSL_LITERAL_PRECISION`
     my_int = 42
     my_float = 3.1415
 

--- a/ndsl/constants.py
+++ b/ndsl/constants.py
@@ -20,14 +20,7 @@ class ConstantVersions(Enum):
 def _get_constant_version(
     default: Literal["GFDL", "UFS", "GEOS"] = "UFS",
 ) -> Literal["GFDL", "UFS", "GEOS"]:
-    if os.getenv("PACE_CONSTANTS", ""):
-        ndsl_log.warning("PACE_CONSTANTS is deprecated. Use NDSL_CONSTANTS instead.")
-        if os.getenv("NDSL_CONSTANTS", ""):
-            ndsl_log.warning(
-                "PACE_CONSTANTS and NDSL_CONSTANTS were both specified. NDSL_CONSTANTS will take precedence."
-            )
-
-    constants_as_str = os.getenv("NDSL_CONSTANTS", os.getenv("PACE_CONSTANTS", default))
+    constants_as_str = os.getenv("NDSL_CONSTANTS", default)
     expected: list[Literal["GFDL", "UFS", "GEOS"]] = ["GFDL", "UFS", "GEOS"]
 
     if constants_as_str not in expected:

--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -17,18 +17,7 @@ if gt4py_config_module in sys.modules:
 
 
 def _get_literal_precision(default: Literal["32", "64"] = "64") -> Literal["32", "64"]:
-    if os.getenv("PACE_FLOAT_PRECISION", ""):
-        ndsl_log.warning(
-            "PACE_FLOAT_PRECISION is deprecated. Use NDSL_LITERAL_PRECISION instead."
-        )
-        if os.getenv("NDSL_LITERAL_PRECISION", ""):
-            ndsl_log.warning(
-                "PACE_FLOAT_PRECISION and NDSL_LOGLEVEL were both specified. NDSL_LITERAL_PRECISION will take precedence."
-            )
-
-    precision = os.getenv(
-        "NDSL_LITERAL_PRECISION", os.getenv("PACE_FLOAT_PRECISION", default)
-    )
+    precision = os.getenv("NDSL_LITERAL_PRECISION", default)
 
     expected: list[Literal["32", "64"]] = ["32", "64"]
     if precision in expected:

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -15,7 +15,6 @@ from ndsl.dsl.caches.cache_location import identify_code_path
 from ndsl.dsl.caches.codepath import FV3CodePath
 from ndsl.dsl.gt4py_utils import is_gpu_backend
 from ndsl.dsl.typing import get_precision
-from ndsl.logging import ndsl_log
 from ndsl.optional_imports import cupy as cp
 from ndsl.performance.collector import NullPerformanceCollector, PerformanceCollector
 
@@ -31,14 +30,7 @@ def _debug_dace_orchestration() -> bool:
     Debugging Dace orchestration deeper can be done by turning on `syncdebug`.
     We control this Dace configuration below with our own override.
     """
-    if os.getenv("PACE_DACE_DEBUG", ""):
-        ndsl_log.warning("PACE_DACE_DEBUG is deprecated. Use NDSL_DACE_DEBUG instead.")
-        if os.getenv("NDSL_DACE_DEBUG", ""):
-            ndsl_log.warning(
-                "PACE_DACE_DEBUG and NDSL_DACE_DEBUG were both specified. NDSL_DACE_DEBUG will take precedence."
-            )
-
-    return os.getenv("NDSL_DACE_DEBUG", os.getenv("PACE_DACE_DEBUG", "False")) == "True"
+    return os.getenv("NDSL_DACE_DEBUG", "False") == "True"
 
 
 def _is_corner(rank: int, partitioner: Partitioner) -> bool:

--- a/ndsl/logging.py
+++ b/ndsl/logging.py
@@ -20,14 +20,7 @@ AVAILABLE_LOG_LEVELS = {
 
 
 def _get_log_level(default: str = "info") -> str:
-    if os.getenv("PACE_LOGLEVEL", ""):
-        logging.warning("PACE_LOGLEVEL is deprecated. Use NDSL_LOGLEVEL instead.")
-        if os.getenv("NDSL_LOGLEVEL", ""):
-            logging.warning(
-                "PACE_LOGLEVEL and NDSL_LOGLEVEL were both specified. NDSL_LOGLEVEL will take precedence."
-            )
-
-    loglevel = os.getenv("NDSL_LOGLEVEL", os.getenv("PACE_LOGLEVEL", default)).lower()
+    loglevel = os.getenv("NDSL_LOGLEVEL", default).lower()
 
     if loglevel in AVAILABLE_LOG_LEVELS.keys():
         return loglevel


### PR DESCRIPTION
# Description

This PR removes `ndsl.Namelist` and `ndsl.NamelistDefaults` as part of https://github.com/NOAA-GFDL/NDSL/issues/64

In `ndsl/stencils/testing/conftest.py`, the translate test flag `--no_legacy_namelist` no longer toggles anything. The functionality has been removed along with the `ndsl.Namelist`. The flag itself remains because the PySHiELD's and PyFV3's `translate.yaml` workflows still use it.  Once the flags are removed from those submodules, we can finally remove the flag from here.

The `test_namelist.py` and `namelist.md` files have also been removed.

## How has this been tested?
Existing CI tests still pass

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
