### PR TITLE
cleanup: type fixes in `Communicator` classes

### DIFF
--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -78,12 +78,12 @@ class Communicator(abc.ABC, Generic[P]):
 
     @property
     def rank(self) -> int:
-        """rank of the current process within this communicator"""
+        """Rank of the current process within this communicator."""
         return self.comm.Get_rank()
 
     @property
     def size(self) -> int:
-        """Total number of ranks in this communicator"""
+        """Total number of ranks in this communicator."""
         return self.comm.Get_size()
 
     def _maybe_force_cpu(self, module: ModuleType) -> ModuleType:
@@ -104,7 +104,7 @@ class Communicator(abc.ABC, Generic[P]):
     def _create_all_reduce_quantity(
         self, input_metadata: QuantityMetadata, input_data: Any
     ) -> Quantity:
-        """Create a Quantity for all_reduce data and metadata"""
+        """Create a Quantity for all_reduce data and metadata."""
         all_reduce_quantity = Quantity(
             input_data,
             dims=input_metadata.dims,
@@ -649,7 +649,7 @@ def bcast_metadata(comm: CommABC, array: Quantity):  # type: ignore[no-untyped-d
 
 
 class TileCommunicator(Communicator[TilePartitioner]):
-    """Performs communications within a single tile or region of a tile"""
+    """Performs communications within a single tile or region of a tile."""
 
     def __init__(
         self,
@@ -666,7 +666,7 @@ class TileCommunicator(Communicator[TilePartitioner]):
             force_cpu: force all communication to go through central memory
             timer: Time communication operations.
         """
-        super().__init__(comm, partitioner, force_cpu=force_cpu, timer=timer)
+        super().__init__(comm, partitioner, force_cpu, timer)
 
     @classmethod
     def from_layout(
@@ -676,8 +676,7 @@ class TileCommunicator(Communicator[TilePartitioner]):
         force_cpu: bool = False,
         timer: Timer | None = None,
     ) -> TileCommunicator:
-        partitioner = TilePartitioner(layout=layout)
-        return cls(comm=comm, partitioner=partitioner, force_cpu=force_cpu, timer=timer)
+        return cls(comm, TilePartitioner(layout=layout), force_cpu, timer)
 
     @property
     def tile(self) -> TileCommunicator:
@@ -763,7 +762,7 @@ class TileCommunicator(Communicator[TilePartitioner]):
 
 
 class CubedSphereCommunicator(Communicator[CubedSpherePartitioner]):
-    """Performs communications within a cubed sphere"""
+    """Performs communications within a cubed sphere."""
 
     _tile_communicator: TileCommunicator | None
 
@@ -810,21 +809,19 @@ class CubedSphereCommunicator(Communicator[CubedSpherePartitioner]):
 
     @property
     def tile(self) -> TileCommunicator:
-        """Communicator for within a tile"""
+        """Communicator for within a tile."""
         if self._tile_communicator is None:
-            self._initialize_tile_communicator()
-        return cast(TileCommunicator, self._tile_communicator)
+            tile_comm = self.comm.Split(
+                color=self.partitioner.tile_index(self.rank), key=self.rank
+            )
+            self._tile_communicator = TileCommunicator(tile_comm, self.partitioner.tile)
 
-    def _initialize_tile_communicator(self) -> None:
-        tile_comm = self.comm.Split(
-            color=self.partitioner.tile_index(self.rank), key=self.rank
-        )
-        self._tile_communicator = TileCommunicator(tile_comm, self.partitioner.tile)
+        return self._tile_communicator
 
     def _get_gather_recv_quantity(
         self, global_extent: Sequence[int], send_metadata: QuantityMetadata
     ) -> Quantity:
-        """Initialize a Quantity for use when receiving global data during gather
+        """Initialize a Quantity for use when receiving global data during gather.
 
         Args:
             shape: ndarray shape, numpy-style
@@ -846,7 +843,7 @@ class CubedSphereCommunicator(Communicator[CubedSpherePartitioner]):
     def _get_scatter_recv_quantity(
         self, shape: Sequence[int], send_metadata: QuantityMetadata
     ) -> Quantity:
-        """Initialize a Quantity for use when receiving subtile data during scatter
+        """Initialize a Quantity for use when receiving subtile data during scatter.
 
         Args:
             shape: ndarray shape, numpy-style

--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 from collections.abc import Mapping, Sequence
 from types import ModuleType
-from typing import Any, Self, cast
+from typing import Any, Generic, Self, TypeVar, cast
 
 import numpy as np
 
@@ -42,16 +42,19 @@ def to_numpy(array, dtype=None) -> np.ndarray:  # type: ignore[no-untyped-def]
     return output
 
 
-class Communicator(abc.ABC):
+P = TypeVar("P", bound=Partitioner)
+
+
+class Communicator(abc.ABC, Generic[P]):
     def __init__(
         self,
         comm: CommABC,
-        partitioner: Partitioner,
+        partitioner: P,
         force_cpu: bool = False,
         timer: Timer | None = None,
     ):
         self.comm = comm
-        self.partitioner: Partitioner = partitioner
+        self.partitioner: P = partitioner
         self._force_cpu = force_cpu
         self._boundaries: Mapping[int, Boundary] | None = None
         self._last_halo_tag = 0
@@ -645,7 +648,7 @@ def bcast_metadata(comm: CommABC, array: Quantity):  # type: ignore[no-untyped-d
     return bcast_metadata_list(comm, [array])[0]
 
 
-class TileCommunicator(Communicator):
+class TileCommunicator(Communicator[TilePartitioner]):
     """Performs communications within a single tile or region of a tile"""
 
     def __init__(
@@ -663,10 +666,7 @@ class TileCommunicator(Communicator):
             force_cpu: force all communication to go through central memory
             timer: Time communication operations.
         """
-        super(TileCommunicator, self).__init__(
-            comm, partitioner, force_cpu=force_cpu, timer=timer
-        )
-        self.partitioner: TilePartitioner = partitioner
+        super().__init__(comm, partitioner, force_cpu=force_cpu, timer=timer)
 
     @classmethod
     def from_layout(
@@ -701,8 +701,8 @@ class TileCommunicator(Communicator):
                 "refactoring our code to remove the assumption that any pair "
                 "of ranks only share one boundary"
             )
-        else:
-            return super().start_halo_update(quantity, n_points)
+
+        return super().start_halo_update(quantity, n_points)
 
     def start_vector_halo_update(
         self,
@@ -728,8 +728,8 @@ class TileCommunicator(Communicator):
                 "refactoring our code to remove the assumption that any pair "
                 "of ranks only share one boundary"
             )
-        else:
-            return super().start_vector_halo_update(x_quantity, y_quantity, n_points)
+
+        return super().start_vector_halo_update(x_quantity, y_quantity, n_points)
 
     def start_synchronize_vector_interfaces(
         self, x_quantity: Quantity, y_quantity: Quantity
@@ -758,15 +758,14 @@ class TileCommunicator(Communicator):
                 "refactoring our code to remove the assumption that any pair "
                 "of ranks only share one boundary"
             )
-        else:
-            return super().start_synchronize_vector_interfaces(x_quantity, y_quantity)
+
+        return super().start_synchronize_vector_interfaces(x_quantity, y_quantity)
 
 
-class CubedSphereCommunicator(Communicator):
+class CubedSphereCommunicator(Communicator[CubedSpherePartitioner]):
     """Performs communications within a cubed sphere"""
 
-    timer: Timer
-    partitioner: CubedSpherePartitioner
+    _tile_communicator: TileCommunicator | None
 
     def __init__(
         self,
@@ -794,12 +793,9 @@ class CubedSphereCommunicator(Communicator):
                 f"comm object with only {comm.Get_size()} ranks, are we running "
                 "with mpi and the correct number of ranks?"
             )
-        self._tile_communicator: TileCommunicator | None = None
-        self._force_cpu = force_cpu
-        super(CubedSphereCommunicator, self).__init__(
-            comm, partitioner, force_cpu, timer
-        )
-        self.partitioner: CubedSpherePartitioner = partitioner
+
+        super().__init__(comm, partitioner, force_cpu, timer)
+        self._tile_communicator = None
 
     @classmethod
     def from_layout(
@@ -814,7 +810,7 @@ class CubedSphereCommunicator(Communicator):
 
     @property
     def tile(self) -> TileCommunicator:
-        """communicator for within a tile"""
+        """Communicator for within a tile"""
         if self._tile_communicator is None:
             self._initialize_tile_communicator()
         return cast(TileCommunicator, self._tile_communicator)
@@ -826,43 +822,43 @@ class CubedSphereCommunicator(Communicator):
         self._tile_communicator = TileCommunicator(tile_comm, self.partitioner.tile)
 
     def _get_gather_recv_quantity(
-        self, global_extent: Sequence[int], metadata: QuantityMetadata
+        self, global_extent: Sequence[int], send_metadata: QuantityMetadata
     ) -> Quantity:
         """Initialize a Quantity for use when receiving global data during gather
 
         Args:
             shape: ndarray shape, numpy-style
-            metadata: metadata to the created Quantity
+            send_metadata: metadata to the created Quantity
         """
         # needs to change the quantity dimensions since we add a "tile" dimension,
         # unlike for tile scatter/gather which retains the same dimensions
         recv_quantity = Quantity(
-            metadata.np.zeros(global_extent, dtype=metadata.dtype),
-            dims=(constants.TILE_DIM,) + metadata.dims,
-            units=metadata.units,
-            origin=(0,) + tuple([0 for dim in metadata.dims]),
+            send_metadata.np.zeros(global_extent, dtype=send_metadata.dtype),
+            dims=(constants.TILE_DIM,) + send_metadata.dims,
+            units=send_metadata.units,
+            origin=(0,) + tuple([0 for dim in send_metadata.dims]),
             extent=global_extent,
-            backend=metadata.backend,
+            backend=send_metadata.backend,
             allow_mismatch_float_precision=True,
         )
         return recv_quantity
 
     def _get_scatter_recv_quantity(
-        self, shape: Sequence[int], metadata: QuantityMetadata
+        self, shape: Sequence[int], send_metadata: QuantityMetadata
     ) -> Quantity:
         """Initialize a Quantity for use when receiving subtile data during scatter
 
         Args:
             shape: ndarray shape, numpy-style
-            metadata: metadata to the created Quantity
+            send_metadata: metadata to the created Quantity
         """
         # needs to change the quantity dimensions since we remove a "tile" dimension,
         # unlike for tile scatter/gather which retains the same dimensions
         recv_quantity = Quantity(
-            metadata.np.zeros(shape, dtype=metadata.dtype),
-            dims=metadata.dims[1:],
-            units=metadata.units,
-            backend=metadata.backend,
+            send_metadata.np.zeros(shape, dtype=send_metadata.dtype),
+            dims=send_metadata.dims[1:],
+            units=send_metadata.units,
+            backend=send_metadata.backend,
             allow_mismatch_float_precision=True,
         )
         return recv_quantity

--- a/ndsl/comm/partitioner.py
+++ b/ndsl/comm/partitioner.py
@@ -21,7 +21,7 @@ from ndsl.constants import (
     SOUTHWEST,
     WEST,
 )
-from ndsl.quantity import Quantity, QuantityMetadata
+from ndsl.quantity import QuantityMetadata
 from ndsl.utils import list_by_dims
 
 
@@ -105,15 +105,11 @@ class Partitioner(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def subtile_extent(
-        self,
-        global_metadata: QuantityMetadata,
-        rank: int,
-    ) -> tuple[int, ...]:
+    def subtile_extent(self, metadata: QuantityMetadata, rank: int) -> tuple[int, ...]:
         """Return the shape of a single rank representation for the given dimensions.
 
         Args:
-            global_metadata: quantity metadata.
+            metadata: quantity metadata.
             rank: rank of the process.
 
         Returns:
@@ -160,9 +156,7 @@ class TilePartitioner(Partitioner):
     def total_ranks(self) -> int:
         return self.layout[0] * self.layout[1]
 
-    def global_extent(
-        self, rank_metadata: Quantity | QuantityMetadata
-    ) -> tuple[int, ...]:
+    def global_extent(self, rank_metadata: QuantityMetadata) -> tuple[int, ...]:
         """Return the shape of a full tile representation for the given dimensions.
 
         Args:
@@ -175,23 +169,19 @@ class TilePartitioner(Partitioner):
             rank_metadata.dims, rank_metadata.extent, self.layout
         )
 
-    def subtile_extent(
-        self,
-        global_metadata: QuantityMetadata,
-        rank: int,
-    ) -> tuple[int, ...]:
+    def subtile_extent(self, metadata: QuantityMetadata, rank: int) -> tuple[int, ...]:
         """Return the shape of a single rank representation for the given dimensions.
 
         Args:
-            global_metadata: quantity metadata.
+            metadata: quantity metadata.
             rank: rank of the process.
 
         Returns:
             extent: shape of a single rank representation for the given dimensions.
         """
         rank_slice = rank_slice_from_tile_metadata(
-            global_metadata.dims,
-            extent=global_metadata.extent,
+            metadata.dims,
+            extent=metadata.extent,
             layout=self.layout,
             subtile_index=self.subtile_index(rank),
             edge_interior_ratio=self.edge_interior_ratio,
@@ -617,22 +607,18 @@ class CubedSpherePartitioner(Partitioner):
             rank_metadata.dims, rank_metadata.extent, self.layout
         )
 
-    def subtile_extent(
-        self,
-        cube_metadata: QuantityMetadata,
-        rank: int,
-    ) -> tuple[int, ...]:
+    def subtile_extent(self, metadata: QuantityMetadata, rank: int) -> tuple[int, ...]:
         """Return the shape of a single rank representation for the given dimensions.
 
         Args:
-            cube_metadata: quantity metadata.
+            metadata: quantity metadata.
             rank: rank of the process.
 
         Returns:
             extent: shape of a single rank representation for the given dimensions.
         """
 
-        return self.tile.subtile_extent(cube_metadata, rank)
+        return self.tile.subtile_extent(metadata, rank)
 
     def subtile_slice(
         self,

--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -267,7 +267,7 @@ class MetricTerms:
         # This will carry the public version of the grid
         # for the selected floating point precision
         self._grid = None
-        npx, npy, _ = self._tile_partitioner.global_extent(self._grid_64)
+        npx, npy, _ = self._tile_partitioner.global_extent(self._grid_64.metadata)
         self._npx = npx
         self._npy = npy
         self._npz = self.quantity_factory.sizer.get_extent(K_DIM)[0]

--- a/ndsl/grid/geometry.py
+++ b/ndsl/grid/geometry.py
@@ -606,7 +606,7 @@ def edge_factors(
     edge_s = np.zeros(i_range) + big_number
     edge_e = np.zeros(j_range) + big_number
     edge_w = np.zeros(j_range) + big_number
-    npx, npy, ndims = tile_partitioner.global_extent(grid_quantity)
+    npx, npy, _ = tile_partitioner.global_extent(grid_quantity.metadata)
     slice_x, slice_y = tile_partitioner.subtile_slice(
         rank, grid_quantity.dims, (npx, npy)
     )
@@ -714,7 +714,7 @@ def efactor_a2c_v(
     """
     big_number = 1.0e8
     grid = grid_quantity[:]
-    npx, npy, ndims = tile_partitioner.global_extent(grid_quantity)
+    npx, npy, _ = tile_partitioner.global_extent(grid_quantity.metadata)
     slice_x, slice_y = tile_partitioner.subtile_slice(
         rank, grid_quantity.dims, (npx, npy)
     )


### PR DESCRIPTION
# Description

This PR brings typing fixes for the `Communicator` classes. Python static analysis tools (e.g. `pyright` and `mypy`) are very strict about overloading class members in subclasses, see https://github.com/microsoft/pyright/issues/7840.

This PR suggests to the `Communicator` base class a `Generic` on the partitioner. That allows us to tell static analysis tools that `TileCommunicators` come with a `TilePartitioner` and `CubedSphereCommunicators` come with a `CubedSpherePartitioner`.

Minor other type fixes are based on the fact that overload function signatures should have arguments with the same name as the base class, e.g. `subtile_extent()` of different `Partitioners`.

## How has this been tested?

All good as long as CI is still happy.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
