### PR TITLE
[Feature | Logging] Clean up multi-rank logging

### DIFF
--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -1,4 +1,5 @@
 # Literal precision for both GT4Py & NDSL
+import logging
 import os
 import sys
 from typing import Literal
@@ -59,3 +60,8 @@ if not any([name.startswith("dace") for name in gt_backend.REGISTRY.names]):
 
 
 ndsl_log.info(f"Literal precision: {NDSL_GLOBAL_PRECISION}")
+
+# We remove warnings from the compiler for higher level of logging
+if ndsl_log.level > logging.WARNING:
+    gt4py.cartesian.config.build_settings["extra_compile_args"]["cxx"].append("-w")
+    gt4py.cartesian.config.build_settings["extra_compile_args"]["cuda"].append("-w")

--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -1,5 +1,4 @@
 # Literal precision for both GT4Py & NDSL
-import logging
 import os
 import sys
 from typing import Literal
@@ -62,6 +61,7 @@ if not any([name.startswith("dace") for name in gt_backend.REGISTRY.names]):
 ndsl_log.info(f"Literal precision: {NDSL_GLOBAL_PRECISION}")
 
 # We remove warnings from the compiler for higher level of logging
-if ndsl_log.level > logging.WARNING:
+NDSL_COMPILER_SILENCE = os.getenv("NDSL_COMPILER_SILENCE", "False").lower() == "true"
+if NDSL_COMPILER_SILENCE:
     gt4py.cartesian.config.build_settings["extra_compile_args"]["cxx"].append("-w")
     gt4py.cartesian.config.build_settings["extra_compile_args"]["cuda"].append("-w")

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -249,7 +249,7 @@ class DaceConfig:
                 "compiler",
                 "cpu",
                 "args",
-                value=f"-march={march_cpu} -std=c++17 -fPIC {warnings_policy} -Wextra -O{optimization_level} {cxx_defaults.cxx_compile_flags}",
+                value=f"-march={march_cpu} -std=c++17 -fPIC {warnings_policy} -O{optimization_level} {cxx_defaults.cxx_compile_flags}",
             )
             # Potentially buggy - deactivate
             dace.config.Config.set(

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import enum
-import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
@@ -10,11 +9,11 @@ import dace.config
 from gt4py.cartesian.config import GT4PY_COMPILE_OPT_LEVEL
 from gt4py.cartesian.utils.compiler import cxx_compiler_defaults, gpu_configuration
 
-from ndsl import LocalComm, ndsl_log
+from ndsl import LocalComm
 from ndsl.comm.communicator import Communicator
 from ndsl.comm.partitioner import Partitioner
 from ndsl.config import Backend
-from ndsl.dsl import NDSL_GLOBAL_PRECISION
+from ndsl.dsl import NDSL_COMPILER_SILENCE, NDSL_GLOBAL_PRECISION
 from ndsl.dsl.caches.cache_location import identify_code_path
 from ndsl.dsl.caches.codepath import FV3CodePath
 from ndsl.optional_imports import cupy as cp
@@ -245,7 +244,7 @@ class DaceConfig:
             march_cpu = "armv8-a" if is_arm_neoverse else "native"
             # Removed --fmath
             cxx_defaults = cxx_compiler_defaults(GT4PY_COMPILE_OPT_LEVEL)
-            warnings_policy = "-Wall" if ndsl_log.level <= logging.WARNING else "-w"
+            warnings_policy = "-Wall" if NDSL_COMPILER_SILENCE else "-w"
             dace.config.Config.set(
                 "compiler",
                 "cpu",

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -244,7 +244,7 @@ class DaceConfig:
             march_cpu = "armv8-a" if is_arm_neoverse else "native"
             # Removed --fmath
             cxx_defaults = cxx_compiler_defaults(GT4PY_COMPILE_OPT_LEVEL)
-            warnings_policy = "-Wall" if NDSL_COMPILER_SILENCE else "-w"
+            warnings_policy = "-w" if NDSL_COMPILER_SILENCE else "-Wall"
             dace.config.Config.set(
                 "compiler",
                 "cpu",

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
@@ -9,7 +10,7 @@ import dace.config
 from gt4py.cartesian.config import GT4PY_COMPILE_OPT_LEVEL
 from gt4py.cartesian.utils.compiler import cxx_compiler_defaults, gpu_configuration
 
-from ndsl import LocalComm
+from ndsl import LocalComm, ndsl_log
 from ndsl.comm.communicator import Communicator
 from ndsl.comm.partitioner import Partitioner
 from ndsl.config import Backend
@@ -244,11 +245,12 @@ class DaceConfig:
             march_cpu = "armv8-a" if is_arm_neoverse else "native"
             # Removed --fmath
             cxx_defaults = cxx_compiler_defaults(GT4PY_COMPILE_OPT_LEVEL)
+            warnings_policy = "-Wall" if ndsl_log.level <= logging.WARNING else "-w"
             dace.config.Config.set(
                 "compiler",
                 "cpu",
                 "args",
-                value=f"-march={march_cpu} -std=c++17 -fPIC -Wall -Wextra -O{optimization_level} {cxx_defaults.cxx_compile_flags}",
+                value=f"-march={march_cpu} -std=c++17 -fPIC {warnings_policy} -Wextra -O{optimization_level} {cxx_defaults.cxx_compile_flags}",
             )
             # Potentially buggy - deactivate
             dace.config.Config.set(
@@ -268,7 +270,7 @@ class DaceConfig:
                 "compiler",
                 "cuda",
                 "args",
-                value=f"-std=c++14 -Xcompiler -fPIC -O{optimization_level} -Xcompiler {march_option} {gpu_config.gpu_compile_flags}",
+                value=f"-std=c++14 {warnings_policy} -Xcompiler -fPIC -O{optimization_level} -Xcompiler {march_option} {gpu_config.gpu_compile_flags}",
             )
 
             cuda_sm = cp.cuda.Device(0).compute_capability if cp else 60

--- a/ndsl/logging.py
+++ b/ndsl/logging.py
@@ -36,10 +36,7 @@ class LogLowerLevelsOnRankZeroOnly(logging.Filter):
         if record.levelno >= logging.ERROR:
             return True
 
-        if rank == 0:
-            return True
-
-        return False
+        return rank == 0
 
 
 def _get_log_level(default: str = "info") -> str:

--- a/ndsl/logging.py
+++ b/ndsl/logging.py
@@ -20,6 +20,28 @@ AVAILABLE_LOG_LEVELS = {
 }
 
 
+class LogLowerLevelsOnRankZeroOnly(logging.Filter):
+    """Allow logging on rank 0 - all other logs are cancelled
+    unless:
+    - `NDSL_LOG_ALL` is `True`
+    - OR the log level is >= `Error`
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        log_all = os.getenv("NDSL_LOG_ALL", "False").lower() == "true"
+        if log_all:
+            return True
+
+        rank = MPI.COMM_WORLD.Get_rank()
+        if record.levelno >= logging.ERROR:
+            return True
+
+        if rank == 0:
+            return True
+
+        return False
+
+
 def _get_log_level(default: str = "info") -> str:
     loglevel = os.getenv("NDSL_LOGLEVEL", default).lower()
 
@@ -49,6 +71,7 @@ def _ndsl_logger() -> logging.Logger:
     )
     handler.setFormatter(formatter)
     name_log.addHandler(handler)
+    name_log.addFilter(LogLowerLevelsOnRankZeroOnly())
     return name_log
 
 

--- a/ndsl/logging.py
+++ b/ndsl/logging.py
@@ -89,7 +89,7 @@ def _ndsl_logger_on_rank_0() -> logging.Logger:
         formatter = logging.Formatter(
             fmt=(
                 f"%(asctime)s|%(levelname)s|rank {MPI.COMM_WORLD.Get_rank()}|"
-                "%(name)s:%(message)s"
+                ": %(message)s"
             ),
             datefmt="%Y-%m-%d %H:%M:%S",
         )
@@ -103,6 +103,7 @@ def _ndsl_logger_on_rank_0() -> logging.Logger:
 ndsl_log: Annotated[logging.Logger, "NDSL Python logger, logs on all rank"] = (
     _ndsl_logger()
 )
+ndsl_log.info(f"Log level: {_get_log_level()}")
 
 ndsl_log_on_rank_0: Annotated[
     logging.Logger, "NDSL Python logger, logs on rank 0 only"


### PR DESCRIPTION
# Description

Using NDSL at scale on many-ranks has a logging issue. Pages and pages of (mostly) the same logs. Going to `NDSL_LOG_LEVEL=Error` kills most of them, but could also swallow the more interesting ones.

We switch here the stance of the logger to _only log on rank 0_ by default. The env var `NDSL_LOG_ALL=True` would revert to the previous wordy log.

In order to keep cleaning logs for production run, we introduce a `NDSL_COMPILER_SILENCE`, which defaults to `False`, that when set to `True` will silence all warnings from the compiler. 

## How has this been tested?

No unit tests so far, just local testing.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
