### PR TITLE
refactor: remove --no_legacy_namelist option of pytest

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -76,12 +76,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="How many indices of failures to print from worst to best. Default to 1.",
     )
     parser.addoption(
-        "--no_legacy_namelist",
-        action="store_true",
-        default=False,
-        help="Temporary flag introduced as part of  NDSL issue #64. No functionality. Soon to be removed.",
-    )
-    parser.addoption(
         "--grid",
         action="store",
         default="file",


### PR DESCRIPTION

**Description**
This is a follow-up (clean-up) from PR https://github.com/NOAA-GFDL/NDSL/pull/297.

(It was originally from @romanc: https://github.com/NOAA-GFDL/NDSL/pull/321)

It removes the flag --no_legacy_namelist option from pytest.

**How Has This Been Tested?**
It passes CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
