### PR TITLE
CI: Add `h5py` dependency for `h5netcdf`, which now supports multiple backends

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requirements: list[str] = [
     "netcdf4==1.7.2",
     "scipy",  # restart capacities only
     "h5netcdf",  # for xarray
+    "h5py",  # for h5netcdf >= 1.8
     "dask",  # for xarray
     "numpy==1.26.4",
     "matplotlib",  # for plotting in boilerplate


### PR DESCRIPTION
# Description

Fix `h5netcdf` failures on CI. This morning, `h5netcdf` released version 1.8.0. This version update [makes `h5py` an optional dependency](https://github.com/h5netcdf/h5netcdf/compare/v1.7.3...v1.8.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) because there's now multiple backend options. While `h5py` remains the default backend, the `h5py` library isn't installed anymore by default. Our CI is thus missing this library, which shows as an `ImportError` in the legacy restart tests.

The PR suggest to just add `h5py` as a dependency of NDSL. This is work, but it's arguably a quick and dirty fix. The proposed change, however, works independently of the `h5netcdf` version. I think the proper fix will be to lock versions in one way or another. Until we move there, I'm okay with having that extra dependency NDSL-side.

## How has this been tested?

CI run is green again while [this run](https://github.com/NOAA-GFDL/NDSL/actions/runs/21063232247/job/60574298528?pr=361) failed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
