### PR TITLE
Improved translate test logging

### DIFF
--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -368,7 +368,7 @@ class MultiModalFloatMetric(BaseMetric):
             )
             report_local_failures = f"changing grid points: {bad_indices_count}/{self.number_changing_values} - {failures_of_changing_gridpoint_pct}%; changing columns: {bad_column_count}/{total_column_count} - {bad_column_pct}%; all grid points: {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
         else:
-            report_local_failures = "Something went wrong when calculating statistics one line print, see log for raw data.\n"
+            report_local_failures = f"all grid points: {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
         report = [
             f"{report_local_failures}"
             f"Index   Computed   Reference   "

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -260,11 +260,11 @@ class MultiModalFloatMetric(BaseMetric):
         # We might have sliced outputs in the translate test. Rather than funnel the slicing
         # all the way down, we bail out if we can measure input vs reference
         if input_values is not None and input_values.shape == reference_values.shape:
-            self.number_changing_values = (
-                (input_values != reference_values).sum()
-            )
+            self.number_changing_values = (input_values != reference_values).sum()
             if len(input_values.shape) == 3:
-                self.changing_column_map = (input_values != reference_values).any(axis=2)
+                self.changing_column_map = (input_values != reference_values).any(
+                    axis=2
+                )
             else:
                 self.changing_column_map = np.nan
         else:
@@ -343,9 +343,11 @@ class MultiModalFloatMetric(BaseMetric):
         # List all errors to terminal and file
         bad_indices_count = len(failed_indices[0])
         if self.success.ndim == 3:
-            bad_column_count = (np.logical_not(self.success).any(axis=2) & self.changing_column_map).sum()
+            bad_column_count = (
+                np.logical_not(self.success).any(axis=2) & self.changing_column_map
+            ).sum()
             total_column_count = self.changing_column_map.sum()
-            bad_column_pct = round(bad_column_count/total_column_count * 100, 2)
+            bad_column_pct = round(bad_column_count / total_column_count * 100, 2)
         else:
             bad_column_count = np.nan
             total_column_count = np.nan

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -269,6 +269,7 @@ class MultiModalFloatMetric(BaseMetric):
                 self.changing_column_map = np.nan
         else:
             self.number_changing_values = None
+            self.changing_column_map = None
 
     def _compute_all_metrics(
         self,
@@ -342,12 +343,17 @@ class MultiModalFloatMetric(BaseMetric):
         failed_indices = np.logical_not(self.success).nonzero()
         # List all errors to terminal and file
         bad_indices_count = len(failed_indices[0])
-        if self.success.ndim == 3:
-            bad_column_count = (
-                np.logical_not(self.success).any(axis=2) & self.changing_column_map
-            ).sum()
-            total_column_count = self.changing_column_map.sum()
-            bad_column_pct = round(bad_column_count / total_column_count * 100, 2)
+        if self.changing_column_map is not None:
+            if self.success.ndim == 3:
+                bad_column_count = (
+                    np.logical_not(self.success).any(axis=2) & self.changing_column_map
+                ).sum()
+                total_column_count = self.changing_column_map.sum()
+                bad_column_pct = round(bad_column_count / total_column_count * 100, 2)
+            else:
+                bad_column_count = np.nan
+                total_column_count = np.nan
+                bad_column_pct = np.nan
         else:
             bad_column_count = np.nan
             total_column_count = np.nan
@@ -362,7 +368,7 @@ class MultiModalFloatMetric(BaseMetric):
             )
             report_local_failures = f"changing grid points: {bad_indices_count}/{self.number_changing_values} - {failures_of_changing_gridpoint_pct}%; changing columns: {bad_column_count}/{total_column_count} - {bad_column_pct}%; all grid points: {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
         else:
-            report_local_failures = ""
+            report_local_failures = "Something went wrong when calculating statistics one line print, see log for raw data.\n"
         report = [
             f"{report_local_failures}"
             f"Index   Computed   Reference   "

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -266,7 +266,7 @@ class MultiModalFloatMetric(BaseMetric):
                     axis=2
                 )
             else:
-                self.changing_column_map = np.nan
+                self.changing_column_map = None
         else:
             self.number_changing_values = None
             self.changing_column_map = None
@@ -351,13 +351,13 @@ class MultiModalFloatMetric(BaseMetric):
                 total_column_count = self.changing_column_map.sum()
                 bad_column_pct = round(bad_column_count / total_column_count * 100, 2)
             else:
-                bad_column_count = np.nan
-                total_column_count = np.nan
-                bad_column_pct = np.nan
+                bad_column_count = None
+                total_column_count = None
+                bad_column_pct = None
         else:
-            bad_column_count = np.nan
-            total_column_count = np.nan
-            bad_column_pct = np.nan
+            bad_column_count = None
+            total_column_count = None
+            bad_column_pct = None
         full_count = len(self.references.flatten())
         failures_of_all_grid_points_pct = round(
             100.0 * (bad_indices_count / full_count), 2
@@ -366,7 +366,7 @@ class MultiModalFloatMetric(BaseMetric):
             failures_of_changing_gridpoint_pct = round(
                 100.0 * (bad_indices_count / self.number_changing_values), 2
             )
-            report_local_failures = f"changing grid points: {bad_indices_count}/{self.number_changing_values} - {failures_of_changing_gridpoint_pct}%; changing columns: {bad_column_count}/{total_column_count} - {bad_column_pct}%; all grid points: {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
+            report_local_failures = f"Failures: (changing columns, chainging points, all points) | {bad_column_count}/{total_column_count} - {bad_column_pct}%, {bad_indices_count}/{self.number_changing_values} - {failures_of_changing_gridpoint_pct}%, {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
         else:
             report_local_failures = f"all grid points: {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
         report = [

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -261,8 +261,12 @@ class MultiModalFloatMetric(BaseMetric):
         # all the way down, we bail out if we can measure input vs reference
         if input_values is not None and input_values.shape == reference_values.shape:
             self.number_changing_values = (
-                (input_values != reference_values).flatten().shape[0]
+                (input_values != reference_values).sum()
             )
+            if len(input_values.shape) == 3:
+                self.changing_column_map = (input_values != reference_values).any(axis=2)
+            else:
+                self.changing_column_map = np.nan
         else:
             self.number_changing_values = None
 
@@ -338,6 +342,14 @@ class MultiModalFloatMetric(BaseMetric):
         failed_indices = np.logical_not(self.success).nonzero()
         # List all errors to terminal and file
         bad_indices_count = len(failed_indices[0])
+        if self.success.ndim == 3:
+            bad_column_count = (np.logical_not(self.success).any(axis=2) & self.changing_column_map).sum()
+            total_column_count = self.changing_column_map.sum()
+            bad_column_pct = round(bad_column_count/total_column_count * 100, 2)
+        else:
+            bad_column_count = np.nan
+            total_column_count = np.nan
+            bad_column_pct = np.nan
         full_count = len(self.references.flatten())
         failures_of_all_grid_points_pct = round(
             100.0 * (bad_indices_count / full_count), 2
@@ -346,12 +358,11 @@ class MultiModalFloatMetric(BaseMetric):
             failures_of_changing_gridpoint_pct = round(
                 100.0 * (bad_indices_count / self.number_changing_values), 2
             )
-            report_local_failures = f"Failures (changing grid points) ({bad_indices_count}/{self.number_changing_values}) ({failures_of_changing_gridpoint_pct}%)\n"
+            report_local_failures = f"changing grid points: {bad_indices_count}/{self.number_changing_values} - {failures_of_changing_gridpoint_pct}%; changing columns: {bad_column_count}/{total_column_count} - {bad_column_pct}%; all grid points: {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
         else:
             report_local_failures = ""
         report = [
             f"{report_local_failures}"
-            f"Failures (all grid points) ({bad_indices_count}/{full_count}) ({failures_of_all_grid_points_pct}%)\n",
             f"Index   Computed   Reference   "
             f"{'🔶 ' if not self.absolute_eps.is_default else ''}Absolute E(<{self.absolute_eps.value:.2e})  "
             f"{'🔶 ' if not self.relative_fraction.is_default else ''}Relative E(<{self.relative_fraction.value * 100:.2e}%)   "

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -362,7 +362,7 @@ class MultiModalFloatMetric(BaseMetric):
         failures_of_all_grid_points_pct = round(
             100.0 * (bad_indices_count / full_count), 2
         )
-        if self.number_changing_values is not None:
+        if self.number_changing_values is not None and bad_indices_count is not None and bad_column_count is not None:
             failures_of_changing_gridpoint_pct = round(
                 100.0 * (bad_indices_count / self.number_changing_values), 2
             )

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -261,6 +261,7 @@ class MultiModalFloatMetric(BaseMetric):
         # all the way down, we bail out if we can measure input vs reference
         if input_values is not None and input_values.shape == reference_values.shape:
             self.number_changing_values = (input_values != reference_values).sum()
+            # column information is only relevant if data is three-dimensional
             if len(input_values.shape) == 3:
                 self.changing_column_map = (input_values != reference_values).any(
                     axis=2
@@ -362,7 +363,11 @@ class MultiModalFloatMetric(BaseMetric):
         failures_of_all_grid_points_pct = round(
             100.0 * (bad_indices_count / full_count), 2
         )
-        if self.number_changing_values is not None and bad_indices_count is not None and bad_column_count is not None:
+        if (
+            self.number_changing_values is not None
+            and bad_indices_count is not None
+            and bad_column_count is not None
+        ):
             failures_of_changing_gridpoint_pct = round(
                 100.0 * (bad_indices_count / self.number_changing_values), 2
             )


### PR DESCRIPTION
Fixed a bug that was incorrectly computing the number of changing points (points that differed between the reference in and out files).

Added a few lines that compute the number of changing columns and failing columns.

Updated the translate test print to show report these new values, and ensure that all are shown on the by the pytest short summary.