### PR TITLE
BREAKING CHANGE: remove deprecated `QuanityFactory.from_backend()`

### DIFF
--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -57,25 +56,6 @@ class QuantityFactory:
                 )
 
         self.sizer.data_dimensions.update(data_dimension_descriptions)
-
-    @classmethod
-    def from_backend(cls, sizer: GridSizer, backend: str) -> QuantityFactory:
-        """Initialize a QuantityFactory to use a specific GT4Py backend.
-
-        Note: This method is deprecated. Please change your code to use the
-        constructor instead.
-
-        Args:
-            sizer: GridSizer object that determines the array sizes.
-            backend: GT4Py backend name used for performance-optimized allocation.
-        """
-        warnings.warn(
-            "QuantityFactory.from_backend(sizer, backend) is deprecated. Use "
-            "QuantityFactory(sizer, backend=backend) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return cls(sizer, backend=backend)
 
     def empty(
         self,

--- a/tests/initialization/test_allocator.py
+++ b/tests/initialization/test_allocator.py
@@ -1,8 +1,0 @@
-import pytest
-
-from ndsl import QuantityFactory
-
-
-def test_QuantityFactory_from_backend_warns() -> None:
-    with pytest.deprecated_call():
-        QuantityFactory.from_backend(None, backend="numpy")


### PR DESCRIPTION
# Description

`QuanityFactory.from_backend(...)` was deprecated with NDSL release `2025.11.00`. The function is superseded by the new constructor. See https://github.com/NOAA-GFDL/NDSL/pull/228 for context.

Blocked by https://github.com/NOAA-GFDL/pace/pull/169, https://github.com/NOAA-GFDL/PyFV3/pull/108, https://github.com/NOAA-GFDL/PySHiELD/pull/79, https://github.com/NOAA-GFDL/pace/pull/173

## How has this been tested?

All good as long as CI is still green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
