### PR TITLE
refactor: remove leftover debug print statements

### DIFF
--- a/ndsl/dsl/ndsl_runtime.py
+++ b/ndsl/dsl/ndsl_runtime.py
@@ -75,7 +75,6 @@ class NDSLRuntime:
                 obj=self,
                 config=self._dace_config,
             )
-            print(type(self))
 
     def __getattribute__(self, name: str) -> Any:
         attr = super().__getattribute__(name)

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -240,7 +240,6 @@ def compare_ranks(comm: Comm, data: dict) -> Mapping[str, int]:
             other = comm.sendrecv(array, pair_rank)
             arr_diffs = np.sum(np.logical_and(~np.isnan(array), array != other))
             if arr_diffs > 0:
-                print(name, rank, pair_rank, array, other)
                 differences[name] = arr_diffs
     return differences
 

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -393,11 +393,6 @@ class Quantity:
 
     def plot_k_level(self, k_index: int = 0) -> None:
         field = self.data
-        print(
-            "Min and max values:",
-            field[:, :, k_index].min(),
-            field[:, :, k_index].max(),
-        )
         plt.xlabel("I")
         plt.ylabel("J")
 

--- a/tests/quantity/test_transpose.py
+++ b/tests/quantity/test_transpose.py
@@ -35,7 +35,6 @@ def quantity_data_input(initial_data, numpy, backend):
         array[:] = initial_data
     else:
         array = initial_data
-    print(type(array))
     return array
 
 

--- a/tests/stencils/test_stencils.py
+++ b/tests/stencils/test_stencils.py
@@ -81,7 +81,6 @@ def test_column_operations():
     min_index = quantity_factory.zeros([X_DIM, Y_DIM], "n/a")
 
     code = ColumnOperations(stencil_factory)
-    print("initalized the class")
     code(data, max_value, max_index, min_value, min_index)
 
     assert max_value.field[:] == np.max(data.field[:], axis=2)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -187,6 +187,5 @@ def test_new_args_gives_different_buffer(allocator, backend, first_args, second_
 @pytest.mark.parametrize("allocator, backend", [["ones", "cupy"]], indirect=True)
 def test_mpi_unsafe_allocator_exception(backend, allocator):
     BUFFER_CACHE.clear()
-    print(allocator)
     with pytest.raises(RuntimeError):
         Buffer.pop_from_cache(allocator, shape=(10, 10, 10), dtype=float)

--- a/tests/test_g2g_communication.py
+++ b/tests/test_g2g_communication.py
@@ -137,7 +137,6 @@ def test_halo_update_only_communicate_on_gpu(backend, gpu_communicators):
 
     # We expect no np calls and several cp calls
     global N_ZEROS_CALLS  # noqa: F824 global ... is unused
-    print(f"Results {N_ZEROS_CALLS}")
     assert N_ZEROS_CALLS[cp.zeros] > 0
     assert N_ZEROS_CALLS[np.zeros] == 0
 

--- a/tests/test_halo_data_transformer.py
+++ b/tests/test_halo_data_transformer.py
@@ -165,12 +165,11 @@ def quantity(dims, units, origin, extent, shape, dtype, gt4py_backend):
     """A list of quantities whose values are 42.42 in the computational domain and 1
     outside of it."""
     sz = _shape_length(shape)
-    print(f"{shape} {sz}")
     data = np.arange(0, sz, dtype=dtype).reshape(shape)
     if "gtc" not in gt4py_backend:
         # should also test code if gt4py_backend is unset
         gt4py_backend = None
-    quantity = Quantity(
+    return Quantity(
         data,
         dims=dims,
         units=units,
@@ -178,7 +177,6 @@ def quantity(dims, units, origin, extent, shape, dtype, gt4py_backend):
         extent=extent,
         gt4py_backend=gt4py_backend,
     )
-    return quantity
 
 
 @pytest.fixture(params=[-0, -1, -2, -3])


### PR DESCRIPTION
# Description

This PR just removes a bunch of leftover debug print statements from `ndsl/` and `tests/`.

## How has this been tested?

All good as long as existing tests are still green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
