### PR TITLE
[Fix | Orchestration] Dynamic type hint removal for quantity

### DIFF
--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -665,7 +665,9 @@ def orchestrate(
 
     # Remove type hint of Quantity to allow for __descriptor__ to be read in JIT
     for arg_name, annotation in func.__annotations__.items():
-        if annotation in [Quantity]:
+        if annotation in [Quantity] or (
+            isinstance(annotation, type) and issubclass(annotation, Quantity)
+        ):
             func.__annotations__[arg_name] = None
 
     # Build DaCe orchestrated wrapper

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -656,11 +656,17 @@ def orchestrate(
     for argument in dace_compiletime_args:
         func.__annotations__[argument] = DaceCompiletime
 
+    # Swap State and subclass into compile time
     for arg_name, annotation in func.__annotations__.items():
-        if annotation in [Quantity, State] or (
+        if annotation in [State] or (
             isinstance(annotation, type) and issubclass(annotation, State)
         ):
             func.__annotations__[arg_name] = DaceCompiletime
+
+    # Remove type hint of Quantity to allow for __descriptor__ to be read in JIT
+    for arg_name, annotation in func.__annotations__.items():
+        if annotation in [Quantity]:
+            func.__annotations__[arg_name] = None
 
     # Build DaCe orchestrated wrapper
     # This is a JIT object, e.g. DaCe compilation will happen on call

--- a/ndsl/dsl/gt4py/__init__.py
+++ b/ndsl/dsl/gt4py/__init__.py
@@ -1,5 +1,6 @@
 # Import gt4py functions, all future references to gt4py should come through here
 from gt4py.cartesian.gtscript import (
+    __INLINED,
     BACKWARD,
     FORWARD,
     IJ,
@@ -62,6 +63,7 @@ from gt4py.cartesian.gtscript import (
 
 
 __all__ = [
+    "__INLINED",
     "BACKWARD",
     "FORWARD",
     "IJ",

--- a/tests/dsl/orchestration/test_call.py
+++ b/tests/dsl/orchestration/test_call.py
@@ -38,12 +38,17 @@ class OrchestratedProgram:
         self.stencil(out_qty)
 
 
+class MyQuantity(Quantity):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
 class TypedOrchestratedProgram(NDSLRuntime):
     def __init__(self, stencil_factory: StencilFactory) -> None:
         super().__init__(stencil_factory)
         self._stencil = stencil_factory.from_dims_halo(_stencil, [I_DIM, J_DIM, K_DIM])
 
-    def __call__(self, out_qty: Quantity) -> None:
+    def __call__(self, out_qty: Quantity, qty_custom: MyQuantity) -> None:
         self._stencil(out_qty)
 
 
@@ -91,15 +96,28 @@ def test_memory_reallocation_quantity_type() -> None:
     )
     code = TypedOrchestratedProgram(stencil_factory)
     qty_A = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "A")
+    _qty_custom = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "A")
+
+    qty_custom = MyQuantity(
+        data=_qty_custom.data,
+        dims=_qty_custom.dims,
+        units=_qty_custom.units,
+        backend=_qty_custom.backend,
+        origin=_qty_custom.origin,
+        extent=_qty_custom.extent,
+        allow_mismatch_float_precision=False,
+        number_of_halo_points=_qty_custom._metadata.n_halo,
+    )
+
     qty_B = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "B")
 
-    code(qty_A)
+    code(qty_A, qty_custom)
     assert (qty_A.field[0, 0, :] == 2).all()
 
-    code(qty_A)
+    code(qty_A, qty_custom)
     assert (qty_A.field[0, 0, :] == 3).all()
 
-    code(qty_B)
+    code(qty_B, qty_custom)
     assert (qty_A.field[0, 0, :] == 3).all()
     assert (qty_B.field[0, 0, :] == 2).all()
 

--- a/tests/dsl/orchestration/test_call.py
+++ b/tests/dsl/orchestration/test_call.py
@@ -34,8 +34,17 @@ class OrchestratedProgram:
         orchestrate(obj=self, config=stencil_factory.config.dace_config)
         self.stencil = stencil_factory.from_dims_halo(_stencil, [I_DIM, J_DIM, K_DIM])
 
-    def __call__(self, out_qty):
+    def __call__(self, out_qty):  # no typehint out_qty on purpose
         self.stencil(out_qty)
+
+
+class TypedOrchestratedProgram(NDSLRuntime):
+    def __init__(self, stencil_factory: StencilFactory) -> None:
+        super().__init__(stencil_factory)
+        self._stencil = stencil_factory.from_dims_halo(_stencil, [I_DIM, J_DIM, K_DIM])
+
+    def __call__(self, out_qty: Quantity) -> None:
+        self._stencil(out_qty)
 
 
 class DSLTypeProgram(NDSLRuntime):
@@ -62,6 +71,25 @@ def test_memory_reallocation_blind_type():
         5, 5, 2, 0
     )
     code = OrchestratedProgram(stencil_factory)
+    qty_A = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "A")
+    qty_B = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "B")
+
+    code(qty_A)
+    assert (qty_A.field[0, 0, :] == 2).all()
+
+    code(qty_A)
+    assert (qty_A.field[0, 0, :] == 3).all()
+
+    code(qty_B)
+    assert (qty_A.field[0, 0, :] == 3).all()
+    assert (qty_B.field[0, 0, :] == 2).all()
+
+
+def test_memory_reallocation_quantity_type() -> None:
+    stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
+        5, 5, 2, 0
+    )
+    code = TypedOrchestratedProgram(stencil_factory)
     qty_A = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "A")
     qty_B = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "B")
 


### PR DESCRIPTION
# Description

The `Quantity` class has a `__descriptor__` for DaCe to be able to interpret the buffer. But the parser of DaCe expects that if the `__descriptor__` exists on the Type (e.g. while type hinting) it is callable.

Previous attempts at dealing with this was replacing the `Quantity` type hint with a `dace.compiletime`. This is not good enough, as this will lead to symbol duplication depending on the usage of said `Quantity` in code. A better approach, is to _remove_ entirely the type hint - and let the _runtime_ call to `__descriptor__` do its work.

Also in this PR:
- move `__INLINED` keyword into forwarded gtp4y API as this is _still_ useful for compile time code exclusion in stencils

## How has this been tested?

Locally on microphysics

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
