### PR TITLE
refactor: remove deprecated ` zeros()` in `gt4py_utils` 

### DIFF
--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Callable, Sequence
 from functools import wraps
 from typing import Any
@@ -447,15 +446,6 @@ def asarray(array, to_type=np.ndarray, dtype=None, order=None):
             return np.asarray(array, dtype, order)
         else:
             return cp.asarray(array, dtype, order)
-
-
-def zeros(shape, dtype=Float, *, backend: Backend):
-    warnings.warn(
-        "gt4py_utils.zeros() is deprecated. Use `zeros()` from `ndsl.xumpy` instead.",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    return xumpy.zeros(shape, backend, dtype)
 
 
 def sum(array, axis=None, dtype=Float, out=None, keepdims=False):


### PR DESCRIPTION
# Description

The function was deprecated with the 2026.03.00 release of NDSL. We plan to remove it for the next release. Users should use `xumpy.zeros()`  as indicated in the deprecation note.

## How has this been tested?

All good as long as CI is still green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
