### PR TITLE
build: update gt4py (numpy 2 compatibility and `ipcx` support)

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -152,9 +152,8 @@ def get_test_class(test_name: str) -> type | None:
         return_class = getattr(translate, translate_class_name)  # type: ignore[name-defined] # noqa: F821
     except AttributeError as err:
         if translate_class_name in err.args[0]:
-            return_class = None
-        else:
-            raise err
+            return None
+        raise err
     return return_class
 
 


### PR DESCRIPTION
# Description

This PR updates the gt4py submodule. In particular, we get

- numpy 2.x compatible code from the debug backend
- support for `icpx`, Intel's parallel compiler

Complete transition to numpy 2.x will come in https://github.com/NOAA-GFDL/NDSL/pull/389 (and PRs that will be linked from there).

/cc @FlorianDeconinck, @twicki FYI

## How has this been tested?

All good as long as CI is still green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
