### PR TITLE
refactor: deprecate duplicate basic stencil definitions

### DIFF
--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -4,6 +4,7 @@ import copy
 import dataclasses
 import inspect
 import numbers
+import warnings
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, cast
 
@@ -277,6 +278,22 @@ class FrozenStencil(SDFGConvertible):
             comm: if given, inputs and outputs will be compared to the "twin"
                 rank of this rank
         """
+        deprecated_basic_operations = [
+            "copy_defn",
+            "set_value_defn",
+            "adjustmentfactor_stencil_defn",
+        ]
+        if (
+            func.__module__ == "ndsl.stencils.basic_operations"
+            and func.__name__ in deprecated_basic_operations
+        ):
+            warnings.warn(
+                f"{func.__name__}(...) is deprecated and will be removed with the next "
+                f"version of NDSL. Use {func.__name__.removesuffix('_defn')}(...) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
         if isinstance(origin, tuple):
             origin = cast_to_index3d(origin)
         self.origin = origin

--- a/ndsl/stencils/basic_operations.py
+++ b/ndsl/stencils/basic_operations.py
@@ -22,10 +22,11 @@ def copy(q_in: FloatField, q_out: FloatField) -> None:
         q_out = q_in
 
 
-# TODO: Deprecate this call next release
 def copy_defn(q_in: FloatField, q_out: FloatField) -> None:
     """
-    Copy q_in to q_out.
+    [DEPRECATED] Copy q_in to q_out.
+
+    This stencil is deprecated, use `copy(q_in, q_out)` instead.
 
     Args:
         q_in: input field
@@ -48,11 +49,12 @@ def adjustmentfactor_stencil(adjustment: FloatFieldIJ, q_out: FloatField) -> Non
         q_out = q_out * adjustment
 
 
-# TODO: Deprecate this call next release
 def adjustmentfactor_stencil_defn(adjustment: FloatFieldIJ, q_out: FloatField) -> None:
     """
-    Multiplies every element of q_out by every element of the adjustment field over the
-    interval, replacing the elements of q_out by the result of the multiplication.
+    [DEPRECATED] Multiplies every element of q_out by every element of the adjustment
+    field over the interval, replacing the elements of q_out by the result of the multiplication.
+
+    This stencil is deprecated, use `adjustmentfactor_stencil(adjustment, q_out)` instead.
 
     Args:
         adjustment: adjustment field
@@ -74,10 +76,11 @@ def set_value(q_out: FloatField, value: Float) -> None:
         q_out = value
 
 
-# TODO: Deprecate this call next release
 def set_value_defn(q_out: FloatField, value: Float) -> None:
     """
-    Sets every element of q_out to the value specified by value argument.
+    [DEPRECATED] Sets every element of q_out to the value specified by value argument.
+
+    This stencil is deprecated, use `set_value(q_out, value)` instead.
 
     Args:
         q_out: output field
@@ -114,7 +117,7 @@ def set_IJ_mask_value(mask_out: BoolFieldIJ, value: Bool) -> None:
 def adjust_divide_stencil(adjustment: FloatField, q_out: FloatField) -> None:
     """
     Divides every element of q_out by every element of the adjustment field over the
-    interval, replacing the elements of q_out by the result of the multiplication.
+    interval, replacing the elements of q_out by the result of the division.
 
     Args:
         adjustment: adjustment field


### PR DESCRIPTION
# Description

Some basic stencils were named with a `_defn` suffix. We don't think the suffix is necessary and thus deprecate the version with a suffix and schedule their removal for the next release.

The deprecation warning can't be in the stencil itself. The python frontend of gt4py won't like this. I will thus warn from the stencil factory (which is assumed to be used in one way or another).

Lastly, the PR updates `test_basic_operations.py` to use the boilerplate module and avoid much of the setup by using `get_factories_single_tile`.

This is a follow-up from PR #337.

## How has this been tested?

New & adapted test cases.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
