### PR TITLE
[Orchestration] Add `NDSL_VERBOSE_ORCHESTRATION` 

### DIFF
--- a/ndsl/dsl/dace/build.py
+++ b/ndsl/dsl/dace/build.py
@@ -27,6 +27,7 @@ def write_build_info(
     sdfg: SDFG,
     layout: tuple[int, int],
     resolution_per_tile: list[int],
+    memory_report: str,
     backend: Backend,
 ) -> None:
     """Write down all relevant information on the build to identify
@@ -41,6 +42,9 @@ def write_build_info(
         build_info_read.write(f"{backend}\n")
         build_info_read.write(f"{str(layout)}\n")
         build_info_read.write(f"{str(resolution_per_tile)}\n")
+
+    with open(f"{path_to_sdfg_dir}/memory_report.txt", "w") as f:
+        f.write(memory_report)
 
 
 ################################################

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -29,12 +29,14 @@ if TYPE_CHECKING:
 DEACTIVATE_DISTRIBUTED_DACE_COMPILE = False
 
 
-def _debug_dace_orchestration() -> bool:
+def _sync_gpu_option() -> bool:
     """
+    Force synchronize after each kernel call.
+
     Debugging Dace orchestration deeper can be done by turning on `syncdebug`.
     We control this Dace configuration below with our own override.
     """
-    return os.getenv("NDSL_DACE_DEBUG", "False") == "True"
+    return os.getenv("NDSL_DACE_FORCE_SYNC_GPU", "False") == "True"
 
 
 def _is_corner(rank: int, partitioner: Partitioner) -> bool:
@@ -203,6 +205,11 @@ class DaceConfig:
         else:
             self._orchestrate = orchestration
 
+        # Verbose orchestration optimization
+        self.verbose_orchestration = (
+            os.getenv("NDSL_VERBOSE_ORCHESTRATION", "False") == "True"
+        )
+
         # We hijack the optimization level of GT4Py because we don't
         # have the configuration at NDSL level, but we do use the GT4Py
         # level
@@ -323,7 +330,7 @@ class DaceConfig:
 
             # Enable to debug GPU failures
             dace.config.Config.set(
-                "compiler", "cuda", "syncdebug", value=_debug_dace_orchestration()
+                "compiler", "cuda", "syncdebug", value=_sync_gpu_option()
             )
 
             if NDSL_GLOBAL_PRECISION == 32:

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -205,9 +205,12 @@ class DaceConfig:
         else:
             self._orchestrate = orchestration
 
-        # Verbose orchestration optimization
+        # Verbose optimizations
         self.verbose_orchestration = (
             os.getenv("NDSL_VERBOSE_ORCHESTRATION", "False") == "True"
+        )
+        self.verbose_schedule_tree_optimizations = (
+            os.getenv("NDSL_VERBOSE_SCHEDULE_TREE_OPTIMIZATIONS", "False") == "True"
         )
 
         # We hijack the optimization level of GT4Py because we don't

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -178,10 +178,12 @@ def _build_sdfg(
                 # Break all loops into uni-dimensional loops to simplify optimizations
                 sdfg.apply_transformations_repeated(MapExpansion, validate=True)
                 stree = sdfg.as_schedule_tree()
-                with open(
-                    os.path.abspath(f"{sdfg.build_folder}/03-pre_opt.stree.txt"), "w"
-                ) as f:
-                    f.write(stree.as_string())
+                if config.verbose_orchestration:
+                    with open(
+                        os.path.abspath(f"{sdfg.build_folder}/02-pre_opt.stree.txt"),
+                        "w+",
+                    ) as f:
+                        f.write(stree.as_string())
 
             with DaCeProgress(config, "Schedule Tree: optimization"):
                 passes = []
@@ -219,17 +221,21 @@ def _build_sdfg(
                     raise NotImplementedError(
                         f"Loop order {backend_name.loop_order} has no schedule tree pipeline"
                     )
-                CPUPipeline(passes=passes).run(stree, verbose=True)
-                with open(
-                    os.path.abspath(f"{sdfg.build_folder}/04-post_opt.stree.txt"), "w"
-                ) as f:
-                    f.write(stree.as_string())
+                CPUPipeline(passes=passes, cache_directory=sdfg.build_folder).run(
+                    stree, verbose=config.verbose_schedule_tree_optimizations
+                )
+                if config.verbose_orchestration:
+                    with open(
+                        os.path.abspath(f"{sdfg.build_folder}/03-post_opt.stree.txt"),
+                        "w+",
+                    ) as f:
+                        f.write(stree.as_string())
 
             with DaCeProgress(config, "Schedule Tree: go back to SDFG"):
                 sdfg = stree.as_sdfg(skip={"ScalarToSymbolPromotion"})
                 if config.verbose_orchestration:
                     sdfg.save(
-                        os.path.abspath(f"{sdfg.build_folder}/05-from_stree.sdfgz"),
+                        os.path.abspath(f"{sdfg.build_folder}/04-from_stree.sdfgz"),
                         compress=True,
                     )
 

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -179,7 +179,7 @@ def _build_sdfg(
                 sdfg.apply_transformations_repeated(MapExpansion, validate=True)
                 stree = sdfg.as_schedule_tree()
                 with open(
-                    os.path.abspath(f"{sdfg.build_folder}/03-pre_opt.stree.txt")
+                    os.path.abspath(f"{sdfg.build_folder}/03-pre_opt.stree.txt"), "w"
                 ) as f:
                     f.write(stree.as_string())
 
@@ -221,7 +221,7 @@ def _build_sdfg(
                     )
                 CPUPipeline(passes=passes).run(stree, verbose=True)
                 with open(
-                    os.path.abspath(f"{sdfg.build_folder}/04-post_opt.stree.txt")
+                    os.path.abspath(f"{sdfg.build_folder}/04-post_opt.stree.txt"), "w"
                 ) as f:
                     f.write(stree.as_string())
 

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -160,7 +160,8 @@ def _build_sdfg(
 
         if config.verbose_orchestration:
             sdfg.save(
-                os.path.abspath(f"{sdfg.build_folder}/00-no-opt.sdfgz"), compress=True
+                os.path.abspath(f"{sdfg.build_folder}/00-combined_from_stencils.sdfgz"),
+                compress=True,
             )
 
         with DaCeProgress(config, "Simplify (1)"):
@@ -177,6 +178,10 @@ def _build_sdfg(
                 # Break all loops into uni-dimensional loops to simplify optimizations
                 sdfg.apply_transformations_repeated(MapExpansion, validate=True)
                 stree = sdfg.as_schedule_tree()
+                with open(
+                    os.path.abspath(f"{sdfg.build_folder}/03-pre_opt.stree.txt")
+                ) as f:
+                    f.write(stree.as_string())
 
             with DaCeProgress(config, "Schedule Tree: optimization"):
                 passes = []
@@ -215,12 +220,16 @@ def _build_sdfg(
                         f"Loop order {backend_name.loop_order} has no schedule tree pipeline"
                     )
                 CPUPipeline(passes=passes).run(stree, verbose=True)
+                with open(
+                    os.path.abspath(f"{sdfg.build_folder}/04-post_opt.stree.txt")
+                ) as f:
+                    f.write(stree.as_string())
 
             with DaCeProgress(config, "Schedule Tree: go back to SDFG"):
                 sdfg = stree.as_sdfg(skip={"ScalarToSymbolPromotion"})
                 if config.verbose_orchestration:
                     sdfg.save(
-                        os.path.abspath(f"{sdfg.build_folder}/02-stree_opt.sdfgz"),
+                        os.path.abspath(f"{sdfg.build_folder}/05-from_stree.sdfgz"),
                         compress=True,
                     )
 
@@ -258,7 +267,7 @@ def _build_sdfg(
             _simplify(sdfg)
             if config.verbose_orchestration:
                 sdfg.save(
-                    os.path.abspath(f"{sdfg.build_folder}/03-simplify_2.sdfgz"),
+                    os.path.abspath(f"{sdfg.build_folder}/06-simplify_2.sdfgz"),
                     compress=True,
                 )
         # Move all memory that can be into a pool to lower memory pressure for GPU
@@ -290,7 +299,6 @@ def _build_sdfg(
         # Compile
         with DaCeProgress(config, "Codegen & compile"):
             sdfg.compile()
-        write_build_info(sdfg, config.layout, config.tile_resolution, backend_name)
 
         # Printing analysis of the compiled SDFG
         with DaCeProgress(config, "Build finished. Running memory static analysis"):
@@ -298,6 +306,11 @@ def _build_sdfg(
                 sdfg, memory_static_analysis(sdfg), False
             )
             ndsl_log.info(f"{DaCeProgress.default_prefix(config)} {report}")
+
+        # Store build info in the common cache directory
+        write_build_info(
+            sdfg, config.layout, config.tile_resolution, report, backend_name
+        )
 
     # Compilation done.
     # On Build: all ranks sync, then exit.

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numbers
 import os
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import Any
 
 from dace import SDFG, CompiledSDFG
@@ -221,7 +222,7 @@ def _build_sdfg(
                     raise NotImplementedError(
                         f"Loop order {backend_name.loop_order} has no schedule tree pipeline"
                     )
-                CPUPipeline(passes=passes, cache_directory=sdfg.build_folder).run(
+                CPUPipeline(passes=passes, cache_directory=Path(sdfg.build_folder)).run(
                     stree, verbose=config.verbose_schedule_tree_optimizations
                 )
                 if config.verbose_orchestration:
@@ -273,7 +274,7 @@ def _build_sdfg(
             _simplify(sdfg)
             if config.verbose_orchestration:
                 sdfg.save(
-                    os.path.abspath(f"{sdfg.build_folder}/06-simplify_2.sdfgz"),
+                    os.path.abspath(f"{sdfg.build_folder}/05-simplify_2.sdfgz"),
                     compress=True,
                 )
         # Move all memory that can be into a pool to lower memory pressure for GPU

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -158,8 +158,18 @@ def _build_sdfg(
                             repl_dict[sym] = val
                     my_sdfg.replace_dict(repl_dict)
 
+        if config.verbose_orchestration:
+            sdfg.save(
+                os.path.abspath(f"{sdfg.build_folder}/00-no-opt.sdfgz"), compress=True
+            )
+
         with DaCeProgress(config, "Simplify (1)"):
             _simplify(sdfg)
+            if config.verbose_orchestration:
+                sdfg.save(
+                    os.path.abspath(f"{sdfg.build_folder}/01-simplify_1.sdfgz"),
+                    compress=True,
+                )
 
         if _INTERNAL__SCHEDULE_TREE_OPTIMIZATION:
             # Here be 🐉 - but tests exists in test_optimization.py
@@ -208,6 +218,11 @@ def _build_sdfg(
 
             with DaCeProgress(config, "Schedule Tree: go back to SDFG"):
                 sdfg = stree.as_sdfg(skip={"ScalarToSymbolPromotion"})
+                if config.verbose_orchestration:
+                    sdfg.save(
+                        os.path.abspath(f"{sdfg.build_folder}/02-stree_opt.sdfgz"),
+                        compress=True,
+                    )
 
         # Make the transients array persistents
         if config.is_gpu_backend():
@@ -241,7 +256,11 @@ def _build_sdfg(
 
         with DaCeProgress(config, "Simplify (2)"):
             _simplify(sdfg)
-
+            if config.verbose_orchestration:
+                sdfg.save(
+                    os.path.abspath(f"{sdfg.build_folder}/03-simplify_2.sdfgz"),
+                    compress=True,
+                )
         # Move all memory that can be into a pool to lower memory pressure for GPU
         # We skip this memory optimization for CPU because we don't have a memory
         # pool available yet (DaCe v1)

--- a/ndsl/dsl/dace/stree/pipeline.py
+++ b/ndsl/dsl/dace/stree/pipeline.py
@@ -26,8 +26,11 @@ class StreePipeline(ABC):
 
 class CPUPipeline(StreePipeline):
     def __init__(
-        self, passes: list[stree.ScheduleNodeTransformer] | None = None
+        self,
+        passes: list[stree.ScheduleNodeTransformer] | None = None,
+        cache_directory: str = "./",
     ) -> None:
+        self.cache_directory = cache_directory
         self.passes = (
             passes if passes is not None else [CartesianAxisMerge(AxisIterator._K)]
         )
@@ -45,11 +48,11 @@ class CPUPipeline(StreePipeline):
     ) -> stree.ScheduleTreeRoot:
         for i, p in enumerate(self.passes):
             if verbose:
-                path = f"pass{i}_{p}.txt"
+                path = f"{self.cache_directory}/stree_pass{i}_{p}.txt"
                 ndsl_log_on_rank_0.info(f"[Stree OPT] {p} (saving {path} after)")
             p.visit(stree)
             if verbose:
-                with open(path, "w") as f:
+                with open(path, "w+") as f:
                     f.write(stree.as_string())
 
         return stree
@@ -57,8 +60,11 @@ class CPUPipeline(StreePipeline):
 
 class GPUPipeline(StreePipeline):
     def __init__(
-        self, passes: list[stree.ScheduleNodeTransformer] | None = None
+        self,
+        passes: list[stree.ScheduleNodeTransformer] | None = None,
+        cache_directory: str = "./",
     ) -> None:
+        self.cache_directory = cache_directory
         self.passes = passes if passes else []
 
     def __repr__(self) -> str:
@@ -72,9 +78,12 @@ class GPUPipeline(StreePipeline):
         stree: stree.ScheduleTreeRoot,
         verbose: bool = False,
     ) -> stree.ScheduleTreeRoot:
-        for p in self.passes:
+        for i, p in enumerate(self.passes):
             if verbose:
-                print(f"[Stree OPT] {p}")
+                path = f"{self.cache_directory}/stree_pass{i}_{p}.txt"
             p.visit(stree)
+            if verbose:
+                with open(path, "w+") as f:
+                    f.write(stree.as_string())
 
         return stree

--- a/ndsl/dsl/dace/stree/pipeline.py
+++ b/ndsl/dsl/dace/stree/pipeline.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from pathlib import Path
 
 import dace.sdfg.analysis.schedule_tree.treenodes as stree
 
@@ -6,40 +6,24 @@ from ndsl.dsl.dace.stree.optimizations import AxisIterator, CartesianAxisMerge
 from ndsl.logging import ndsl_log_on_rank_0
 
 
-class StreePipeline(ABC):
-    @abstractmethod
-    def __hash__(self) -> int:
-        raise NotImplementedError("Missing implementation of __hash__")
-
-    @abstractmethod
-    def __repr__(self) -> str:
-        raise NotImplementedError("Missing implementation of __repr__")
-
-    @abstractmethod
-    def run(
-        self,
-        stree: stree.ScheduleTreeRoot,
-        verbose: bool = False,
-    ) -> stree.ScheduleTreeRoot:
-        raise NotImplementedError("Missing implementation of run")
-
-
-class CPUPipeline(StreePipeline):
+class StreePipeline:
     def __init__(
         self,
-        passes: list[stree.ScheduleNodeTransformer] | None = None,
-        cache_directory: str = "./",
+        *,
+        passes: list[stree.ScheduleNodeTransformer],
+        cache_directory: Path | None = None,
     ) -> None:
-        self.cache_directory = cache_directory
-        self.passes = (
-            passes if passes is not None else [CartesianAxisMerge(AxisIterator._K)]
-        )
+        if cache_directory is None:
+            cache_directory = Path()
 
-    def __repr__(self) -> str:
-        return str([type(p) for p in self.passes])
+        self.cache_directory = cache_directory
+        self.passes = passes
 
     def __hash__(self) -> int:
         return hash(repr(self))
+
+    def __repr__(self) -> str:
+        return str([type(p) for p in self.passes])
 
     def run(
         self,
@@ -48,42 +32,40 @@ class CPUPipeline(StreePipeline):
     ) -> stree.ScheduleTreeRoot:
         for i, p in enumerate(self.passes):
             if verbose:
-                path = f"{self.cache_directory}/stree_pass{i}_{p}.txt"
+                path = self.cache_directory / f"pass{i}_{p}.txt"
                 ndsl_log_on_rank_0.info(f"[Stree OPT] {p} (saving {path} after)")
+
             p.visit(stree)
+
             if verbose:
                 with open(path, "w+") as f:
                     f.write(stree.as_string())
 
         return stree
+
+
+class CPUPipeline(StreePipeline):
+    def __init__(
+        self,
+        *,
+        passes: list[stree.ScheduleNodeTransformer] | None = None,
+        cache_directory: Path | None = None,
+    ) -> None:
+        super().__init__(
+            passes=(
+                passes if passes is not None else [CartesianAxisMerge(AxisIterator._K)]
+            ),
+            cache_directory=cache_directory,
+        )
 
 
 class GPUPipeline(StreePipeline):
     def __init__(
         self,
         passes: list[stree.ScheduleNodeTransformer] | None = None,
-        cache_directory: str = "./",
+        cache_directory: Path | None = None,
     ) -> None:
-        self.cache_directory = cache_directory
-        self.passes = passes if passes else []
-
-    def __repr__(self) -> str:
-        return str([type(p) for p in self.passes])
-
-    def __hash__(self) -> int:
-        return hash(repr(self))
-
-    def run(
-        self,
-        stree: stree.ScheduleTreeRoot,
-        verbose: bool = False,
-    ) -> stree.ScheduleTreeRoot:
-        for i, p in enumerate(self.passes):
-            if verbose:
-                path = f"{self.cache_directory}/stree_pass{i}_{p}.txt"
-            p.visit(stree)
-            if verbose:
-                with open(path, "w+") as f:
-                    f.write(stree.as_string())
-
-        return stree
+        super().__init__(
+            passes=passes if passes is not None else [],
+            cache_directory=cache_directory,
+        )


### PR DESCRIPTION
# Description

The env var will control a somewhat step-by-step save of SDFGs as it goes down the orchestration optimization. The SDFGs are saved in the same folder than the central SDFG cache (`.dacecache` by default)

Also:
 - Rename option for force GPU sync in orchestration

## How has this been tested?

No-op - debug only.
