### PR TITLE
[QOL | Translate] Sort one line report and add "all" as a threshold hook

### DIFF
--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -38,7 +38,7 @@ def process_override(threshold_overrides, testobj, test_name, backend: Backend):
         for spec in override:
             if "platform" not in spec:
                 spec["platform"] = platform()
-            if "backend" not in spec:
+            if "backend" not in spec or spec["backend"] == "all":
                 spec["backend"] = backend
         matches = [
             spec
@@ -288,7 +288,7 @@ def test_sequential_savepoint(
 
     # Reporting & data save
     if not case.no_report:
-        _report_results(case.savepoint_name, case.grid.rank, results)
+        _report_results(case.savepoint_name, case.grid.rank, ndsl_backend, results)
     if len(failing_names) > 0 and not case.no_report:
         get_thresholds(case.testobj, input_data=original_input_data)
         os.makedirs(OUTDIR, exist_ok=True)
@@ -430,7 +430,7 @@ def test_parallel_savepoint(
             passing_names.append(failing_names.pop())
 
     # Reporting & data save
-    _report_results(case.savepoint_name, case.grid.rank, results)
+    _report_results(case.savepoint_name, case.grid.rank, ndsl_backend, results)
     if len(failing_names) > 0:
         os.makedirs(OUTDIR, exist_ok=True)
         nct_filename = os.path.join(
@@ -462,15 +462,21 @@ def test_parallel_savepoint(
 def _report_results(
     savepoint_name: str,
     rank: int,
+    backend: Backend,
     results: dict[str, BaseMetric],
 ) -> None:
     detail_dir = f"{OUTDIR}/details"
     os.makedirs(detail_dir, exist_ok=True)
 
     # Summary
+    header = f"{savepoint_name} w/ f{backend.as_humanly_readable()}"
+    lines = []
+    for varname, metric in results.items():
+        lines.append(f"{varname}: {metric.one_line_report()}")
+    lines.sort()
+    lines.insert(0, header)
     with open(f"{OUTDIR}/summary-{savepoint_name}-{rank}.log", "w") as f:
-        for varname, metric in results.items():
-            f.write(f"{varname}: {metric.one_line_report()}\n")
+        f.write("\n".join(lines))
 
     # Detailed log
     for varname, metric in results.items():

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -5,7 +5,7 @@ import numpy as np
 import numpy.typing as npt
 
 
-def _fixed_width_float_16e(value: np.floating[Any]) -> str:
+def _fixed_width_float_16e(value: Any) -> str:
     """Account for extra '-' character"""
     if value > 0:
         return f" {value:.16e}"
@@ -13,7 +13,7 @@ def _fixed_width_float_16e(value: np.floating[Any]) -> str:
         return f"{value:.16e}"
 
 
-def _fixed_width_float_2e(value: np.floating[Any]) -> str:
+def _fixed_width_float_2e(value: Any) -> str:
     """Account for extra '-' character"""
     if value > 0:
         return f" {value:.2e}"
@@ -29,7 +29,7 @@ class BaseMetric(ABC):
     ):
         self.references = np.squeeze(np.atleast_1d(reference_values))
         self.computed = np.squeeze(np.atleast_1d(computed_values))
-        self.check = False
+        self.check: np.bool[bool] = np.bool(False)
 
     @abstractmethod
     def __str__(self) -> str: ...
@@ -254,7 +254,7 @@ class MultiModalFloatMetric(BaseMetric):
             self.ulp_threshold.value = ulp_override
 
         self.success = self._compute_all_metrics()
-        self.check = np.all(self.success)
+        self.check = self.success.all()
         self.sort_report = sort_report
 
         # We might have sliced outputs in the translate test. Rather than funnel the slicing
@@ -339,8 +339,6 @@ class MultiModalFloatMetric(BaseMetric):
             return f"❌ Numerical failures: {failed_indices}/{all_indices} failed - metric: {metric_thresholds}"
 
     def report(self, file_path: str | None = None) -> list[str]:
-        report = []
-        report.append(self.one_line_report())
         failed_indices = np.logical_not(self.success).nonzero()
         # List all errors to terminal and file
         bad_indices_count = len(failed_indices[0])
@@ -389,7 +387,7 @@ class MultiModalFloatMetric(BaseMetric):
         elif self.sort_report == "relative":
             indices_flatten = np.argsort(self.relative_distance.flatten())
         elif self.sort_report == "index":
-            indices_flatten = list(range(self.ulp_distance.size - 1, -1, -1))
+            indices_flatten = np.array(list(range(self.ulp_distance.size - 1, -1, -1)))
         else:
             RuntimeError(
                 f"[Translate test] Unknown {self.sort_report} report sorting option."


### PR DESCRIPTION
# Description

- Allow "all" for backend overrides for multimodal override threshold file
- Sort one line report by variable name and add backend at the top of the header
- Some linting for numpy 2.0

## How has this been tested?

CI will cover.
