### PR TITLE
refactor: make GridSizer an abstract base class

### DIFF
--- a/ndsl/initialization/grid_sizer.py
+++ b/ndsl/initialization/grid_sizer.py
@@ -1,9 +1,10 @@
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 
 
 @dataclass
-class GridSizer:
+class GridSizer(ABC):
     nx: int
     """Length of the x compute dimension for produced arrays."""
     ny: int
@@ -15,11 +16,11 @@ class GridSizer:
     data_dimensions: dict[str, int]
     """Name/Lengths pair of any non-x/y/z dimensions, such as land or radiation dimensions."""
 
-    def get_origin(self, dims: Sequence[str]) -> tuple[int, ...]:
-        raise NotImplementedError()
+    @abstractmethod
+    def get_origin(self, dims: Sequence[str]) -> tuple[int, ...]: ...
 
-    def get_extent(self, dims: Sequence[str]) -> tuple[int, ...]:
-        raise NotImplementedError()
+    @abstractmethod
+    def get_extent(self, dims: Sequence[str]) -> tuple[int, ...]: ...
 
-    def get_shape(self, dims: Sequence[str]) -> tuple[int, ...]:
-        raise NotImplementedError()
+    @abstractmethod
+    def get_shape(self, dims: Sequence[str]) -> tuple[int, ...]: ...


### PR DESCRIPTION
# Description

`GridSizer` is de-facto already a base class with abstract methods `get_origin()`, `get_extent()`, and `get_shape()`. This PR just formalizes that intent.

## How has this been tested?

All good as long as `mypy` is still happy and existing tests don't complain. I've checked upstream repos and found no usage of instantiating a `GridSizer` class.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
