### PR TITLE
BREAKING CHANGE: remove deprecated `CopyCornersXY`

### DIFF
--- a/ndsl/stencils/__init__.py
+++ b/ndsl/stencils/__init__.py
@@ -10,11 +10,10 @@ from .basic_operations import (
     set_value_2D,
     sign,
 )
-from .corners import CopyCornersXY, FillCornersBGrid
+from .corners import FillCornersBGrid
 
 
 __all__ = [
-    "CopyCornersXY",
     "FillCornersBGrid",
     "copy",
     "adjustmentfactor_stencil",

--- a/tests/stencils/test_stencils.py
+++ b/tests/stencils/test_stencils.py
@@ -6,7 +6,6 @@ from ndsl.boilerplate import get_factories_single_tile
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import FORWARD, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, set_4d_field_size
-from ndsl.stencils import CopyCornersXY
 from ndsl.stencils.column_operations import (
     column_max,
     column_max_ddim,
@@ -165,10 +164,3 @@ def test_column_operations(boilerplate):
     assert min_index_ddim.field[:] == 5 + np.argmin(
         data_ddim.field[:, :, 5:, 1], axis=2
     )
-
-
-def test_CopyCornersXY_deprecation(boilerplate) -> None:
-    stencil_factory, _ = boilerplate
-
-    with pytest.deprecated_call(match="Usage of CopyCornersXY is deprecated"):
-        CopyCornersXY(stencil_factory, [X_DIM, Y_DIM, Z_DIM], None)


### PR DESCRIPTION
# Description

`CopyCornersXY` was deprecated with NDSL release 2025.11.00 (see https://github.com/NOAA-GFDL/NDSL/pull/317) and is now removed.

## How has this been tested?

All good as long as CI is green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
