### PR TITLE
Deprecate `CopyCornersXY`

### DIFF
--- a/ndsl/stencils/corners.py
+++ b/ndsl/stencils/corners.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Sequence
 
 from gt4py.cartesian import gtscript
@@ -28,6 +29,13 @@ class CopyCornersXY:
             y_field: 3D gt4py storage to use for y-differenceable field
                 (x-differenceable field uses same memory as base field)
         """
+        warnings.warn(
+            "Usage of CopyCornersXY is deprecated and will be removed in the next release. "
+            "Use `CopyCornersX` and `CopyCornersY` in PyFV3 for a more future-proof "
+            "implementation of the corner code.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         grid_indexing = stencil_factory.grid_indexing
         origin, domain = grid_indexing.get_origin_domain(
             dims=dims, halos=(grid_indexing.n_halo, grid_indexing.n_halo)


### PR DESCRIPTION
# Description

`CopyCornersXY` are replaced with `CopyCornersX` and `CopyCornersY` in PyFV3. The class is currently unused and will be removed after the next release of NDSL. This is a follow up from discussions in #300.

The PR contains minor unrelated cleanups in `ndsl.stencils` test code.

## How has this been tested?

New unit test ensuring that we log the deprecation warning.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [ ] My changes generate no new warnings
  No, but that's kind of the point of deprecation warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
