### PR TITLE
BREAKING CHANGE: remove deprecated stencils

### DIFF
--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -4,7 +4,6 @@ import copy
 import dataclasses
 import inspect
 import numbers
-import warnings
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, cast
 
@@ -278,22 +277,6 @@ class FrozenStencil(SDFGConvertible):
             comm: if given, inputs and outputs will be compared to the "twin"
                 rank of this rank
         """
-        deprecated_basic_operations = [
-            "copy_defn",
-            "set_value_defn",
-            "adjustmentfactor_stencil_defn",
-        ]
-        if (
-            func.__module__ == "ndsl.stencils.basic_operations"
-            and func.__name__ in deprecated_basic_operations
-        ):
-            warnings.warn(
-                f"{func.__name__}(...) is deprecated and will be removed with the next "
-                f"version of NDSL. Use {func.__name__.removesuffix('_defn')}(...) instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-
         if isinstance(origin, tuple):
             origin = cast_to_index3d(origin)
         self.origin = origin

--- a/ndsl/stencils/basic_operations.py
+++ b/ndsl/stencils/basic_operations.py
@@ -24,20 +24,6 @@ def copy(q_in: FloatField, q_out: FloatField) -> None:
         q_out = q_in
 
 
-def copy_defn(q_in: FloatField, q_out: FloatField) -> None:
-    """
-    [DEPRECATED] Copy q_in to q_out.
-
-    This stencil is deprecated, use `copy(q_in, q_out)` instead.
-
-    Args:
-        q_in: input field
-        q_out: output field
-    """
-    with computation(PARALLEL), interval(...):
-        q_out = q_in
-
-
 def adjustmentfactor_stencil(adjustment: FloatFieldIJ, q_out: FloatField) -> None:
     """
     Multiplies every element of q_out by every element of the adjustment field over the
@@ -51,38 +37,9 @@ def adjustmentfactor_stencil(adjustment: FloatFieldIJ, q_out: FloatField) -> Non
         q_out = q_out * adjustment
 
 
-def adjustmentfactor_stencil_defn(adjustment: FloatFieldIJ, q_out: FloatField) -> None:
-    """
-    [DEPRECATED] Multiplies every element of q_out by every element of the adjustment
-    field over the interval, replacing the elements of q_out by the result of the multiplication.
-
-    This stencil is deprecated, use `adjustmentfactor_stencil(adjustment, q_out)` instead.
-
-    Args:
-        adjustment: adjustment field
-        q_out: output field
-    """
-    with computation(PARALLEL), interval(...):
-        q_out = q_out * adjustment
-
-
 def set_value(q_out: FloatField, value: Float) -> None:
     """
     Sets every element of q_out to the value specified by value argument.
-
-    Args:
-        q_out: output field
-        value: NDSL Float type
-    """
-    with computation(PARALLEL), interval(...):
-        q_out = value
-
-
-def set_value_defn(q_out: FloatField, value: Float) -> None:
-    """
-    [DEPRECATED] Sets every element of q_out to the value specified by value argument.
-
-    This stencil is deprecated, use `set_value(q_out, value)` instead.
 
     Args:
         q_out: output field

--- a/tests/test_basic_operations.py
+++ b/tests/test_basic_operations.py
@@ -1,5 +1,3 @@
-import pytest
-
 from ndsl import StencilFactory
 from ndsl.boilerplate import get_factories_single_tile
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
@@ -10,7 +8,6 @@ from ndsl.stencils import (
     copy,
     set_value,
 )
-from ndsl.stencils.basic_operations import copy_defn
 
 
 class Copy:
@@ -95,18 +92,6 @@ def test_copy():
     stencil(f_in=infield, f_out=outfield)
 
     assert (infield.field == outfield.field).all()
-
-
-def test_copy_defn_deprecated():
-    stencil_factory, _ = get_factories_single_tile(nx=20, ny=20, nz=79, nhalo=0)
-
-    with pytest.deprecated_call(match=r"^copy_defn\(\.\.\.\) is deprecated"):
-        grid_indexing = stencil_factory.grid_indexing
-        stencil_factory.from_origin_domain(
-            copy_defn,
-            origin=grid_indexing.origin_compute(),
-            domain=grid_indexing.domain_compute(),
-        )
 
 
 def test_adjustment_factor():


### PR DESCRIPTION
# Description

This PR removes deprecated (duplicated) stencils from `basic_operations`. This PR depends on https://github.com/NOAA-GFDL/PyFV3/pull/117, https://github.com/NOAA-GFDL/PySHiELD/pull/83 and https://github.com/NOAA-GFDL/pace/pull/177 to be merged first.

## How has this been tested?

All good as long as CI is green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
