### PR TITLE
[Feature | GPU] Heterogeneous Memory Management support

### DIFF
--- a/ndsl/__init__.py
+++ b/ndsl/__init__.py
@@ -1,4 +1,5 @@
 # isort:skip_file
+from .internal import hmm
 from . import dsl  # isort:skip
 from .logging import ndsl_log  # isort:skip
 from .comm.communicator import CubedSphereCommunicator, TileCommunicator
@@ -40,6 +41,7 @@ from .dsl.dace.orchestration import orchestrate, orchestrate_function
 
 
 __all__ = [
+    "hmm",
     "dsl",
     "Backend",
     "CubedSphereCommunicator",

--- a/ndsl/internal/hmm.py
+++ b/ndsl/internal/hmm.py
@@ -1,21 +1,22 @@
-"""This module sole role is to attempt to setup Heterogenous Memory Management
-usage DSL-wide by levaraging the CuPy experimental support.
+"""
+This module's sole role is to attempt to setup DSL-wide usage of Heterogeneous
+Memory Management (HMM) by leveraging CuPy's experimental support.
 
-We relied on Nvidia's docs and CuPy evolving support (reference in inline comment). It boils down to:
+We rely on Nvidia's docs and CuPy's evolving support (reference in inline comment). It boils down to:
 
 HMM requires:
     - a device that can access paged RAM on an OS that has an HMM service running on kernel
     - the `CUPY_ENABLE_UMP` environement variable set to 1
 
-⚠️ If `CUPY_ENABLE_UMP` is set _but_ the device/OS cannot support pageable memory, the upload/downlowd
-will fail as CuPy does blind pointer-binding ⚠️
+⚠️ If `CUPY_ENABLE_UMP` is set _but_ the device/OS cannot support pageable memory, the upload/download
+will fail as CuPy does blind pointer-binding. ⚠️
 
 If HMM is availbale we:
     - flip `cupy` malloc managed allocator to the system one
     - set the `numpy` allocator to the system one (using the `numpy_allocator` package)
 
 Once set globally - every allocation will happen on paged memory and every cupy initiated transfer will bypass
-call for upload/download and do pointer-mapping.
+calls for upload/download and do pointer-mapping.
 
 In addition, we make a good effort to log when HMM could be used hardware-wise but isn't due to a software
 or configuration limitation.
@@ -26,12 +27,7 @@ import os
 
 from ndsl.logging import ndsl_log
 from ndsl.optional_imports import cupy as cp
-
-
-try:
-    import numpy_allocator as np_allocator
-except ModuleNotFoundError:
-    np_allocator = None
+from ndsl.optional_imports import numpy_allocator as np_allocator
 
 
 def _is_hmm_available() -> bool:
@@ -44,7 +40,7 @@ def _is_hmm_available() -> bool:
         return False
 
     if "CUPY_ENABLE_UMP" not in os.environ or os.environ["CUPY_ENABLE_UMP"] != "1":
-        ndsl_log.info("HMM possible - but `CUPY_ENABLE_UMP` not set")
+        ndsl_log.info("HMM possible but OFF: set `CUPY_ENABLE_UMP=1` to activate HMM")
         return False
 
     if np_allocator is None:

--- a/ndsl/internal/hmm.py
+++ b/ndsl/internal/hmm.py
@@ -1,0 +1,74 @@
+"""This module sole role is to attempt to setup Heterogenous Memory Management
+usage DSL-wide by levaraging the CuPy experimental support.
+
+We relied on Nvidia's docs and CuPy evolving support (reference in inline comment). It boils down to:
+
+HMM requires:
+    - a device that can access paged RAM on an OS that has an HMM service running on kernel
+    - the `CUPY_ENABLE_UMP` environement variable set to 1
+
+⚠️ If `CUPY_ENABLE_UMP` is set _but_ the device/OS cannot support pageable memory, the upload/downlowd
+will fail as CuPy does blind pointer-binding ⚠️
+
+If HMM is availbale we:
+    - flip `cupy` malloc managed allocator to the system one
+    - set the `numpy` allocator to the system one (using the `numpy_allocator` package)
+
+Once set globally - every allocation will happen on paged memory and every cupy initiated transfer will bypass
+call for upload/download and do pointer-mapping.
+
+In addition, we make a good effort to log when HMM could be used hardware-wise but isn't due to a software
+or configuration limitation.
+"""
+
+import ctypes
+import os
+
+from ndsl.logging import ndsl_log
+from ndsl.optional_imports import cupy as cp
+
+
+try:
+    import numpy_allocator as np_allocator
+except ModuleNotFoundError:
+    np_allocator = None
+
+
+def _is_hmm_available() -> bool:
+    if cp is None:
+        return False
+
+    if not cp.cuda.runtime.deviceGetAttribute(
+        cp.cuda.runtime.cudaDevAttrPageableMemoryAccess, 0
+    ):
+        return False
+
+    if "CUPY_ENABLE_UMP" not in os.environ or os.environ["CUPY_ENABLE_UMP"] != "1":
+        ndsl_log.info("HMM possible - but `CUPY_ENABLE_UMP` not set")
+        return False
+
+    if np_allocator is None:
+        ndsl_log.info("HMM possible - but `numpy_allocator` is not installed")
+
+    ndsl_log.info("HMM is ON")
+    return True
+
+
+if _is_hmm_available():
+    # Based on https://github.com/cupy/cupy/issues/8711 and
+    # https://docs.cupy.dev/en/stable/user_guide/memory.html#unified-memory-programming-ump-support-experimental
+    import cupy._core.numpy_allocator as ac
+
+    # System allocator for cupy
+    cp.cuda.set_allocator(cp.cuda.MemoryPool(cp.cuda.memory.malloc_system).malloc)
+
+    # System allocator for numpy
+    lib = ctypes.CDLL(ac.__file__)
+
+    class my_allocator(metaclass=np_allocator.type):
+        _calloc_ = ctypes.addressof(lib._calloc)
+        _malloc_ = ctypes.addressof(lib._malloc)
+        _realloc_ = ctypes.addressof(lib._realloc)
+        _free_ = ctypes.addressof(lib._free)
+
+    my_allocator.__enter__()  # flip the allocator

--- a/ndsl/internal/hmm.py
+++ b/ndsl/internal/hmm.py
@@ -30,7 +30,10 @@ from ndsl.optional_imports import cupy as cp
 from ndsl.optional_imports import numpy_allocator as np_allocator
 
 
-def _is_hmm_available() -> bool:
+_IS_HMM_AVAILABLE: bool | None = None
+
+
+def _internal_is_hmm_available() -> bool:
     if cp is None:
         return False
 
@@ -50,7 +53,17 @@ def _is_hmm_available() -> bool:
     return True
 
 
-if _is_hmm_available():
+def is_hmm_available() -> bool:
+    """Can Heterogeneous Memory Management be used on the current hardware"""
+    global _IS_HMM_AVAILABLE
+    if _IS_HMM_AVAILABLE is not None:
+        return _IS_HMM_AVAILABLE
+
+    _IS_HMM_AVAILABLE = _internal_is_hmm_available()
+    return _IS_HMM_AVAILABLE
+
+
+if is_hmm_available():
     # Based on https://github.com/cupy/cupy/issues/8711 and
     # https://docs.cupy.dev/en/stable/user_guide/memory.html#unified-memory-programming-ump-support-experimental
     import cupy._core.numpy_allocator as ac

--- a/ndsl/optional_imports.py
+++ b/ndsl/optional_imports.py
@@ -33,3 +33,8 @@ if cupy is not None:
         cupy.cuda.runtime.deviceSynchronize()
     except cupy.cuda.runtime.CUDARuntimeError:
         cupy = None
+
+try:
+    import numpy_allocator
+except ModuleNotFoundError:
+    numpy_allocator = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ readme = "README.md"
 requires-python = ">=3.11,<3.14"
 
 [project.optional-dependencies]
+cuda12 = ['cupy-cuda12x>=12.0']
+cuda13 = ['cupy-cuda13x>=14.0']
 demos = ["ipython", "ipykernel"]
 dev = [
   "flake8-pyproject",
@@ -33,6 +35,8 @@ dev = [
 ]
 docs = ["mkdocs-material", "mkdocstrings[python]", "mkdocs-exclude"]
 extras = ["ndsl[docs]", "ndsl[demos]", "ndsl[test]", "ndsl[dev]"]
+hmm-cuda12 = ['numpy_allocator', 'ndsl[cuda12]']
+hmm-cuda13 = ['numpy_allocator', 'ndsl[cuda13]']
 pyfms = ["pyfms @ git+https://github.com/noaa-gfdl/pyfms.git"]
 serialbox = ["serialbox @ git+https://github.com/FlorianDeconinck/serialbox.git@feature/data_ijkbuff#subdirectory=src/serialbox-python"]
 test = ["pytest", "coverage"]


### PR DESCRIPTION
# Description

This setups HMM for a DSL-wide execution transparently for the user. Details are spelled out in `hmm.py` module comment.

This should be a no-op to most user as APUs with HMM support are not legion. It has been tested on a GH200 device, but should work on GBXXX series and MI300A series of AMD. Likewise, the flow of new consumer APU that is starting to see the light should also be able to leverage it.

## How has this been tested?

It has been tested on the PRISM cluster. No test made for it as we don't have the hardware on CI to have it work.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
