### PR TITLE
fix backend default in translate test conftest

### DIFF
--- a/ndsl/stencils/testing/conftest.py
+++ b/ndsl/stencils/testing/conftest.py
@@ -33,7 +33,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--backend",
         action="store",
-        default="st:python:cpu:numpy",
+        default="st:numpy:cpu:IJK",
         help="Backend to execute the test with, can only be one.",
     )
     parser.addoption(


### PR DESCRIPTION
# Description

Found while trying to run translate tests of pyMoist locally in VSCode, which comes here and uses the default backend when it tries to list all the tests (which then fails :()

## How has this been tested?

Locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
