### PR TITLE
[Orchestration/Build]: Flag to force single cache for orchestration 

### DIFF
--- a/ndsl/dsl/caches/cache_location.py
+++ b/ndsl/dsl/caches/cache_location.py
@@ -5,7 +5,20 @@ from ndsl.dsl.caches.codepath import FV3CodePath
 def identify_code_path(
     rank: int,
     partitioner: Partitioner,
+    single_code_path: bool,
 ) -> FV3CodePath:
+    """Determine which code path your rank will hit.
+
+    If single_code_path is True, single_code_path is True,
+    only one code path exists (case of doubly periodic grid).
+    If single_code_path is False, we are in the case of the
+    cube-sphere and we will look at our position on the tile."""
+
+    # Doubly-periodic or single tile grid
+    if single_code_path:
+        return FV3CodePath.All
+
+    # Cube-sphere
     if partitioner.layout == (1, 1):
         return FV3CodePath.All
     elif partitioner.layout[0] == 1 or partitioner.layout[1] == 1:


### PR DESCRIPTION
# Description

Introduce a `single_code_path` flag in the DaCeConfig that forces a single cache to be built. This is the case of the doubly-periodic or tile grid, which is the case of most column-physics. It allows a single rank to compile, which in the case of many ranks compiling (HPC) dimishes the ram & disk pressure.

## How has this been tested?

Tested in GEOS - this remains an "hidden" feature which should be superseeded by a better build/cache system for orchestation.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
