### PR TITLE
fix: `LocalState.make_as_state()` is leaking `Quantities`

### DIFF
--- a/ndsl/quantity/state.py
+++ b/ndsl/quantity/state.py
@@ -663,7 +663,7 @@ class LocalState(State):
             data_dimensions = {}
 
         class _DeactivatePostInitMethod:
-            """[Here be 🐉] Temporily shadow the __post_init__ method to deactivate the guardrails
+            """[Here be 🐉] Temporarily shadow the __post_init__ method to deactivate the guardrails
             of the LocalState. DO NOT USE OUTSIDE OF THIS FUNCTION."""
 
             def __init__(self) -> None:
@@ -700,7 +700,7 @@ class LocalState(State):
             def _restore_local_recursive(cls: Any) -> None:
                 for _field in dataclasses.fields(cls):
                     if dataclasses.is_dataclass(_field.type):
-                        _swap_local_recursive(_field.type)
+                        _restore_local_recursive(_field.type)
                     elif _field.type is Quantity:
                         _field.type = Local
 

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -213,8 +213,10 @@ def test_sequential_savepoint(
     # give the user a chance to load data from other savepoints to allow
     # for gathering required data from multiple sources (constants, etc.)
     case.testobj.extra_data_load(DataLoader(case.grid.rank, case.data_dir))
+
     # run python version of functionality
     output = case.testobj.compute(input_data)
+
     failing_names: list[str] = []
     passing_names: list[str] = []
     if hasattr(case.testobj, "override_output_netcdf_name"):

--- a/tests/quantity/test_local.py
+++ b/tests/quantity/test_local.py
@@ -45,6 +45,33 @@ class GoodLocals(LocalState):
 
 
 @dataclasses.dataclass
+class NestedLocals(LocalState):
+    my_local: Local = dataclasses.field(
+        metadata={
+            "name": "my_local",
+            "dims": [I_DIM, J_DIM, K_DIM],
+            "units": "?",
+            "intent": "?",
+            "dtype": Float,
+        }
+    )
+
+    @dataclasses.dataclass
+    class MyNestedLocals(LocalState):
+        my_local: Local = dataclasses.field(
+            metadata={
+                "name": "my_local",
+                "dims": [I_DIM, J_DIM, K_DIM],
+                "units": "?",
+                "intent": "?",
+                "dtype": Float,
+            }
+        )
+
+    nested_locals: MyNestedLocals
+
+
+@dataclasses.dataclass
 class BadLocals(LocalState):
     my_local: Local = dataclasses.field(
         metadata={
@@ -134,10 +161,25 @@ def test_local_state_as_regular_state() -> None:
         match="LocalState allocated outside of NDSLRuntime: forbidden",
     ):
         _ = GoodLocals.make_locals(quantity_factory)
+
     B = GoodLocals.make_as_state(quantity_factory)
     assert type(B.my_local) is Quantity
+    # Ensure that local have been correctly reset
+    GoodLocals._check_only_locals()
+
     with pytest.raises(
         RuntimeError,
         match="LocalState allocated outside of NDSLRuntime: forbidden",
     ):
         _ = GoodLocals.make_locals(quantity_factory)
+
+
+def test_nested_local_state_as_regular_state() -> None:
+    _, quantity_factory = get_factories_single_tile(3, 3, 5, 0, backend="debug")
+
+    nested = NestedLocals.make_as_state(quantity_factory)
+    assert type(nested.my_local) is Quantity
+    assert type(nested.nested_locals.my_local) is Quantity
+
+    # Ensure that locals have been correctly reset
+    NestedLocals._check_only_locals()


### PR DESCRIPTION
# Description

`LocalState` has a class function `make_as_state()` for testing purposes. That class function creates a "LocalState" object with `Quantities`  instead of `Locals`. This is done by temporarily switching the field type on the dataclass. The restore function wasn't properly recursing, which resulted in premanently altered field types after calling `.make_as_state()`  once.

This PR fixes the recursion and adds a test guarding against popential future regressions. The behavior was first observed in translate tests (of pyMoist) with data of multiple ranks. Starting with the second rank tests, `LocalState._check_only_Locals()` would raise a `TypeError` because of the changed types on the DataClass (which is the same between two test cases).

## How has this been tested?

New unit tests. Double check with initial pyMoist translate test.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [ ] My changes generate no new warnings
  A new warning is emitted in test runs because `LocalState.make_as_state()`  emits a warning.
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
