### PR TITLE
[Experimental | Debugger] Save all stencils

### DIFF
--- a/ndsl/debug/config.py
+++ b/ndsl/debug/config.py
@@ -7,11 +7,14 @@ When loading, the configuration will be searched in the global environment varia
 Configuration is a yaml file of the shape
 ```yaml
 stencils_or_class:
-    - copy_corners_x_nord
-    - copy_corners_y_nord
-    - DGridShallowWaterLagrangianDynamics.__call__
+    - stencil_name
+    - ClassName.orchestrated_method
+    - ClassName.__call__
 track_parameter_by_name:
-    - fy
+    - name_of_variable
+save_all_stencils: False
+dir_name: ./my/local/path
+save_compute_domain_only: False
 ```
 
 Global variable:

--- a/ndsl/debug/debugger.py
+++ b/ndsl/debug/debugger.py
@@ -107,7 +107,8 @@ class Debugger:
             xr.Dataset(data_arrays).to_netcdf(path)
         except ValueError as e:
             ndsl_log.error(f"[DebugInfo] Failure to save {savename}: {e}")
-        self.step += 1
+        if not is_in:
+            self.step += 1
 
     def increment_call_count(self, savename: str) -> None:
         """Increment the call count for this savename"""

--- a/ndsl/debug/debugger.py
+++ b/ndsl/debug/debugger.py
@@ -22,9 +22,11 @@ class Debugger:
     track_parameter_by_name: list[str] = dataclasses.field(default_factory=list)
     save_compute_domain_only: bool = False
     dir_name: str = "./"
+    save_all_stencils: bool = False
 
     # Runtime data
     rank: int = -1
+    step: int = 0
     calls_count: dict[str, int] = dataclasses.field(default_factory=dict)
     track_parameter_count: dict[str, int] = dataclasses.field(default_factory=dict)
 
@@ -78,7 +80,7 @@ class Debugger:
 
         Note: Unknown types in the dictionary won't be saved.
         """
-        if savename not in self.stencils_or_class:
+        if savename not in self.stencils_or_class and not self.save_all_stencils:
             return
 
         data_arrays = {}
@@ -99,12 +101,13 @@ class Debugger:
         path = pathlib.Path(f"{self.dir_name}/debug/savepoints/R{self.rank}/")
         os.makedirs(path, exist_ok=True)
         path = pathlib.Path(
-            f"{path}/{savename}-Call{call_count}-{'In' if is_in else 'Out'}.nc4"
+            f"{path}/S{self.step:06d}_{savename}-Call{call_count}-{'In' if is_in else 'Out'}.nc4"
         )
         try:
             xr.Dataset(data_arrays).to_netcdf(path)
         except ValueError as e:
             ndsl_log.error(f"[DebugInfo] Failure to save {savename}: {e}")
+        self.step += 1
 
     def increment_call_count(self, savename: str) -> None:
         """Increment the call count for this savename"""

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -68,7 +68,7 @@ class Quantity:
         ):
             raise ValueError(
                 f"Floating-point data type mismatch, asked for {data.dtype}, "
-                f"Pace configured for {Float}"
+                f"NDSL configured for {Float}"
             )
         if origin is None:
             origin = (0,) * len(dims)  # default origin at origin of array


### PR DESCRIPTION
# Description

Add `save_all_stencils` to the config that will save all stencils. Prefix the netcdf with `S######` before the name, with the number incrementing after saving the `Out` file.

Also:
- better docs
- replace a mention of "Pace" with NDSL

## How has this been tested?

Debugger is an experimental feature without coverage for now.

