### PR TITLE
:wrench: Harden `Quantity` to hybrid usage

### DIFF
--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -359,19 +359,19 @@ class Quantity:
     @property
     def field_as_xarray(self) -> xr.DataArray:
         """Returns an Xarray.DataArray of the field (domain)"""
-        if isinstance(self.field, cupy.ndarray):
-            field = self.field.get()
-        else:
+        if isinstance(self.field, np.ndarray):
             field = self.field
+        else:
+            field = self.field.get()
         return xr.DataArray(field, dims=self.dims, attrs=self.attrs)
 
     @property
     def data_as_xarray(self) -> xr.DataArray:
         """Returns an Xarray.DataArray of the underlying array"""
-        if isinstance(self.data, cupy.ndarray):
-            data = self.data.get()
-        else:
+        if isinstance(self.data, np.ndarray):
             data = self.data
+        else:
+            data = self.data.get()
         return xr.DataArray(data, dims=self.dims, attrs=self.attrs)
 
     @property


### PR DESCRIPTION
# Description

Bits and bobs that make using `Quantity` in the case of hybrid CPU/GPU memory more straightforward for the user:
- Check for device residency in allocation and move to upload/download if needed
- Make sure to download data before using the `xarray` getter
- Loosen the `from_data_array` to read data that doesn't have a `units`


## How has this been tested?

We don't have the possibility to do GPU tests for now so we can test this outside of model use. This has been tested in NASA's GEOS current porting work.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
