### PR TITLE
[Feature | Fix] Boilerplate adjustements for physics and bench

### DIFF
--- a/ndsl/boilerplate.py
+++ b/ndsl/boilerplate.py
@@ -1,4 +1,5 @@
 import warnings
+
 from ndsl import (
     CompilationConfig,
     DaceConfig,


### PR DESCRIPTION

- Relax the raise in favor of a warnings when using boilerplate in a multi-rank situation. Before it would `raise` and block usage, but in truth usage is fine, halo exchange will not be, and we warn of that.
- Add keyword override for orchestration mode for ease of benchmarking.

## How has this been tested?

No API change, utest is in there.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
