### PR TITLE
fix: dimensions of GridDefinitions for `ew1` and `ew2`

### DIFF
--- a/ndsl/grid/generation.py
+++ b/ndsl/grid/generation.py
@@ -122,24 +122,10 @@ class GridDefinitions:
     bk = GridDefinition(dims=(K_INTERFACE_DIM,), units="m")
     ec1 = GridDefinition(dims=CELL_CENTER + (CARTESIAN_DIM,), units="m")
     ec2 = GridDefinition(dims=CELL_CENTER + (CARTESIAN_DIM,), units="m")
-    ew1 = GridDefinition(dims=CELL_CORNERS + (CARTESIAN_DIM,), units="m")
-    ew2 = GridDefinition(dims=CELL_CORNERS + (CARTESIAN_DIM,), units="m")
-    es1 = GridDefinition(
-        dims=(
-            I_DIM,
-            J_INTERFACE_DIM,
-            CARTESIAN_DIM,
-        ),
-        units="m",
-    )
-    es2 = GridDefinition(
-        dims=(
-            I_DIM,
-            J_INTERFACE_DIM,
-            CARTESIAN_DIM,
-        ),
-        units="m",
-    )
+    ew1 = GridDefinition(dims=(I_INTERFACE_DIM, J_DIM, CARTESIAN_DIM), units="m")
+    ew2 = GridDefinition(dims=(I_INTERFACE_DIM, J_DIM, CARTESIAN_DIM), units="m")
+    es1 = GridDefinition(dims=(I_DIM, J_INTERFACE_DIM, CARTESIAN_DIM), units="m")
+    es2 = GridDefinition(dims=(I_DIM, J_INTERFACE_DIM, CARTESIAN_DIM), units="m")
     cosa_u = GridDefinition(dims=(I_INTERFACE_DIM, J_DIM), units="")
     cosa_v = GridDefinition(dims=(I_DIM, J_INTERFACE_DIM), units="")
     cosa_s = GridDefinition(dims=(I_DIM, J_DIM), units="")


### PR DESCRIPTION
# Description

Allocation patterns and translate test results data suggests that `ew1` and `ew2` have `dims=(I_INTERFACE_DIM, J_DIM, CARTESIAN_DIM)` instead of the current `dims=(I_INTERFACE_DIM, J_INTERFACE_DIM, CARTESIAN_DIM)`. We don't see any issues with that in the translate tests because

1. In any layout other than `KJI`, we padd non-interface dimensions.
2. The translate tests assume this padding to happen even in `KJI`.

Togehter, these two imply that in translate tests, we always allocate enough for interface dimensions in both I and J, regardless of the the I/J dimension in the GridDefinition.

Until we address 2 (which will allow us to run translate tests in KJI), this will primarily be important for running online in KJI.

/cc @FlorianDeconinck fallout from trying to get dynamics translate tests running with a KJI backend (on GPU) yesterday.

## How has this been tested?

By looking at allocation patterns when `ew1` and `ew2` are constructed and by checking the translate test (input) data.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
