### PR TITLE
[Fix] [CI] Keeping `networkx` under control to side-step update related bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ requirements: list[str] = [
     "cartopy",  # for plotting in ndsl.viz
     "pytest-subtests",  # for translate tests
     "dacite",  # for state
+    "networkx<=3.5",
 ]
 
 


### PR DESCRIPTION
# Description

Force `networkx` below `3.5` to keep `DaCe` from crashing in graph analysis as per https://github.com/spcl/dace/issues/2235

## How has this been tested?

This will restore the `ci` to stability
