### PR TITLE
cleanup: keep a copy of min/max values in column min/max stencils

### DIFF
--- a/ndsl/stencils/column_operations.py
+++ b/ndsl/stencils/column_operations.py
@@ -17,15 +17,16 @@ def column_max(field, start_index, end_index):
         Returns: [max value, index of max value]
     """
     max_index = start_index
+    max_value = field.at(K=max_index)
     level = start_index
     while level <= end_index:
-        new = field.at(K=level)
-        old = field.at(K=max_index)
-        if new > old:
+        value = field.at(K=level)
+        if value > max_value:
+            max_value = value
             max_index = level
         level += 1
 
-    return field.at(K=max_index), max_index
+    return max_value, max_index
 
 
 @typing.no_type_check
@@ -42,15 +43,16 @@ def column_max_ddim(field, ddim, start_index, end_index):
         Returns: [max value, index of max value]
     """
     max_index = start_index
+    max_value = field.at(K=max_index, ddim=[ddim])
     level = start_index
     while level <= end_index:
-        new = field.at(K=level, ddim=[ddim])
-        old = field.at(K=max_index, ddim=[ddim])
-        if new > old:
+        value = field.at(K=level, ddim=[ddim])
+        if value > max_value:
+            max_value = value
             max_index = level
         level += 1
 
-    return field.at(K=max_index, ddim=[ddim]), max_index
+    return max_value, max_index
 
 
 @typing.no_type_check
@@ -67,15 +69,16 @@ def column_min(field, start_index, end_index):
         Returns: [min value, index of min value]
     """
     min_index = start_index
+    min_value = field.at(K=min_index)
     level = start_index
     while level <= end_index:
-        new = field.at(K=level)
-        old = field.at(K=min_index)
-        if new < old:
+        value = field.at(K=level)
+        if value < min_value:
+            min_value = value
             min_index = level
         level += 1
 
-    return field.at(K=min_index), min_index
+    return min_value, min_index
 
 
 @typing.no_type_check
@@ -92,12 +95,13 @@ def column_min_ddim(field, ddim, start_index, end_index):
         Returns: [min value, index of min value]
     """
     min_index = start_index
+    min_value = field.at(K=min_index, ddim=[ddim])
     level = start_index
     while level <= end_index:
-        new = field.at(K=level, ddim=[ddim])
-        old = field.at(K=min_index, ddim=[ddim])
-        if new < old:
+        value = field.at(K=level, ddim=[ddim])
+        if value < min_value:
+            min_value = value
             min_index = level
         level += 1
 
-    return field.at(K=min_index, ddim=[ddim]), min_index
+    return min_value, min_index


### PR DESCRIPTION
# Description

When finding column min/max index and value, keep a scalar copy of the min/max value to avoid redundant field accesses.

## How has this been tested?

Covered by existing tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
