### PR TITLE
refactor: remove `DummyComm` as alias to `LocalComm`

### DIFF
--- a/docs/docstrings/testing/dummy_comm.md
+++ b/docs/docstrings/testing/dummy_comm.md
@@ -1,3 +1,0 @@
-# dummy_comm
-
-::: testing.dummy_comm

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,6 @@ nav:
           - "tridiag": docstrings/stencils/tridiag.md
       - testing:
           - "comparison": docstrings/testing/comparison.md
-          - "dummy_comm": docstrings/testing/dummy_comm.md
           - "perturbation": docstrings/testing/perturbation.md
       - viz:
           - "cube_sphere": docstrings/viz/cube_sphere.md

--- a/ndsl/__init__.py
+++ b/ndsl/__init__.py
@@ -28,7 +28,6 @@ from .performance.profiler import NullProfiler, Profiler
 from .performance.report import Experiment, Report, TimeReport
 from .quantity import Local, Quantity, State
 from .quantity.field_bundle import FieldBundle, FieldBundleType  # Break circular import
-from .testing.dummy_comm import DummyComm
 from .types import Allocator
 from .utils import MetaEnumStr
 
@@ -79,7 +78,6 @@ __all__ = [
     "Quantity",
     "FieldBundle",
     "FieldBundleType",
-    "DummyComm",
     "Allocator",
     "MetaEnumStr",
     "State",

--- a/ndsl/testing/dummy_comm.py
+++ b/ndsl/testing/dummy_comm.py
@@ -1,1 +1,0 @@
-from ndsl.comm.local_comm import LocalComm as DummyComm  # noqa

--- a/tests/mpi/test_mpi_mock.py
+++ b/tests/mpi/test_mpi_mock.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from ndsl import DummyComm
+from ndsl import LocalComm
 from ndsl.buffer import recv_buffer
 from ndsl.comm.local_comm import ConcurrencyError
 from tests.mpi.mpi_comm import MPI
@@ -33,11 +33,11 @@ def send_recv(comm, numpy):
     data = numpy.asarray([rank], dtype=numpy.int32)
 
     if rank < size - 1:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"sending data from {rank} to {rank + 1}")
         comm.Send(data, dest=rank + 1)
     if rank > 0:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"receiving data from {rank - 1} to {rank}")
         comm.Recv(data, source=rank - 1)
     return data
@@ -50,11 +50,11 @@ def send_recv_big_data(comm, numpy):
     data = numpy.ones([5, 3, 96], dtype=numpy.float64) * rank
 
     if rank < size - 1:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"sending data from {rank} to {rank + 1}")
         comm.Send(data, dest=rank + 1)
     if rank > 0:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"receiving data from {rank - 1} to {rank}")
         comm.Recv(data, source=rank - 1)
     return data
@@ -96,11 +96,11 @@ def send_f_contiguous_buffer(comm, numpy):
     data = numpy.random.uniform(size=[2, 3]).T
 
     if rank < size - 1:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"sending data from {rank} to {rank + 1}")
         comm.Send(data, dest=rank + 1)
     if rank > 0:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"receiving data from {rank - 1} to {rank}")
         comm.Recv(data, source=rank - 1)
     return data
@@ -115,7 +115,7 @@ def send_non_contiguous_buffer(comm, numpy):
     recv_buffer = numpy.zeros([4, 2, 3])
 
     if rank < size - 1:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"sending data from {rank} to {rank + 1}")
         comm.Send(data, dest=rank + 1)
     if rank > 0:
@@ -132,7 +132,7 @@ def send_subarray(comm, numpy):
     recv_buffer = numpy.zeros([2, 2, 2])
 
     if rank < size - 1:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"sending data from {rank} to {rank + 1}")
         comm.Send(data[1:-1, 1:-1, 1:-1], dest=rank + 1)
     if rank > 0:
@@ -151,11 +151,11 @@ def recv_to_subarray(comm, numpy):
     return_value = recv_buffer
 
     if rank < size - 1:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"sending data from {rank} to {rank + 1}")
         comm.Send(data, dest=rank + 1)
     if rank > 0:
-        if isinstance(comm, DummyComm):
+        if isinstance(comm, LocalComm):
             print(f"receiving data from {rank - 1} to {rank}")
         try:
             comm.Recv(recv_buffer[1:-1, 1:-1, 1:-1], source=rank - 1)
@@ -255,7 +255,7 @@ def dummy_list(total_ranks):
     return_list = []
     for rank in range(total_ranks):
         return_list.append(
-            DummyComm(rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer)
+            LocalComm(rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer)
         )
     return return_list
 

--- a/tests/test_cube_scatter_gather.py
+++ b/tests/test_cube_scatter_gather.py
@@ -6,7 +6,7 @@ import pytest
 from ndsl import (
     CubedSphereCommunicator,
     CubedSpherePartitioner,
-    DummyComm,
+    LocalComm,
     Quantity,
     TilePartitioner,
 )
@@ -100,7 +100,7 @@ def communicator_list(layout):
     for rank in range(total_ranks):
         return_list.append(
             CubedSphereCommunicator(
-                DummyComm(rank, total_ranks, shared_buffer),
+                LocalComm(rank, total_ranks, shared_buffer),
                 CubedSpherePartitioner(TilePartitioner(layout)),
                 timer=Timer(),
             )

--- a/tests/test_g2g_communication.py
+++ b/tests/test_g2g_communication.py
@@ -12,7 +12,7 @@ import pytest
 from ndsl import (
     CubedSphereCommunicator,
     CubedSpherePartitioner,
-    DummyComm,
+    LocalComm,
     Quantity,
     TilePartitioner,
 )
@@ -56,7 +56,7 @@ def cpu_communicators(cube_partitioner):
     for rank in range(cube_partitioner.total_ranks):
         return_list.append(
             CubedSphereCommunicator(
-                comm=DummyComm(
+                comm=LocalComm(
                     rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
                 ),
                 force_cpu=True,
@@ -74,7 +74,7 @@ def gpu_communicators(cube_partitioner):
     for rank in range(cube_partitioner.total_ranks):
         return_list.append(
             CubedSphereCommunicator(
-                comm=DummyComm(
+                comm=LocalComm(
                     rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
                 ),
                 partitioner=cube_partitioner,

--- a/tests/test_halo_update.py
+++ b/tests/test_halo_update.py
@@ -6,8 +6,8 @@ import pytest
 from ndsl import (
     CubedSphereCommunicator,
     CubedSpherePartitioner,
-    DummyComm,
     HaloUpdater,
+    LocalComm,
     Quantity,
     TileCommunicator,
     TilePartitioner,
@@ -204,7 +204,7 @@ def communicator_list(cube_partitioner: CubedSpherePartitioner):
     for rank in range(total_ranks):
         return_list.append(
             CubedSphereCommunicator(
-                comm=DummyComm(
+                comm=LocalComm(
                     rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
                 ),
                 partitioner=cube_partitioner,
@@ -222,7 +222,7 @@ def tile_communicator_list(tile_partitioner):
     for rank in range(total_ranks):
         return_list.append(
             TileCommunicator(
-                comm=DummyComm(
+                comm=LocalComm(
                     rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
                 ),
                 partitioner=tile_partitioner,

--- a/tests/test_halo_update_ranks.py
+++ b/tests/test_halo_update_ranks.py
@@ -3,7 +3,7 @@ import pytest
 from ndsl import (
     CubedSphereCommunicator,
     CubedSpherePartitioner,
-    DummyComm,
+    LocalComm,
     Quantity,
     TilePartitioner,
 )
@@ -103,7 +103,7 @@ def communicator_list(cube_partitioner, total_ranks):
     for rank in range(cube_partitioner.total_ranks):
         return_list.append(
             CubedSphereCommunicator(
-                comm=DummyComm(
+                comm=LocalComm(
                     rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
                 ),
                 partitioner=cube_partitioner,

--- a/tests/test_legacy_restart.py
+++ b/tests/test_legacy_restart.py
@@ -10,7 +10,7 @@ import ndsl.io as io
 from ndsl import (
     CubedSphereCommunicator,
     CubedSpherePartitioner,
-    DummyComm,
+    LocalComm,
     Quantity,
     TilePartitioner,
 )
@@ -38,7 +38,7 @@ def get_c12_restart_state_list(layout, only_names, tracer_properties):
     communicator_list = []
     for rank in range(total_ranks):
         communicator = CubedSphereCommunicator(
-            DummyComm(rank, total_ranks, shared_buffer),
+            LocalComm(rank, total_ranks, shared_buffer),
             CubedSpherePartitioner(TilePartitioner(layout)),
         )
         communicator_list.append(communicator)
@@ -148,7 +148,7 @@ def test_open_c12_restart_empty_to_state_without_crashing(layout):
     communicator_list = []
     for rank in range(total_ranks):
         communicator = CubedSphereCommunicator(
-            DummyComm(rank, total_ranks, shared_buffer),
+            LocalComm(rank, total_ranks, shared_buffer),
             CubedSpherePartitioner(TilePartitioner(layout)),
         )
         communicator_list.append(communicator)
@@ -190,7 +190,7 @@ def test_open_c12_restart_to_allocated_state_without_crashing(layout):
     communicator_list = []
     for rank in range(total_ranks):
         communicator = CubedSphereCommunicator(
-            DummyComm(rank, total_ranks, shared_buffer),
+            LocalComm(rank, total_ranks, shared_buffer),
             CubedSpherePartitioner(TilePartitioner(layout)),
         )
         communicator_list.append(communicator)

--- a/tests/test_netcdf_monitor.py
+++ b/tests/test_netcdf_monitor.py
@@ -10,7 +10,7 @@ import xarray as xr
 from ndsl import (
     CubedSphereCommunicator,
     CubedSpherePartitioner,
-    DummyComm,
+    LocalComm,
     NetCDFMonitor,
     Quantity,
     TilePartitioner,
@@ -54,7 +54,7 @@ def test_monitor_store_multi_rank_state(
     for rank in range(total_ranks):
         communicator = CubedSphereCommunicator(
             partitioner=partitioner,
-            comm=DummyComm(
+            comm=LocalComm(
                 rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
             ),
         )

--- a/tests/test_sync_shared_boundary.py
+++ b/tests/test_sync_shared_boundary.py
@@ -3,7 +3,7 @@ import pytest
 from ndsl import (
     CubedSphereCommunicator,
     CubedSpherePartitioner,
-    DummyComm,
+    LocalComm,
     Quantity,
     TilePartitioner,
 )
@@ -56,7 +56,7 @@ def communicator_list(cube_partitioner, total_ranks):
     for rank in range(cube_partitioner.total_ranks):
         return_list.append(
             CubedSphereCommunicator(
-                comm=DummyComm(
+                comm=LocalComm(
                     rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
                 ),
                 partitioner=cube_partitioner,

--- a/tests/test_tile_scatter.py
+++ b/tests/test_tile_scatter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ndsl import DummyComm, Quantity, TileCommunicator, TilePartitioner
+from ndsl import LocalComm, Quantity, TileCommunicator, TilePartitioner
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM
 
 
@@ -20,7 +20,7 @@ def get_tile_communicator_list(partitioner):
     for rank in range(total_ranks):
         tile_communicator_list.append(
             TileCommunicator(
-                comm=DummyComm(
+                comm=LocalComm(
                     rank=rank, total_ranks=total_ranks, buffer_dict=shared_buffer
                 ),
                 partitioner=partitioner,

--- a/tests/test_tile_scatter_gather.py
+++ b/tests/test_tile_scatter_gather.py
@@ -3,7 +3,7 @@ import datetime
 
 import pytest
 
-from ndsl import DummyComm, Quantity, TileCommunicator, TilePartitioner
+from ndsl import LocalComm, Quantity, TileCommunicator, TilePartitioner
 from ndsl.constants import (
     HORIZONTAL_DIMS,
     X_DIM,
@@ -84,7 +84,7 @@ def communicator_list(layout):
     for rank in range(total_ranks):
         return_list.append(
             TileCommunicator(
-                DummyComm(rank, total_ranks, shared_buffer),
+                LocalComm(rank, total_ranks, shared_buffer),
                 TilePartitioner(layout),
             )
         )


### PR DESCRIPTION
# Description

There's no need to alias `LocalComm` as `DummyComm`. We thus replace all occurrences for the alias with the underlying `LocalComm` directly.

Part of issue #298.

## How has this been tested?

All good as long as tests are still green. I've quickly checked pyFV3, pySHiELD, and pace: the `DummyComm` isn't used there. We should thus be fine to just remove it from `ndsl/__init__.py` without formal deprecation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
