### PR TITLE
[Dace] Default to `BuildAndRun`

### DIFF
--- a/ndsl/dsl/stencil_config.py
+++ b/ndsl/dsl/stencil_config.py
@@ -195,7 +195,7 @@ class StencilConfig(Hashable):
             else DaceConfig(
                 communicator=None,
                 backend=self.compilation_config.backend,
-                orchestration=DaCeOrchestration.Run,
+                orchestration=DaCeOrchestration.BuildAndRun,
             )
         )
         self.backend_opts = {


### PR DESCRIPTION
# Description

The default `DaceConfig` build was flipped to `Run` when `Python` was removed. But `Run` will force looking at the `cache` directory and in two-step init (like Pace) this is too early as we haven't read the configuration entirely yet.

This yet another echo of the (mine) bad design of `DaceConfig`. This PR will help is just a rubber band before we rebuild the entire orchestration build system.

## How has this been tested?

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
