### PR TITLE
build: update gt4py to get compiler support

### DIFF
--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -1,6 +1,5 @@
 # Literal precision for both GT4Py & NDSL
 import os
-import platform
 import sys
 from typing import Literal
 
@@ -35,15 +34,6 @@ def _get_literal_precision(default: Literal["32", "64"] = "64") -> Literal["32",
 NDSL_GLOBAL_PRECISION = int(_get_literal_precision())
 os.environ["GT4PY_LITERAL_INT_PRECISION"] = str(NDSL_GLOBAL_PRECISION)
 os.environ["GT4PY_LITERAL_FLOAT_PRECISION"] = str(NDSL_GLOBAL_PRECISION)
-
-# OpenMP handling
-
-detected_macos = platform.system() == "Darwin"
-if detected_macos:
-    ndsl_log.warning(
-        "Multithreading is deactivated under MacOS due to apple-clang not handling OpenMP by default."
-    )
-os.environ["GT4PY_CARTESIAN_ENABLE_OPENMP"] = "False" if detected_macos else "True"
 
 
 # Set cache names for default gt backends workflow

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Self
 
 import dace.config
 from gt4py.cartesian.config import GT4PY_COMPILE_OPT_LEVEL
+from gt4py.cartesian.utils.compiler import cxx_compiler_defaults, gpu_configuration
 
 from ndsl import LocalComm
 from ndsl.comm.communicator import Communicator
@@ -226,23 +227,18 @@ class DaceConfig:
             else:
                 dace.config.Config.set("compiler", "build_type", value="Release")
 
-            # Required to True for gt4py storage/memory
-            dace.config.Config.set(
-                "compiler",
-                "allow_view_arguments",
-                value=True,
-            )
             # Resolve "march/mtune" option for GPU
             # - turn on numeric-centric SSE by default
             # - Neoverse-V2 Grace CPU is too new for GCC 14 and -march=native will fail
             # - use alternative march=armv8-a instead
             march_cpu = "armv8-a" if is_arm_neoverse else "native"
             # Removed --fmath
+            cxx_defaults = cxx_compiler_defaults(GT4PY_COMPILE_OPT_LEVEL)
             dace.config.Config.set(
                 "compiler",
                 "cpu",
                 "args",
-                value=f"-march={march_cpu} -std=c++17 -fPIC -Wall -Wextra -O{optimization_level}",
+                value=f"-march={march_cpu} -std=c++17 -fPIC -Wall -Wextra -O{optimization_level} {cxx_defaults.cxx_compile_flags}",
             )
             # Potentially buggy - deactivate
             dace.config.Config.set(
@@ -257,11 +253,12 @@ class DaceConfig:
             # - use alternative mcpu=native instead
             march_option = "-mcpu=native" if is_arm_neoverse else "-march=native"
             # Removed --fast-math
+            gpu_config = gpu_configuration(GT4PY_COMPILE_OPT_LEVEL)
             dace.config.Config.set(
                 "compiler",
                 "cuda",
                 "args",
-                value=f"-std=c++14 -Xcompiler -fPIC -O3 -Xcompiler {march_option}",
+                value=f"-std=c++14 -Xcompiler -fPIC -O{optimization_level} -Xcompiler {march_option} {gpu_config.gpu_compile_flags}",
             )
 
             cuda_sm = cp.cuda.Device(0).compute_capability if cp else 60
@@ -280,6 +277,14 @@ class DaceConfig:
                 "max_concurrent_streams",
                 value=-1,  # no concurrent streams, every kernel on defaultStream
             )
+
+            # Required to True for gt4py storage/memory
+            dace.config.Config.set(
+                "compiler",
+                "allow_view_arguments",
+                value=True,
+            )
+
             # Speed up built time
             dace.config.Config.set(
                 "compiler",


### PR DESCRIPTION
# Description

The PR adds extended compiler support by updating GT4Py, which now auto-detects compilers (gnu, intel, clang, and apple-clang) and sets defaults for the compiler flags accordingly. For example, not all compilers have the same OpenMP flags and `apple-clang` doesn't support it out of the box anyway. All of this is now captured at the GT4Py level.

In addiition, GT4Py now automatically disables FMA operations in case of `-O0` (optimization level 0) to help with stability in porting when comparing to Fortran generated reference data.

## How has this been tested?

GT4Py changes were tested manually (because resetting environment variables and reloading the configuration isn't possible from within the `pytest` framework).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
