### PR TITLE
refactor: remove `--no_legacy_namelist` option of pytest

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -76,12 +76,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="How many indices of failures to print from worst to best. Default to 1.",
     )
     parser.addoption(
-        "--no_legacy_namelist",
-        action="store_true",
-        default=False,
-        help="Temporary flag introduced as part of  NDSL issue #64. No functionality. Soon to be removed.",
-    )
-    parser.addoption(
         "--grid",
         action="store",
         default="file",


### PR DESCRIPTION
# Description

This is a follow-up from PR https://github.com/NOAA-GFDL/NDSL/pull/297.

## How has this been tested?

Not

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
