### PR TITLE
Fix | Type Hint: `make_locals` dimension argument is a `Sequence`

### DIFF
--- a/ndsl/dsl/ndsl_runtime.py
+++ b/ndsl/dsl/ndsl_runtime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Sequence
 
 from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.stencil import StencilFactory
@@ -106,7 +106,7 @@ class NDSLRuntime:
     def make_local(
         self,
         quantity_factory: QuantityFactory,
-        dims: list[str],
+        dims: Sequence[str],
         dtype: type = Float,
         units: str = "unspecified",
         *,


### PR DESCRIPTION
# Description

Wider type hint to accommodate `tuple`.

## How has this been tested?

It hasn't, it's a type hint.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
