### PR TITLE
Improved data_loader

### DIFF
--- a/ndsl/stencils/testing/savepoint.py
+++ b/ndsl/stencils/testing/savepoint.py
@@ -25,19 +25,19 @@ class DataLoader:
     def __init__(self, rank: int, data_path: Path, i_call: int) -> None:
         self._data_path = data_path
         self._rank = rank
-        self.i_call = i_call
+        self._i_call = i_call
 
     def load(
         self,
         name: str,
         postfix: str = "",
-        i_call: int = 0,
+        use_dynamic_i_call: bool = False,
     ) -> dict[str, np.ndarray | float | int]:
+        call_index = self._i_call if use_dynamic_i_call else 0
         return dataset_to_dict(
             xr.open_dataset(self._data_path / f"{name}{postfix}.nc")
             .isel(rank=self._rank)
-            .isel(savepoint=i_call)
-        )
+            .isel(savepoint=call_index))
 
 
 class Translate(Protocol):

--- a/ndsl/stencils/testing/savepoint.py
+++ b/ndsl/stencils/testing/savepoint.py
@@ -22,9 +22,10 @@ def _process_if_scalar(value: np.ndarray) -> np.ndarray | float | int:
 
 
 class DataLoader:
-    def __init__(self, rank: int, data_path: Path) -> None:
+    def __init__(self, rank: int, data_path: Path, i_call: int) -> None:
         self._data_path = data_path
         self._rank = rank
+        self.i_call = i_call
 
     def load(
         self,

--- a/ndsl/stencils/testing/savepoint.py
+++ b/ndsl/stencils/testing/savepoint.py
@@ -37,7 +37,8 @@ class DataLoader:
         return dataset_to_dict(
             xr.open_dataset(self._data_path / f"{name}{postfix}.nc")
             .isel(rank=self._rank)
-            .isel(savepoint=call_index))
+            .isel(savepoint=call_index)
+        )
 
 
 class Translate(Protocol):

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -214,7 +214,7 @@ def test_sequential_savepoint(
     original_input_data = copy.deepcopy(input_data)
     # give the user a chance to load data from other savepoints to allow
     # for gathering required data from multiple sources (constants, etc.)
-    case.testobj.extra_data_load(DataLoader(case.grid.rank, case.data_dir))
+    case.testobj.extra_data_load(DataLoader(case.grid.rank, case.data_dir, case.i_call))
 
     # run python version of functionality
     output = case.testobj.compute(input_data)


### PR DESCRIPTION
Tiny PR adding ability for data_loader to auto-detect current savepoint index in the netcdf. Needed for some newer translate tests where the existing translate test systems fail to load 4D variables. No changes to existing code, previous uses of data_loader should be unaffected.