### PR TITLE
QOL: detect missing dace backends in GT4Py

### DIFF
--- a/ndsl/config/backend.py
+++ b/ndsl/config/backend.py
@@ -76,7 +76,7 @@ class Backend:
     on the frontend code. Additionally, it gives a hint toward the macro-strategy
     for loop ordering (IJK, KJI, etc.) or a more broad intent (debug, numpy).
 
-    For convenience, shorcuts are given to the most common needs (
+    For convenience, shortcuts are given to the most common needs (
     `backend_python`, `backend_cpu`, `backend_gpu`).
     """
 

--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -1,6 +1,7 @@
 # Literal precision for both GT4Py & NDSL
 import os
 import sys
+import warnings
 from typing import Literal
 
 from ndsl.comm.mpi import MPI
@@ -46,5 +47,21 @@ if MPI is not None:
     gt4py.cartesian.config.cache_settings["dir_name"] = os.environ.get(
         "GT_CACHE_DIR_NAME", f".gt_cache_{MPI.COMM_WORLD.Get_rank():06}"
     )
+
+# Ensure DaCe backends are registered in GT4Py
+with warnings.catch_warnings(record=True) as caught:
+    # Cause all warnings to always be triggered.
+    warnings.simplefilter("always")
+
+    # Load GT4Py backends
+    import gt4py.cartesian.backend  # noqa: E402
+
+    # If DaCe backends aren't registered in GT4Py, escalate the warning with a descriptive error message.
+    for warning in caught:
+        if "GT4Py was unable to load DaCe" in str(warning.message):
+            raise RuntimeError(
+                "NDSL installation is incomplete. GT4Py was unable to load DaCe. Contact the team."
+            )
+
 
 ndsl_log.info(f"Literal precision: {NDSL_GLOBAL_PRECISION}")

--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -1,7 +1,6 @@
 # Literal precision for both GT4Py & NDSL
 import os
 import sys
-import warnings
 from typing import Literal
 
 from ndsl.comm.mpi import MPI
@@ -48,20 +47,15 @@ if MPI is not None:
         "GT_CACHE_DIR_NAME", f".gt_cache_{MPI.COMM_WORLD.Get_rank():06}"
     )
 
-# Ensure DaCe backends are registered in GT4Py
-with warnings.catch_warnings(record=True) as caught:
-    # Cause all warnings to always be triggered.
-    warnings.simplefilter("always")
 
-    # Load GT4Py backends
-    import gt4py.cartesian.backend  # noqa: E402
+# Raise an error if DaCe backends aren't registered in GT4Py.
+import gt4py.cartesian.backend as gt_backend  # noqa: E402
 
-    # If DaCe backends aren't registered in GT4Py, escalate the warning with a descriptive error message.
-    for warning in caught:
-        if "GT4Py was unable to load DaCe" in str(warning.message):
-            raise RuntimeError(
-                "NDSL installation is incomplete. GT4Py was unable to load DaCe. Contact the team."
-            )
+
+if not any([name.startswith("dace") for name in gt_backend.REGISTRY.names]):
+    raise RuntimeError(
+        "NDSL installation is incomplete: GT4Py was unable to load the DaCe backends."
+    )
 
 
 ndsl_log.info(f"Literal precision: {NDSL_GLOBAL_PRECISION}")


### PR DESCRIPTION
# Description

According to issue https://github.com/NOAA-GFDL/NDSL/issues/440, a missing DaCe installation is detected rather late and the resulting error from the backend initialization is confusing. This PR suggests to fix that by explicitly checking in `ndsl/dsl/__init__.py` if GT4Py could load the DaCe backend. That's the same point where we also set the literal precision.

If we detect missing DaCe backends in GT4Py, a descriptive exception is raised:

```shell
(.venv) romanc@localhost /tmp/NDSL (romanc/detect-dace-missing) $ python
Python 3.13.12 (main, Feb 09 2026, 22:37:44) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ndsl
/tmp/NDSL/.venv/lib64/python3.13/site-packages/gt4py/cartesian/__init__.py:13: UserWarning: GT4Py was unable to load DaCe. DaCe backends (`dace:cpu`, `dace:cpu_kfirst`, and `dace:gpu`) will not be available.
  from . import (
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import ndsl
  File "/tmp/NDSL/ndsl/__init__.py", line 2, in <module>
    from . import dsl  # isort:skip
    ^^^^^^^^^^^^^^^^^
  File "/tmp/NDSL/ndsl/dsl/__init__.py", line 56, in <module>
    raise RuntimeError(
        "NDSL installation is incomplete: GT4Py was unable to load the DaCe backends."
    )
RuntimeError: NDSL installation is incomplete: GT4Py was unable to load the DaCe backends.
```

The typo fix in `ndsl/config/backend.py` is unrelated.

@CharlesKrop / @FlorianDeconinck what do you think? Good enough (for now)?

## How has this been tested?

I've checked out NDSL into a separate folder, initialized the submodules, ran `pip install .` and then `pip uninstall dace` to get to a working state without the DaCe backends loaded in GT4Py.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
