### PR TITLE
refactor: specify `backend` when allocating a `Quantity`

### DIFF
--- a/ndsl/quantity/field_bundle.py
+++ b/ndsl/quantity/field_bundle.py
@@ -95,6 +95,7 @@ class FieldBundle:
                 units=self._quantity.units,
                 origin=self._quantity.origin[:-1],
                 extent=self._quantity.extent[:-1],
+                backend=self._quantity.backend,
             )
         return self._per_name_view[name]
 

--- a/tests/mpi/test_mpi_halo_update.py
+++ b/tests/mpi/test_mpi_halo_update.py
@@ -271,14 +271,9 @@ def depth_quantity(
                 data[tuple(pos)] = numpy.nan
                 pos[i] = origin[i] + extent[i] + n_outside - 1
                 data[tuple(pos)] = numpy.nan
-    quantity = Quantity(
-        data,
-        dims=dims,
-        units=units,
-        origin=origin,
-        extent=extent,
+    return Quantity(
+        data, dims=dims, units=units, origin=origin, extent=extent, backend="debug"
     )
-    return quantity
 
 
 @pytest.mark.skipif(MPI is None, reason="pytest is not run in parallel")
@@ -320,11 +315,7 @@ def zeros_quantity(dims, units, origin, extent, shape, numpy, dtype):
     outside of it."""
     data = numpy.ones(shape, dtype=dtype)
     quantity = Quantity(
-        data,
-        dims=dims,
-        units=units,
-        origin=origin,
-        extent=extent,
+        data, dims=dims, units=units, origin=origin, extent=extent, backend="debug"
     )
     quantity.view[:] = 0.0
     return quantity


### PR DESCRIPTION
# Description

This PR is a follow-up from PR https://github.com/NOAA-GFDL/NDSL/pull/314 and adds the soon to be required `backend` parameter to constructor calls of `Quantity`. I missed a couple ones because PRs were merged in parallel, e.g. re-enabling the `ZarrMonitor` tests.

## How has this been tested?

Checked the output of test runs (serial and parallel) locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
