### PR TITLE
refactor: improve types in python extension

### DIFF
--- a/ndsl/internal/python_extensions.py
+++ b/ndsl/internal/python_extensions.py
@@ -11,7 +11,7 @@ def find_first_NDSLRuntime_caller(frame: FrameType | None) -> NDSLRuntime | None
     search_frame: FrameType | None = frame
 
     # Search for a NDSLRuntime frame
-    while search_frame:
+    while search_frame is not None:
         if "self" in search_frame.f_locals and issubclass(
             type(search_frame.f_locals["self"]), NDSLRuntime
         ):
@@ -33,7 +33,7 @@ def find_all_NDSLRuntime_callers(frame: FrameType | None) -> list[NDSLRuntime]:
     runtimes = []
 
     # Search for a NDSLRuntime frame
-    while search_frame:
+    while search_frame is not None:
         if "self" in search_frame.f_locals and issubclass(
             type(search_frame.f_locals["self"]), NDSLRuntime
         ):


### PR DESCRIPTION
# Description

The pre-release checklist highlighted a typing issue in `python_extension.py`  where a `while` condition wouldn't use `is (not) None` and thus `mypy` couldn't safely derive the type and thus the last return was deemed unreachable code (which isn't true). This is a quick PR to improve the types such that `mypy` is happy.

## How has this been tested?

Tested locally and as part of https://github.com/NOAA-GFDL/pace/pull/175 (which is currently pointing NDSL to this branch).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
