### PR TITLE
typing: add types to `ndsl.stencils.testing.grid`

### DIFF
--- a/ndsl/stencils/testing/__init__.py
+++ b/ndsl/stencils/testing/__init__.py
@@ -1,4 +1,4 @@
-from .grid import Grid  # type: ignore
+from .grid import Grid
 from .parallel_translate import (
     ParallelTranslate,
     ParallelTranslate2Py,

--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -19,7 +19,7 @@ from ndsl.comm.mpi import MPI, MPIComm
 from ndsl.comm.partitioner import CubedSpherePartitioner, TilePartitioner
 from ndsl.config import Backend
 from ndsl.dsl.dace.dace_config import DaceConfig
-from ndsl.stencils.testing.grid import Grid  # type: ignore
+from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.parallel_translate import ParallelTranslate
 from ndsl.stencils.testing.savepoint import SavepointCase, Translate, dataset_to_dict
 from ndsl.stencils.testing.translate import TranslateGrid

--- a/ndsl/stencils/testing/grid.py
+++ b/ndsl/stencils/testing/grid.py
@@ -1,7 +1,10 @@
-# type: ignore
+from typing import Sequence
 
 import numpy as np
+from f90nml import Namelist
 
+from ndsl import GridSizer
+from ndsl.comm.communicator import Communicator
 from ndsl.comm.partitioner import TilePartitioner
 from ndsl.config import Backend
 from ndsl.constants import I_DIM, J_DIM, K_DIM, N_HALO_DEFAULT
@@ -27,7 +30,6 @@ TRACER_DIM = "tracers"
 
 
 class Grid:
-    # indices = ["is_", "ie", "isd", "ied", "js", "je", "jsd", "jed"]
     index_pairs = [("is_", "js"), ("ie", "je"), ("isd", "jsd"), ("ied", "jed")]
     shape_params = ["npz", "npx", "npy"]
     # npx -- number of grid corners on one tile of the domain
@@ -35,8 +37,31 @@ class Grid:
     # But we need to add the halo - 1 to change this check to 0 based python arrays
     # grid.ie == npx + halo - 2
 
+    # shape params (initialized in __init__ with `setattr`)
+    npx: int
+    npy: int
+    npz: int
+
+    # index params (initialized in __int___ with `setattr`)
+    is_: int  # `is` is a reserved keyword in python
+    ie: int
+    isd: int
+    ied: int
+    js: int
+    je: int
+    jsd: int
+    jed: int
+
     @classmethod
-    def _make(cls, npx, npy, npz, layout, rank, backend: Backend):
+    def _make(
+        cls,
+        npx: int,
+        npy: int,
+        npz: int,
+        layout: tuple[int, int],
+        rank: int,
+        backend: Backend,
+    ) -> "Grid":
         shape_params = {
             "npx": npx,
             "npy": npy,
@@ -60,13 +85,15 @@ class Grid:
         return cls(indices, shape_params, rank, layout, backend, local_indices=True)
 
     @classmethod
-    def from_namelist(cls, namelist, rank, backend: Backend):
+    def from_namelist(cls, namelist: Namelist, rank: int, backend: Backend) -> "Grid":
         return cls._make(
             namelist.npx, namelist.npy, namelist.npz, namelist.layout, rank, backend
         )
 
     @classmethod
-    def with_data_from_namelist(cls, namelist, communicator, backend: Backend):
+    def with_data_from_namelist(
+        cls, namelist: Namelist, communicator: Communicator, backend: Backend
+    ) -> "Grid":
         grid = cls.from_namelist(namelist, communicator.rank, backend)
         grid.make_grid_data(
             npx=namelist.npx,
@@ -79,14 +106,14 @@ class Grid:
 
     def __init__(
         self,
-        indices,
-        shape_params,
-        rank,
-        layout,
+        indices: dict[str, int],
+        shape_params: dict[str, int],
+        rank: int,
+        layout: tuple[int, int],
         backend: Backend,
         data_fields: dict | None = None,
-        local_indices=False,
-    ):
+        local_indices: bool = False,
+    ) -> None:
         if data_fields is None:
             data_fields = {}
 
@@ -129,16 +156,16 @@ class Grid:
         self.se_corner = self.east_edge and self.south_edge
         self.nw_corner = self.west_edge and self.north_edge
         self.ne_corner = self.east_edge and self.north_edge
-        self.data_fields = {}
+        self.data_fields: dict = {}
         self.add_data(data_fields)
-        self._sizer = None
-        self._quantity_factory = None
-        self._grid_data = None
-        self._driver_grid_data = None
-        self._damping_coefficients = None
+        self._sizer: GridSizer | None = None
+        self._quantity_factory: QuantityFactory | None = None
+        self._grid_data: GridData | None = None
+        self._driver_grid_data: DriverGridData | None = None
+        self._damping_coefficients: DampingCoefficients | None = None
 
     @property
-    def sizer(self):
+    def sizer(self) -> GridSizer:
         if self._sizer is None:
             # in the future this should use from_namelist, when we have a non-flattened
             # namelist
@@ -164,28 +191,32 @@ class Grid:
             self._quantity_factory = QuantityFactory(self.sizer, backend=self.backend)
         return self._quantity_factory
 
-    def global_to_local_1d(self, global_value, subtile_index, subtile_length):
-        return int(global_value - subtile_index * subtile_length)
+    def global_to_local_1d(
+        self, global_value: int, subtile_index: int, subtile_length: int
+    ) -> int:
+        return global_value - subtile_index * subtile_length
 
-    def global_to_local_x(self, i_global):
+    def global_to_local_x(self, i_global: int) -> int:
         return self.global_to_local_1d(
             i_global, self.subtile_index[1], self.subtile_width_x
         )
 
-    def global_to_local_y(self, j_global):
+    def global_to_local_y(self, j_global: int) -> int:
         return self.global_to_local_1d(
             j_global, self.subtile_index[0], self.subtile_width_y
         )
 
-    def global_to_local_indices(self, i_global, j_global):
+    def global_to_local_indices(self, i_global: int, j_global: int) -> tuple[int, int]:
         i_local = self.global_to_local_x(i_global)
         j_local = self.global_to_local_y(j_global)
         return i_local, j_local
 
-    def local_to_global_1d(self, local_value, subtile_index, subtile_length):
-        return int(local_value + subtile_index * subtile_length)
+    def local_to_global_1d(
+        self, local_value: int, subtile_index: int, subtile_length: int
+    ) -> int:
+        return local_value + subtile_index * subtile_length
 
-    def local_to_global_indices(self, i_local, j_local):
+    def local_to_global_indices(self, i_local: int, j_local: int) -> tuple[int, int]:
         i_global = self.local_to_global_1d(
             i_local, self.subtile_index[1], self.subtile_width_x
         )
@@ -194,53 +225,53 @@ class Grid:
         )
         return i_global, j_global
 
-    def add_data(self, data_dict):
+    def add_data(self, data_dict: dict) -> None:
         self.data_fields.update(data_dict)
         for k, v in self.data_fields.items():
             setattr(self, k, v)
 
-    def irange_compute(self):
+    def irange_compute(self) -> range:
         return range(self.is_, self.ie + 1)
 
-    def irange_compute_x(self):
+    def irange_compute_x(self) -> range:
         return range(self.is_, self.ie + 2)
 
-    def jrange_compute(self):
+    def jrange_compute(self) -> range:
         return range(self.js, self.je + 1)
 
-    def jrange_compute_y(self):
+    def jrange_compute_y(self) -> range:
         return range(self.js, self.je + 2)
 
-    def irange_domain(self):
+    def irange_domain(self) -> range:
         return range(self.isd, self.ied + 1)
 
-    def jrange_domain(self):
+    def jrange_domain(self) -> range:
         return range(self.jsd, self.jed + 1)
 
-    def krange(self):
+    def krange(self) -> range:
         return range(0, self.npz)
 
-    def compute_interface(self):
+    def compute_interface(self) -> tuple[slice, ...]:
         return self.slice_dict(self.compute_dict())
 
-    def x3d_interface(self):
+    def x3d_interface(self) -> tuple[slice, ...]:
         return self.slice_dict(self.x3d_compute_dict())
 
-    def y3d_interface(self):
+    def y3d_interface(self) -> tuple[slice, ...]:
         return self.slice_dict(self.y3d_compute_dict())
 
-    def x3d_domain_interface(self):
+    def x3d_domain_interface(self) -> tuple[slice, ...]:
         return self.slice_dict(self.x3d_domain_dict())
 
-    def y3d_domain_interface(self):
+    def y3d_domain_interface(self) -> tuple[slice, ...]:
         return self.slice_dict(self.y3d_domain_dict())
 
-    def add_one(self, num):
+    def add_one(self, num: int | None) -> int:
         if num is None:
-            return None
+            raise ValueError("Can't add one to `None`.")
         return num + 1
 
-    def slice_dict(self, d, ndim: int = 3):
+    def slice_dict(self, d: dict, ndim: int = 3) -> tuple[slice, ...]:
         iters: str = "ijk" if ndim > 1 else "k"
         return tuple(
             [
@@ -251,7 +282,7 @@ class Grid:
             ]
         )
 
-    def default_domain_dict(self):
+    def default_domain_dict(self) -> dict:
         return {
             "istart": self.isd,
             "iend": self.ied,
@@ -261,13 +292,13 @@ class Grid:
             "kend": self.npz - 1,
         }
 
-    def default_dict_buffer_2d(self):
+    def default_dict_buffer_2d(self) -> dict:
         mydict = self.default_domain_dict()
         mydict["iend"] += 1
         mydict["jend"] += 1
         return mydict
 
-    def compute_dict(self):
+    def compute_dict(self) -> dict:
         return {
             "istart": self.is_,
             "iend": self.ie,
@@ -277,23 +308,23 @@ class Grid:
             "kend": self.npz - 1,
         }
 
-    def compute_dict_buffer_2d(self):
+    def compute_dict_buffer_2d(self) -> dict:
         mydict = self.compute_dict()
         mydict["iend"] += 1
         mydict["jend"] += 1
         return mydict
 
-    def default_buffer_k_dict(self):
+    def default_buffer_k_dict(self) -> dict:
         mydict = self.default_domain_dict()
         mydict["kend"] = self.npz
         return mydict
 
-    def compute_buffer_k_dict(self):
+    def compute_buffer_k_dict(self) -> dict:
         mydict = self.compute_dict()
         mydict["kend"] = self.npz
         return mydict
 
-    def x3d_domain_dict(self):
+    def x3d_domain_dict(self) -> dict:
         horizontal_dict = {
             "istart": self.isd,
             "iend": self.ied + 1,
@@ -302,7 +333,7 @@ class Grid:
         }
         return {**self.default_domain_dict(), **horizontal_dict}
 
-    def y3d_domain_dict(self):
+    def y3d_domain_dict(self) -> dict:
         horizontal_dict = {
             "istart": self.isd,
             "iend": self.ied,
@@ -311,7 +342,7 @@ class Grid:
         }
         return {**self.default_domain_dict(), **horizontal_dict}
 
-    def x3d_compute_dict(self):
+    def x3d_compute_dict(self) -> dict:
         horizontal_dict = {
             "istart": self.is_,
             "iend": self.ie + 1,
@@ -320,7 +351,7 @@ class Grid:
         }
         return {**self.default_domain_dict(), **horizontal_dict}
 
-    def y3d_compute_dict(self):
+    def y3d_compute_dict(self) -> dict:
         horizontal_dict = {
             "istart": self.is_,
             "iend": self.ie,
@@ -329,7 +360,7 @@ class Grid:
         }
         return {**self.default_domain_dict(), **horizontal_dict}
 
-    def x3d_compute_domain_y_dict(self):
+    def x3d_compute_domain_y_dict(self) -> dict:
         horizontal_dict = {
             "istart": self.is_,
             "iend": self.ie + 1,
@@ -338,7 +369,7 @@ class Grid:
         }
         return {**self.default_domain_dict(), **horizontal_dict}
 
-    def y3d_compute_domain_x_dict(self):
+    def y3d_compute_domain_x_dict(self) -> dict:
         horizontal_dict = {
             "istart": self.isd,
             "iend": self.ied,
@@ -347,18 +378,22 @@ class Grid:
         }
         return {**self.default_domain_dict(), **horizontal_dict}
 
-    def domain_shape_full(self, *, add: tuple[int, int, int] = (0, 0, 0)):
+    def domain_shape_full(
+        self, *, add: tuple[int, int, int] = (0, 0, 0)
+    ) -> tuple[int, int, int]:
         """Domain shape for the full array including halo points."""
         return (self.nid + add[0], self.njd + add[1], self.npz + add[2])
 
-    def domain_shape_compute(self, *, add: tuple[int, int, int] = (0, 0, 0)):
+    def domain_shape_compute(
+        self, *, add: tuple[int, int, int] = (0, 0, 0)
+    ) -> tuple[int, int, int]:
         """Compute domain shape excluding halo points."""
         return (self.nic + add[0], self.njc + add[1], self.npz + add[2])
 
-    def copy_right_edge(self, var, i_index, j_index):
+    def copy_right_edge(self, var, i_index, j_index):  # type: ignore
         return np.copy(var[i_index:, :, :]), np.copy(var[:, j_index:, :])
 
-    def insert_left_edge(self, var, edge_data_i, i_index, edge_data_j, j_index):
+    def insert_left_edge(self, var, edge_data_i, i_index, edge_data_j, j_index):  # type: ignore
         if len(var.shape) < 3:
             var[:i_index, :] = edge_data_i
             var[:, :j_index] = edge_data_j
@@ -366,7 +401,7 @@ class Grid:
             var[:i_index, :, :] = edge_data_i
             var[:, :j_index, :] = edge_data_j
 
-    def insert_right_edge(self, var, edge_data_i, i_index, edge_data_j, j_index):
+    def insert_right_edge(self, var, edge_data_i, i_index, edge_data_j, j_index):  # type: ignore
         if len(var.shape) < 3:
             var[i_index:, :] = edge_data_i
             var[:, j_index:] = edge_data_j
@@ -374,21 +409,25 @@ class Grid:
             var[i_index:, :, :] = edge_data_i
             var[:, j_index:, :] = edge_data_j
 
-    def uvar_edge_halo(self, var):
+    def uvar_edge_halo(self, var):  # type: ignore
         return self.copy_right_edge(var, self.ie + 2, self.je + 1)
 
-    def vvar_edge_halo(self, var):
+    def vvar_edge_halo(self, var):  # type: ignore
         return self.copy_right_edge(var, self.ie + 1, self.je + 2)
 
-    def compute_origin(self, add: tuple[int, int, int] = (0, 0, 0)):
+    def compute_origin(
+        self, add: tuple[int, int, int] = (0, 0, 0)
+    ) -> tuple[int, int, int]:
         """Start of the compute domain (e.g. (halo, halo, 0))"""
         return (self.is_ + add[0], self.js + add[1], add[2])
 
-    def full_origin(self, add: tuple[int, int, int] = (0, 0, 0)):
+    def full_origin(
+        self, add: tuple[int, int, int] = (0, 0, 0)
+    ) -> tuple[int, int, int]:
         """Start of the full array including halo points (e.g. (0, 0, 0))"""
         return (self.isd + add[0], self.jsd + add[1], add[2])
 
-    def horizontal_starts_from_shape(self, shape):
+    def horizontal_starts_from_shape(self, shape: Sequence[int]) -> tuple[int, int]:
         if shape[0:2] in [
             self.domain_shape_compute()[0:2],
             self.domain_shape_compute(add=(1, 0, 0))[0:2],
@@ -396,12 +435,13 @@ class Grid:
             self.domain_shape_compute(add=(1, 1, 0))[0:2],
         ]:
             return self.is_, self.js
-        elif shape[0:2] == (self.nic + 2, self.njc + 2):
-            return self.is_ - 1, self.js - 1
-        else:
-            return 0, 0
 
-    def get_halo_update_spec(
+        if shape[0:2] == (self.nic + 2, self.njc + 2):
+            return self.is_ - 1, self.js - 1
+
+        return 0, 0
+
+    def get_halo_update_spec(  # type: ignore
         self,
         shape,
         origin,
@@ -417,7 +457,7 @@ class Grid:
     @property
     def grid_indexing(self) -> GridIndexing:
         return GridIndexing(
-            domain=tuple(int(item) for item in self.domain_shape_compute()),
+            domain=self.domain_shape_compute(),
             n_halo=self.halo,
             south_edge=self.south_edge,
             north_edge=self.north_edge,
@@ -430,16 +470,18 @@ class Grid:
         if self._damping_coefficients is not None:
             return self._damping_coefficients
         self._damping_coefficients = DampingCoefficients(
-            divg_u=self.divg_u,
-            divg_v=self.divg_v,
-            del6_u=self.del6_u,
-            del6_v=self.del6_v,
-            da_min=self.da_min,
-            da_min_c=self.da_min_c,
+            divg_u=self.divg_u,  # type: ignore
+            divg_v=self.divg_v,  # type: ignore
+            del6_u=self.del6_u,  # type: ignore
+            del6_v=self.del6_v,  # type: ignore
+            da_min=self.da_min,  # type: ignore
+            da_min_c=self.da_min_c,  # type: ignore
         )
         return self._damping_coefficients
 
-    def set_damping_coefficients(self, damping_coefficients: DampingCoefficients):
+    def set_damping_coefficients(
+        self, damping_coefficients: DampingCoefficients
+    ) -> None:
         self._damping_coefficients = damping_coefficients
 
     @property
@@ -491,103 +533,103 @@ class Grid:
 
         horizontal = HorizontalGridData(
             lon=self.quantity_factory.from_array(
-                data=self.bgrid1,
+                data=self.bgrid1,  # type: ignore
                 dims=GridDefinitions.lon.dims,
                 units=GridDefinitions.lon.units,
             ),
             lat=self.quantity_factory.from_array(
-                data=self.bgrid2,
+                data=self.bgrid2,  # type: ignore
                 dims=GridDefinitions.lat.dims,
                 units=GridDefinitions.lat.units,
             ),
             lon_agrid=self.quantity_factory.from_array(
-                data=self.agrid1,
+                data=self.agrid1,  # type: ignore
                 dims=GridDefinitions.lon_agrid.dims,
                 units=GridDefinitions.lon_agrid.units,
             ),
             lat_agrid=self.quantity_factory.from_array(
-                data=self.agrid2,
+                data=self.agrid2,  # type: ignore
                 dims=GridDefinitions.lat_agrid.dims,
                 units=GridDefinitions.lat_agrid.units,
             ),
             area=self.quantity_factory.from_array(
-                data=self.area,
+                data=self.area,  # type: ignore
                 dims=GridDefinitions.area.dims,
                 units=GridDefinitions.area.units,
             ),
             area_64=self.quantity_factory.from_array(
-                data=self.area_64,
+                data=self.area_64,  # type: ignore
                 dims=GridDefinitions.area.dims,
                 units=GridDefinitions.area.units,
                 allow_mismatch_float_precision=True,
             ),
             rarea=self.quantity_factory.from_array(
-                data=self.rarea,
+                data=self.rarea,  # type: ignore
                 dims=GridDefinitions.rarea.dims,
                 units=GridDefinitions.rarea.units,
             ),
             rarea_c=self.quantity_factory.from_array(
-                data=self.rarea_c,
+                data=self.rarea_c,  # type: ignore
                 dims=GridDefinitions.rarea_c.dims,
                 units=GridDefinitions.rarea_c.units,
             ),
             dx=self.quantity_factory.from_array(
-                data=self.dx,
+                data=self.dx,  # type: ignore
                 dims=GridDefinitions.dx.dims,
                 units=GridDefinitions.dx.units,
             ),
             dy=self.quantity_factory.from_array(
-                data=self.dy,
+                data=self.dy,  # type: ignore
                 dims=GridDefinitions.dy.dims,
                 units=GridDefinitions.dy.units,
             ),
             dxc=self.quantity_factory.from_array(
-                data=self.dxc,
+                data=self.dxc,  # type: ignore
                 dims=GridDefinitions.dxc.dims,
                 units=GridDefinitions.dxc.units,
             ),
             dyc=self.quantity_factory.from_array(
-                data=self.dyc,
+                data=self.dyc,  # type: ignore
                 dims=GridDefinitions.dyc.dims,
                 units=GridDefinitions.dyc.units,
             ),
             dxa=self.quantity_factory.from_array(
-                data=self.dxa,
+                data=self.dxa,  # type: ignore
                 dims=GridDefinitions.dxa.dims,
                 units=GridDefinitions.dxa.units,
             ),
             dya=self.quantity_factory.from_array(
-                data=self.dya,
+                data=self.dya,  # type: ignore
                 dims=GridDefinitions.dya.dims,
                 units=GridDefinitions.dya.units,
             ),
             rdx=self.quantity_factory.from_array(
-                data=self.rdx,
+                data=self.rdx,  # type: ignore
                 dims=GridDefinitions.rdx.dims,
                 units=GridDefinitions.rdx.units,
             ),
             rdy=self.quantity_factory.from_array(
-                data=self.rdy,
+                data=self.rdy,  # type: ignore
                 dims=GridDefinitions.rdy.dims,
                 units=GridDefinitions.rdy.units,
             ),
             rdxc=self.quantity_factory.from_array(
-                data=self.rdxc,
+                data=self.rdxc,  # type: ignore
                 dims=GridDefinitions.rdxc.dims,
                 units=GridDefinitions.rdxc.units,
             ),
             rdyc=self.quantity_factory.from_array(
-                data=self.rdyc,
+                data=self.rdyc,  # type: ignore
                 dims=GridDefinitions.rdyc.dims,
                 units=GridDefinitions.rdyc.units,
             ),
             rdxa=self.quantity_factory.from_array(
-                data=self.rdxa,
+                data=self.rdxa,  # type: ignore
                 dims=GridDefinitions.rdxa.dims,
                 units=GridDefinitions.rdxa.units,
             ),
             rdya=self.quantity_factory.from_array(
-                data=self.rdya,
+                data=self.rdya,  # type: ignore
                 dims=GridDefinitions.rdya.dims,
                 units=GridDefinitions.rdya.units,
             ),
@@ -596,22 +638,22 @@ class Grid:
             es1=clipped_data["es1"],
             ew2=clipped_data["ew2"],
             a11=self.quantity_factory.from_array(
-                data=self.a11,
+                data=self.a11,  # type: ignore
                 dims=GridDefinitions.a11.dims,
                 units=GridDefinitions.a11.units,
             ),
             a12=self.quantity_factory.from_array(
-                data=self.a12,
+                data=self.a12,  # type: ignore
                 dims=GridDefinitions.a12.dims,
                 units=GridDefinitions.a12.units,
             ),
             a21=self.quantity_factory.from_array(
-                data=self.a21,
+                data=self.a21,  # type: ignore
                 dims=GridDefinitions.a21.dims,
                 units=GridDefinitions.a21.units,
             ),
             a22=self.quantity_factory.from_array(
-                data=self.a22,
+                data=self.a22,  # type: ignore
                 dims=GridDefinitions.a22.dims,
                 units=GridDefinitions.a22.units,
             ),
@@ -622,156 +664,156 @@ class Grid:
         )
         vertical = VerticalGridData(
             ak=self.quantity_factory.from_array(
-                data=self.ak,
+                data=self.ak,  # type: ignore
                 dims=GridDefinitions.ak.dims,
                 units=GridDefinitions.ak.units,
             ),
             bk=self.quantity_factory.from_array(
-                data=self.bk,
+                data=self.bk,  # type: ignore
                 dims=GridDefinitions.bk.dims,
                 units=GridDefinitions.bk.units,
             ),
         )
         contravariant = ContravariantGridData(
             cosa=self.quantity_factory.from_array(
-                data=self.cosa,
+                data=self.cosa,  # type: ignore
                 dims=GridDefinitions.cosa.dims,
                 units=GridDefinitions.cosa.units,
             ),
             cosa_u=self.quantity_factory.from_array(
-                data=self.cosa_u,
+                data=self.cosa_u,  # type: ignore
                 dims=GridDefinitions.cosa_u.dims,
                 units=GridDefinitions.cosa_u.units,
             ),
             cosa_v=self.quantity_factory.from_array(
-                data=self.cosa_v,
+                data=self.cosa_v,  # type: ignore
                 dims=GridDefinitions.cosa_v.dims,
                 units=GridDefinitions.cosa_v.units,
             ),
             cosa_s=self.quantity_factory.from_array(
-                data=self.cosa_s,
+                data=self.cosa_s,  # type: ignore
                 dims=GridDefinitions.cosa_s.dims,
                 units=GridDefinitions.cosa_s.units,
             ),
             sina_u=self.quantity_factory.from_array(
-                data=self.sina_u,
+                data=self.sina_u,  # type: ignore
                 dims=GridDefinitions.sina_u.dims,
                 units=GridDefinitions.sina_u.units,
             ),
             sina_v=self.quantity_factory.from_array(
-                data=self.sina_v,
+                data=self.sina_v,  # type: ignore
                 dims=GridDefinitions.sina_v.dims,
                 units=GridDefinitions.sina_v.units,
             ),
             rsina=self.quantity_factory.from_array(
-                data=self.rsina,
+                data=self.rsina,  # type: ignore
                 dims=GridDefinitions.rsina.dims,
                 units=GridDefinitions.rsina.units,
             ),
             rsin_u=self.quantity_factory.from_array(
-                data=self.rsin_u,
+                data=self.rsin_u,  # type: ignore
                 dims=GridDefinitions.rsin_u.dims,
                 units=GridDefinitions.rsin_u.units,
             ),
             rsin_v=self.quantity_factory.from_array(
-                data=self.rsin_v,
+                data=self.rsin_v,  # type: ignore
                 dims=GridDefinitions.rsin_v.dims,
                 units=GridDefinitions.rsin_v.units,
             ),
             rsin2=self.quantity_factory.from_array(
-                data=self.rsin2,
+                data=self.rsin2,  # type: ignore
                 dims=GridDefinitions.rsin2.dims,
                 units=GridDefinitions.rsin2.units,
             ),
         )
         angle = AngleGridData(
             sin_sg1=self.quantity_factory.from_array(
-                data=self.sin_sg1,
+                data=self.sin_sg1,  # type: ignore
                 dims=GridDefinitions.sin_sg1.dims,
                 units=GridDefinitions.sin_sg1.units,
             ),
             sin_sg2=self.quantity_factory.from_array(
-                data=self.sin_sg2,
+                data=self.sin_sg2,  # type: ignore
                 dims=GridDefinitions.sin_sg2.dims,
                 units=GridDefinitions.sin_sg2.units,
             ),
             sin_sg3=self.quantity_factory.from_array(
-                data=self.sin_sg3,
+                data=self.sin_sg3,  # type: ignore
                 dims=GridDefinitions.sin_sg3.dims,
                 units=GridDefinitions.sin_sg3.units,
             ),
             sin_sg4=self.quantity_factory.from_array(
-                data=self.sin_sg4,
+                data=self.sin_sg4,  # type: ignore
                 dims=GridDefinitions.sin_sg4.dims,
                 units=GridDefinitions.sin_sg4.units,
             ),
             sin_sg5=self.quantity_factory.from_array(
-                data=self.sin_sg5,
+                data=self.sin_sg5,  # type: ignore
                 dims=GridDefinitions.sin_sg5.dims,
                 units=GridDefinitions.sin_sg5.units,
             ),
             sin_sg6=self.quantity_factory.from_array(
-                data=self.sin_sg6,
+                data=self.sin_sg6,  # type: ignore
                 dims=GridDefinitions.sin_sg6.dims,
                 units=GridDefinitions.sin_sg6.units,
             ),
             sin_sg7=self.quantity_factory.from_array(
-                data=self.sin_sg7,
+                data=self.sin_sg7,  # type: ignore
                 dims=GridDefinitions.sin_sg7.dims,
                 units=GridDefinitions.sin_sg7.units,
             ),
             sin_sg8=self.quantity_factory.from_array(
-                data=self.sin_sg8,
+                data=self.sin_sg8,  # type: ignore
                 dims=GridDefinitions.sin_sg8.dims,
                 units=GridDefinitions.sin_sg8.units,
             ),
             sin_sg9=self.quantity_factory.from_array(
-                data=self.sin_sg9,
+                data=self.sin_sg9,  # type: ignore
                 dims=GridDefinitions.sin_sg9.dims,
                 units=GridDefinitions.sin_sg9.units,
             ),
             cos_sg1=self.quantity_factory.from_array(
-                data=self.cos_sg1,
+                data=self.cos_sg1,  # type: ignore
                 dims=GridDefinitions.cos_sg1.dims,
                 units=GridDefinitions.cos_sg1.units,
             ),
             cos_sg2=self.quantity_factory.from_array(
-                data=self.cos_sg2,
+                data=self.cos_sg2,  # type: ignore
                 dims=GridDefinitions.cos_sg2.dims,
                 units=GridDefinitions.cos_sg2.units,
             ),
             cos_sg3=self.quantity_factory.from_array(
-                data=self.cos_sg3,
+                data=self.cos_sg3,  # type: ignore
                 dims=GridDefinitions.cos_sg3.dims,
                 units=GridDefinitions.cos_sg3.units,
             ),
             cos_sg4=self.quantity_factory.from_array(
-                data=self.cos_sg4,
+                data=self.cos_sg4,  # type: ignore
                 dims=GridDefinitions.cos_sg4.dims,
                 units=GridDefinitions.cos_sg4.units,
             ),
             cos_sg5=self.quantity_factory.from_array(
-                data=self.cos_sg5,
+                data=self.cos_sg5,  # type: ignore
                 dims=GridDefinitions.cos_sg5.dims,
                 units=GridDefinitions.cos_sg5.units,
             ),
             cos_sg6=self.quantity_factory.from_array(
-                data=self.cos_sg6,
+                data=self.cos_sg6,  # type: ignore
                 dims=GridDefinitions.cos_sg6.dims,
                 units=GridDefinitions.cos_sg6.units,
             ),
             cos_sg7=self.quantity_factory.from_array(
-                data=self.cos_sg7,
+                data=self.cos_sg7,  # type: ignore
                 dims=GridDefinitions.cos_sg7.dims,
                 units=GridDefinitions.cos_sg7.units,
             ),
             cos_sg8=self.quantity_factory.from_array(
-                data=self.cos_sg8,
+                data=self.cos_sg8,  # type: ignore
                 dims=GridDefinitions.cos_sg8.dims,
                 units=GridDefinitions.cos_sg8.units,
             ),
             cos_sg9=self.quantity_factory.from_array(
-                data=self.cos_sg9,
+                data=self.cos_sg9,  # type: ignore
                 dims=GridDefinitions.cos_sg9.dims,
                 units=GridDefinitions.cos_sg9.units,
             ),
@@ -781,8 +823,8 @@ class Grid:
             vertical_data=vertical,
             contravariant_data=contravariant,
             angle_data=angle,
-            fc=self.fC,
-            fc_agrid=self.f0,
+            fc=self.fC,  # type: ignore
+            fc_agrid=self.f0,  # type: ignore
         )
         return self._grid_data
 
@@ -790,21 +832,23 @@ class Grid:
     def driver_grid_data(self) -> DriverGridData:
         if self._driver_grid_data is None:
             self._driver_grid_data = DriverGridData.new_from_grid_variables(
-                vlon=self.vlon,
-                vlat=self.vlat,
-                edge_vect_w=self.edge_vect_w,
-                edge_vect_e=self.edge_vect_e,
-                edge_vect_s=self.edge_vect_s,
-                edge_vect_n=self.edge_vect_n,
-                es1=self.es1,
-                ew2=self.ew2,
+                vlon=self.vlon,  # type: ignore
+                vlat=self.vlat,  # type: ignore
+                edge_vect_w=self.edge_vect_w,  # type: ignore
+                edge_vect_e=self.edge_vect_e,  # type: ignore
+                edge_vect_s=self.edge_vect_s,  # type: ignore
+                edge_vect_n=self.edge_vect_n,  # type: ignore
+                es1=self.es1,  # type: ignore
+                ew2=self.ew2,  # type: ignore
             )
         return self._driver_grid_data
 
-    def set_grid_data(self, grid_data: GridData):
+    def set_grid_data(self, grid_data: GridData) -> None:
         self._grid_data = grid_data
 
-    def make_grid_data(self, npx, npy, npz, communicator, backend: Backend):
+    def make_grid_data(
+        self, npx: int, npy: int, npz: int, communicator: Communicator, backend: Backend
+    ) -> None:
         metric_terms = MetricTerms.from_tile_sizing(
             npx=npx, npy=npy, npz=npz, communicator=communicator, backend=backend
         )

--- a/ndsl/stencils/testing/grid.py
+++ b/ndsl/stencils/testing/grid.py
@@ -164,41 +164,6 @@ class Grid:
             self._quantity_factory = QuantityFactory(self.sizer, backend=self.backend)
         return self._quantity_factory
 
-    def make_quantity(
-        self,
-        array,
-        dims=(I_DIM, J_DIM, K_DIM),
-        units="Unknown",
-        origin=None,
-        extent=None,
-    ):
-        if origin is None:
-            origin = self.compute_origin()
-        if extent is None:
-            extent = self.domain_shape_compute()
-        return Quantity(array, dims=dims, units=units, origin=origin, extent=extent)
-
-    def quantity_dict_update(
-        self,
-        data_dict,
-        varname,
-        dims=(I_DIM, J_DIM, K_DIM),
-        units="Unknown",
-    ):
-        data_dict[varname + "_quantity"] = self.quantity_wrap(
-            data_dict[varname], dims=dims, units=units
-        )
-
-    def quantity_wrap(
-        self,
-        data,
-        dims=(I_DIM, J_DIM, K_DIM),
-        units="unknown",
-    ):
-        origin = self.sizer.get_origin(dims)
-        extent = self.sizer.get_extent(dims)
-        return Quantity(data, dims=dims, units=units, origin=origin, extent=extent)
-
     def global_to_local_1d(self, global_value, subtile_index, subtile_length):
         return int(global_value - subtile_index * subtile_length)
 

--- a/ndsl/stencils/testing/savepoint.py
+++ b/ndsl/stencils/testing/savepoint.py
@@ -5,7 +5,7 @@ from typing import Any, Protocol
 import numpy as np
 import xarray as xr
 
-from ndsl.stencils.testing.grid import Grid  # type: ignore
+from ndsl.stencils.testing.grid import Grid
 
 
 def dataset_to_dict(ds: xr.Dataset) -> dict[str, np.ndarray | float | int]:

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -9,7 +9,7 @@ from ndsl.config import Backend
 from ndsl.dsl.stencil import StencilFactory
 from ndsl.optional_imports import cupy as cp
 from ndsl.quantity import Quantity
-from ndsl.stencils.testing.grid import Grid  # type: ignore
+from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 
 


### PR DESCRIPTION
# Description

Add type hints to the `Grid` class used in translate tests. This is not perfect, but at least we have now most types. Lots of magic happening here and if we don't have minimal type hint and type checking we'll missing things like the `Quantity` update in the first commit.

## How has this been tested?

All good as long as CI is still green. Locally, `mypy` is happy.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
