### PR TITLE
ci: move `mypy` configuration to `pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,8 @@ repos:
     rev: v1.18.2
     hooks:
       - id: mypy
-        name: mypy-ndsl
         args: ["--config-file", "pyproject.toml"]
         additional_dependencies: [types-PyYAML]
-        files: ndsl
-        exclude: |
-          (?x)^(
-          ndsl/ndsl/gt4py_utils.py |
-          )$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/examples/mpi/global_timings.py
+++ b/examples/mpi/global_timings.py
@@ -1,17 +1,18 @@
 import contextlib
+from typing import Any, Generator
 
 import numpy as np
 from mpi4py import MPI
 
-from ndsl import Timer
+from ndsl.performance import Timer
 
 
 @contextlib.contextmanager
-def nullcontext():
+def nullcontext() -> Generator[None, Any, None]:
     yield
 
 
-def print_global_timings(times, comm, root=0):
+def print_global_timings(timer: Timer, comm: MPI.Comm, root: int = 0) -> None:
     is_root = comm.Get_rank() == root
     recvbuf = np.array(0.0)
     for name, value in timer.times.items():
@@ -45,4 +46,4 @@ if __name__ == "__main__":
     comm = MPI.COMM_WORLD
     # timer.times is a dictionary giving you the total time in seconds spent on each
     # operation
-    print_global_timings(timer.times, comm)
+    print_global_timings(timer, comm)

--- a/examples/mpi/zarr_monitor.py
+++ b/examples/mpi/zarr_monitor.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any
 
 import cftime
 import numpy as np
@@ -10,16 +11,16 @@ from ndsl import (
     QuantityFactory,
     SubtileGridSizer,
     TilePartitioner,
-    ZarrMonitor,
 )
 from ndsl.config import backend_python
 from ndsl.constants import I_DIM, J_DIM, K_DIM
+from ndsl.monitor import ZarrMonitor
 
 
 OUTPUT_PATH = "output/zarr_monitor.zarr"
 
 
-def get_example_state(time):
+def get_example_state(time: cftime.DatetimeJulian) -> dict[str, Any]:
     sizer = SubtileGridSizer(
         nx=48, ny=48, nz=70, n_halo=3, data_dimensions={}, backend=backend_python
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,13 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
+ignore_errors = true
+module = [
+  # TODO: fix tests later
+  "tests.*"
+]
+
+[[tool.mypy.overrides]]
 disallow_incomplete_defs = false
 disallow_untyped_defs = false
 module = [


### PR DESCRIPTION
# Description

The configuration for `mpyp` was split between `.pre-commit-config.yaml` and `pyproject.toml`. This PR moves the config completely into `pyproject.toml`.

In the `.pre-commit-config.yaml`, there was a file filter for `mypy` to only check the `ndsl/` source folder. This restriction was lifted and (type) issues in the `examples/` folder were fixed. The `tests/` folder will be fixed in a subsequent PR.

## How has this been tested?

All good as long as CI is green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
