### PR TITLE
Fix | Cleanup: centralize normalize dimension names

### DIFF
--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -7,7 +7,7 @@ import numpy as np
 from gt4py import storage as gt_storage
 
 from ndsl.config import Backend
-from ndsl.constants import SPATIAL_DIMS
+from ndsl.constants import INTERFACE_DIMS, SPATIAL_DIMS
 from ndsl.dsl.typing import Float
 from ndsl.initialization import GridSizer
 from ndsl.quantity import Quantity, QuantityHaloSpec
@@ -184,16 +184,21 @@ class QuantityFactory:
         origin = self.sizer.get_origin(dims)
         extent = self.sizer.get_extent(dims)
         shape = self.sizer.get_shape(dims)
-        dimensions = [
-            (
-                axis
-                if any(dim in axis_dims for axis_dims in SPATIAL_DIMS)
-                else str(shape[index])
-            )
-            for index, (dim, axis) in enumerate(
-                zip(dims, ("I", "J", "K", *([None] * (len(dims) - 3))))
-            )
-        ]
+
+        # Normalize dimensions for the gt4py.cartesian allocator
+        # The allocator expects "I", "J" or "K", or  the size of the dimension
+        # as a string
+        dims_as_list = []
+        for index, dim in enumerate(dims):
+            if dim in SPATIAL_DIMS:
+                # Interface dimensions are cartesian dimensions for gt4py
+                # with an added point in the shape
+                if dim in INTERFACE_DIMS:
+                    dim = dim.removesuffix("_interface")
+                dims_as_list.append(dim.upper())
+            else:
+                dims_as_list.append(str(shape[index]))
+        dimensions = tuple(dims_as_list)
 
         data = allocator(
             shape,

--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -7,10 +7,10 @@ import numpy as np
 from gt4py import storage as gt_storage
 
 from ndsl.config import Backend
-from ndsl.constants import INTERFACE_DIMS, SPATIAL_DIMS
 from ndsl.dsl.typing import Float
 from ndsl.initialization import GridSizer
 from ndsl.quantity import Quantity, QuantityHaloSpec
+from ndsl.quantity.quantity import normalize_dimensions
 
 
 class QuantityFactory:
@@ -184,21 +184,7 @@ class QuantityFactory:
         origin = self.sizer.get_origin(dims)
         extent = self.sizer.get_extent(dims)
         shape = self.sizer.get_shape(dims)
-
-        # Normalize dimensions for the gt4py.cartesian allocator
-        # The allocator expects "I", "J" or "K", or  the size of the dimension
-        # as a string
-        dims_as_list = []
-        for index, dim in enumerate(dims):
-            if dim in SPATIAL_DIMS:
-                # Interface dimensions are cartesian dimensions for gt4py
-                # with an added point in the shape
-                if dim in INTERFACE_DIMS:
-                    dim = dim.removesuffix("_interface")
-                dims_as_list.append(dim.upper())
-            else:
-                dims_as_list.append(str(shape[index]))
-        dimensions = tuple(dims_as_list)
+        dimensions = normalize_dimensions(dims, shape)
 
         data = allocator(
             shape,

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -25,6 +25,27 @@ if cupy is None:
     import numpy as cupy
 
 
+def normalize_dimensions(
+    dims: Sequence[str], shape: tuple[int, ...]
+) -> tuple[str, ...]:
+    """
+    Normalize dimensions for the gt4py.cartesian allocator.
+
+    The allocator expects "I", "J" or "K", or  the size of the dimension as a string.
+    """
+    dims_as_list = []
+    for index, dim in enumerate(dims):
+        if dim in constants.SPATIAL_DIMS:
+            # Interface dimensions are cartesian dimensions for gt4py
+            # with an added point in the shape
+            if dim in constants.INTERFACE_DIMS:
+                dim = dim.removesuffix("_interface")
+            dims_as_list.append(dim.upper())
+        else:
+            dims_as_list.append(str(shape[index]))
+    return tuple(dims_as_list)
+
+
 class Quantity:
     """Data container for physical quantities."""
 
@@ -88,23 +109,7 @@ class Quantity:
         _validate_quantity_property_lengths(data.shape, dims, origin, extent)
 
         gt4py_backend_cls = gt_backend.from_name(backend.as_gt4py())
-        is_optimal_layout = gt4py_backend_cls.storage_info["is_optimal_layout"]
         device = gt4py_backend_cls.storage_info["device"]
-
-        # Normalize dimensions for the gt4py.cartesian allocator
-        # The allocator expects "I", "J" or "K", or  the size of the dimension
-        # as a string
-        dims_as_list = []
-        for index, dim in enumerate(dims):
-            if dim in constants.SPATIAL_DIMS:
-                # Interface dimensions are cartesian dimensions for gt4py
-                # with an added point in the shape
-                if dim in constants.INTERFACE_DIMS:
-                    dim = dim.removesuffix("_interface")
-                dims_as_list.append(dim.upper())
-            else:
-                dims_as_list.append(str(data.shape[index]))
-        dimensions = tuple(dims_as_list)
 
         if isinstance(data, np.ndarray):
             is_correct_device = device == "cpu"
@@ -114,6 +119,9 @@ class Quantity:
             raise ValueError(
                 f"Unknown device target for quantity allocation {type(data)}"
             )
+
+        is_optimal_layout = gt4py_backend_cls.storage_info["is_optimal_layout"]
+        dimensions = normalize_dimensions(dims, data.shape)
 
         if is_optimal_layout(data, dimensions) and is_correct_device:
             self._data = data

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -100,7 +100,7 @@ class Quantity:
                 # Interface dimensions are cartesian dimensions for gt4py
                 # with an added point in the shape
                 if dim in constants.INTERFACE_DIMS:
-                    dim = dim[: -len("_interface")]
+                    dim = dim.removesuffix("_interface")
                 dims_as_list.append(dim.upper())
             else:
                 dims_as_list.append(str(data.shape[index]))

--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -369,7 +369,7 @@ class MultiModalFloatMetric(BaseMetric):
             failures_of_changing_gridpoint_pct = round(
                 100.0 * (bad_indices_count / self.number_changing_values), 2
             )
-            report_local_failures = f"Failures: (changing columns, chainging points, all points) | {bad_column_count}/{total_column_count} - {bad_column_pct}%, {bad_indices_count}/{self.number_changing_values} - {failures_of_changing_gridpoint_pct}%, {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
+            report_local_failures = f"Failures: (changing columns, changing points, all points) | {bad_column_count}/{total_column_count} - {bad_column_pct}%, {bad_indices_count}/{self.number_changing_values} - {failures_of_changing_gridpoint_pct}%, {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
         else:
             report_local_failures = f"all grid points: {bad_indices_count}/{full_count} - {failures_of_all_grid_points_pct}%\n"
         report = [


### PR DESCRIPTION
# Description

In PR https://github.com/NOAA-GFDL/NDSL/pull/452 we changed the way we normalize dimension names in `Quantity`. Turns out we have the same code in `QuantityFactory`. Let's keep them in sync.

The change in `ndsl/testing/comparison.py` is an unrelated typo fix.

## How has this been tested?

All good as long as CI is still green, I guess ...

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
