### PR TITLE
restore the ci  hooks for shield and pace

### DIFF
--- a/.github/workflows/fv3_translate_tests.yaml
+++ b/.github/workflows/fv3_translate_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   fv3_translate_tests:
-    uses: twicki/pyFV3/.github/workflows/translate.yaml@update/numpy_2x
+    uses: NOAA-GFDL/pyFV3/.github/workflows/translate.yaml@develop
     with:
       component_trigger: true
       component_name: NDSL

--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pace_main_tests:
-    uses: floriandeconinck/pace/.github/workflows/main_unit_tests.yaml@update/numpy_2x
+    uses: NOAA-GFDL/pace/.github/workflows/main_unit_tests.yaml@develop
     with:
       component_trigger: true
       component_name: NDSL

--- a/.github/workflows/shield_tests.yaml
+++ b/.github/workflows/shield_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   shield_translate_tests:
-    uses: floriandeconinck/pySHiELD/.github/workflows/translate.yaml@update/numpy_2x
+    uses: NOAA-GFDL/pySHiELD/.github/workflows/translate.yaml@develop
     with:
       component_trigger: true
       component_name: NDSL


### PR DESCRIPTION
# Description

This PR restores the default ci hooks for pyFV3, pySHiELD, and pace. This can be done once all the repos have implemented the changes:
- [X] Pace: https://github.com/NOAA-GFDL/pace/pull/182
- [X] pyFV3 https://github.com/NOAA-GFDL/pyFV3/pull/122
- [X] pySHiELD https://github.com/NOAA-GFDL/pySHiELD/pull/91

The reason for hooking the CI to branchesin the first place was to allow NDSL https://github.com/NOAA-GFDL/NDSL/pull/415 to make a hard breaking change.

## How has this been tested?

All good as long as CI is green again.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
