### PR TITLE
refactor: cleanups around logging

### DIFF
--- a/ndsl/__init__.py
+++ b/ndsl/__init__.py
@@ -1,7 +1,7 @@
 # isort:skip_file
 from .internal import hmm
 from . import dsl  # isort:skip
-from .logging import ndsl_log  # isort:skip
+from .logging import ndsl_log, ndsl_log_on_rank_0  # isort:skip
 from .comm.communicator import CubedSphereCommunicator, TileCommunicator
 from .comm.local_comm import LocalComm
 from .comm.mpi import MPIComm
@@ -76,6 +76,7 @@ __all__ = [
     "GridSizer",
     "SubtileGridSizer",
     "ndsl_log",
+    "ndsl_log_on_rank_0",
     "NetCDFMonitor",
     "NullPerformanceCollector",
     "PerformanceCollector",

--- a/ndsl/__init__.py
+++ b/ndsl/__init__.py
@@ -1,7 +1,7 @@
 # isort:skip_file
+from .logging import ndsl_log, ndsl_log_on_rank_0
 from .internal import hmm
-from . import dsl  # isort:skip
-from .logging import ndsl_log, ndsl_log_on_rank_0  # isort:skip
+from . import dsl
 from .comm.communicator import CubedSphereCommunicator, TileCommunicator
 from .comm.local_comm import LocalComm
 from .comm.mpi import MPIComm

--- a/ndsl/comm/local_comm.py
+++ b/ndsl/comm/local_comm.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import copy
 from typing import Any, TypeVar
 
+from ndsl import ndsl_log
 from ndsl.comm.comm_abc import Comm, ReductionOperator
-from ndsl.logging import ndsl_log
 from ndsl.utils import ensure_contiguous, safe_assign_array
 
 

--- a/ndsl/constants.py
+++ b/ndsl/constants.py
@@ -4,8 +4,8 @@ from typing import Literal
 
 import numpy as np
 
+from ndsl import ndsl_log
 from ndsl.dsl.typing import Float
-from ndsl.logging import ndsl_log
 
 
 # The FV3GFS model ships with two sets of constants, one used in the UFS physics

--- a/ndsl/debug/config.py
+++ b/ndsl/debug/config.py
@@ -26,9 +26,9 @@ import os
 
 import yaml
 
+from ndsl import ndsl_log
 from ndsl.comm.mpi import MPIComm
 from ndsl.debug.debugger import Debugger
-from ndsl.logging import ndsl_log
 
 
 def _set_debugger() -> Debugger | None:

--- a/ndsl/debug/debugger.py
+++ b/ndsl/debug/debugger.py
@@ -7,7 +7,7 @@ from typing import Any
 import pandas as pd
 import xarray as xr
 
-from ndsl.logging import ndsl_log
+from ndsl import ndsl_log
 from ndsl.quantity import Quantity
 
 

--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -3,8 +3,8 @@ import os
 import sys
 from typing import Literal
 
+from ndsl import ndsl_log
 from ndsl.comm.mpi import MPI
-from ndsl.logging import ndsl_log
 
 
 gt4py_config_module = "gt4py.cartesian.config"

--- a/ndsl/dsl/dace/build.py
+++ b/ndsl/dsl/dace/build.py
@@ -2,10 +2,10 @@ from dace import config as dace_conf
 from dace.sdfg import SDFG
 from gt4py.cartesian import config as gt_config
 
+from ndsl import ndsl_log
 from ndsl.config import Backend
 from ndsl.dsl.caches.cache_location import get_cache_directory, get_cache_fullpath
 from ndsl.dsl.dace.dace_config import DaceConfig, DaCeOrchestration
-from ndsl.logging import ndsl_log
 
 
 ################################################

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -23,6 +23,7 @@ from dace.transformation.helpers import get_parent_map
 from gt4py import storage as gt_storage
 
 import ndsl.dsl.dace.replacements  # noqa # We load in the DaCe replacements
+from ndsl import ndsl_log
 from ndsl.comm.mpi import MPI
 from ndsl.config import BackendLoopOrder
 from ndsl.dsl.dace.build import get_sdfg_path, write_build_info
@@ -50,7 +51,6 @@ from ndsl.dsl.dace.utils import (
     memory_static_analysis,
     report_memory_static_analysis,
 )
-from ndsl.logging import ndsl_log
 from ndsl.optional_imports import cupy as cp
 from ndsl.quantity import Quantity, State
 

--- a/ndsl/dsl/dace/sdfg_debug_passes.py
+++ b/ndsl/dsl/dace/sdfg_debug_passes.py
@@ -8,7 +8,7 @@ from dace.sdfg import graph as gr
 from dace.sdfg import utils as sdutil
 from dace.transformation.helpers import get_parent_map
 
-from ndsl.logging import ndsl_log
+from ndsl import ndsl_log
 
 
 def _filter_all_maps(

--- a/ndsl/dsl/dace/stree/optimizations/axis_merge.py
+++ b/ndsl/dsl/dace/stree/optimizations/axis_merge.py
@@ -6,6 +6,7 @@ import dace
 from dace.properties import CodeBlock
 from dace.sdfg.analysis.schedule_tree import treenodes as tn
 
+from ndsl import ndsl_log
 from ndsl.dsl.dace.stree.optimizations.memlet_helpers import (
     AxisIterator,
     no_data_dependencies_on_cartesian_axis,
@@ -15,7 +16,6 @@ from ndsl.dsl.dace.stree.optimizations.tree_common_op import (
     list_index,
     swap_node_position_in_tree,
 )
-from ndsl.logging import ndsl_log
 
 
 # Buggy passes that should work

--- a/ndsl/dsl/dace/stree/optimizations/clean_tree.py
+++ b/ndsl/dsl/dace/stree/optimizations/clean_tree.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dace.sdfg.analysis.schedule_tree import treenodes as tn
 
-from ndsl.logging import ndsl_log
+from ndsl import ndsl_log
 
 
 class CleanUpScheduleTree(tn.ScheduleNodeTransformer):

--- a/ndsl/dsl/dace/stree/optimizations/memlet_helpers.py
+++ b/ndsl/dsl/dace/stree/optimizations/memlet_helpers.py
@@ -3,7 +3,7 @@ from enum import Enum
 import dace.sdfg.analysis.schedule_tree.treenodes as stree
 from dace.memlet import Memlet
 
-from ndsl.logging import ndsl_log
+from ndsl import ndsl_log
 
 
 class AxisIterator(Enum):

--- a/ndsl/dsl/dace/stree/optimizations/refine_transients.py
+++ b/ndsl/dsl/dace/stree/optimizations/refine_transients.py
@@ -3,9 +3,9 @@ import warnings
 import dace.data
 import dace.sdfg.analysis.schedule_tree.treenodes as stree
 
+from ndsl import ndsl_log
 from ndsl.config import Backend, BackendFramework
 from ndsl.dsl.dace.stree.optimizations.memlet_helpers import AxisIterator
-from ndsl.logging import ndsl_log
 
 
 def _change_index_of_tuple(

--- a/ndsl/dsl/dace/stree/pipeline.py
+++ b/ndsl/dsl/dace/stree/pipeline.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import dace.sdfg.analysis.schedule_tree.treenodes as stree
 
+from ndsl import ndsl_log_on_rank_0
 from ndsl.dsl.dace.stree.optimizations import AxisIterator, CartesianAxisMerge
-from ndsl.logging import ndsl_log_on_rank_0
 
 
 class StreePipeline:

--- a/ndsl/dsl/dace/utils.py
+++ b/ndsl/dsl/dace/utils.py
@@ -9,11 +9,11 @@ from dace.transformation.helpers import get_parent_map
 from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
 import ndsl.xumpy as xp
+from ndsl import ndsl_log
 from ndsl.config import Backend
 from ndsl.dsl.dace.dace_config import DaceConfig
 from ndsl.dsl.stencil import CompilationConfig, FrozenStencil, StencilConfig
 from ndsl.dsl.typing import Float, FloatField
-from ndsl.logging import ndsl_log
 
 
 class DaCeProgress:
@@ -182,7 +182,7 @@ def memory_static_analysis_from_path(
 # ----------------------------------------------------------
 # Theoretical bandwidth from SDFG
 # ----------------------------------------------------------
-def copy_kernel(q_in: FloatField, q_out: FloatField) -> None:
+def copy_kernel(q_in: FloatField, q_out: FloatField) -> None:  # type: ignore[valid-type]
     with computation(PARALLEL), interval(...):
         q_in = q_out
 

--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -6,11 +6,10 @@ import numpy as np
 import numpy.typing as npt
 from gt4py import storage as gt_storage
 
-from ndsl import xumpy
+from ndsl import ndsl_log, xumpy
 from ndsl.config.backend import Backend
 from ndsl.constants import N_HALO_DEFAULT
 from ndsl.dsl.typing import Float
-from ndsl.logging import ndsl_log
 from ndsl.optional_imports import cupy as cp
 
 

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -16,6 +16,7 @@ from gt4py.cartesian.definitions import FieldInfo
 from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline, OirPipeline
 from gt4py.cartesian.stencil_object import StencilObject
 
+from ndsl import ndsl_log
 from ndsl.comm.comm_abc import Comm
 from ndsl.comm.communicator import Communicator
 from ndsl.comm.decomposition import block_waiting_for_compilation, unblock_waiting_tiles
@@ -50,7 +51,6 @@ from ndsl.dsl.typing import (
 )
 from ndsl.initialization import GridSizer
 from ndsl.internal.deferred_type import StencilDeferredType
-from ndsl.logging import ndsl_log
 from ndsl.quantity import Quantity
 from ndsl.testing.comparison import LegacyMetric
 

--- a/ndsl/grid/eta.py
+++ b/ndsl/grid/eta.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
-from ndsl import logging
+from ndsl import ndsl_log
 
 
 ETA_0 = 0.252
@@ -69,7 +69,7 @@ def set_hybrid_pressure_coefficients(
         ak, bk = _load_ak_bk_from_file(eta_file)
     else:
         if eta_file is not None:
-            logging.ndsl_log.warning(
+            ndsl_log.warning(
                 f"Ignoring eta_file {eta_file} since `ak_data` and `bk_data` were given."
             )
         ak, bk = ak_data, bk_data

--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -63,7 +63,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         units: str,
-        dtype: npt.DTypeLike = Float,
+        dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -78,7 +78,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         units: str,
-        dtype: npt.DTypeLike = Float,
+        dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -93,7 +93,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         units: str,
-        dtype: npt.DTypeLike = Float,
+        dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -109,7 +109,7 @@ class QuantityFactory:
         dims: Sequence[str],
         units: str,
         value: Any,  # no type hint because it would be a TypeVar = type[dtype] and mypy says no
-        dtype: npt.DTypeLike = Float,
+        dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -179,7 +179,7 @@ class QuantityFactory:
         allocator: Callable,
         dims: Sequence[str],
         units: str,
-        dtype: npt.DTypeLike = Float,
+        dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
         origin = self.sizer.get_origin(dims)
@@ -210,7 +210,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         n_halo: int | None = None,
-        dtype: npt.DTypeLike = Float,
+        dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
     ) -> QuantityHaloSpec:
         """Build memory specifications for the halo update.
 

--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 from gt4py import storage as gt_storage
 
 from ndsl.config import Backend
@@ -62,7 +63,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         units: str,
-        dtype: type | np.dtype = Float,
+        dtype: npt.DTypeLike = Float,
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -77,7 +78,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         units: str,
-        dtype: type | np.dtype = Float,
+        dtype: npt.DTypeLike = Float,
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -92,7 +93,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         units: str,
-        dtype: type | np.dtype = Float,
+        dtype: npt.DTypeLike = Float,
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -108,7 +109,7 @@ class QuantityFactory:
         dims: Sequence[str],
         units: str,
         value: Any,  # no type hint because it would be a TypeVar = type[dtype] and mypy says no
-        dtype: type | np.dtype = Float,
+        dtype: npt.DTypeLike = Float,
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -178,7 +179,7 @@ class QuantityFactory:
         allocator: Callable,
         dims: Sequence[str],
         units: str,
-        dtype: type | np.dtype = Float,
+        dtype: npt.DTypeLike = Float,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
         origin = self.sizer.get_origin(dims)
@@ -209,7 +210,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         n_halo: int | None = None,
-        dtype: type | np.dtype = Float,
+        dtype: npt.DTypeLike = Float,
     ) -> QuantityHaloSpec:
         """Build memory specifications for the halo update.
 

--- a/ndsl/initialization/allocator.py
+++ b/ndsl/initialization/allocator.py
@@ -62,7 +62,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         units: str,
-        dtype: type = Float,
+        dtype: type | np.dtype = Float,
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -108,7 +108,7 @@ class QuantityFactory:
         dims: Sequence[str],
         units: str,
         value: Any,  # no type hint because it would be a TypeVar = type[dtype] and mypy says no
-        dtype: type = Float,
+        dtype: type | np.dtype = Float,
         *,
         allow_mismatch_float_precision: bool = False,
     ) -> Quantity:
@@ -209,7 +209,7 @@ class QuantityFactory:
         self,
         dims: Sequence[str],
         n_halo: int | None = None,
-        dtype: type = Float,
+        dtype: type | np.dtype = Float,
     ) -> QuantityHaloSpec:
         """Build memory specifications for the halo update.
 

--- a/ndsl/internal/hmm.py
+++ b/ndsl/internal/hmm.py
@@ -6,12 +6,12 @@ We rely on Nvidia's docs and CuPy's evolving support (reference in inline commen
 
 HMM requires:
     - a device that can access paged RAM on an OS that has an HMM service running on kernel
-    - the `CUPY_ENABLE_UMP` environement variable set to 1
+    - the `CUPY_ENABLE_UMP` environment variable set to 1
 
 ⚠️ If `CUPY_ENABLE_UMP` is set _but_ the device/OS cannot support pageable memory, the upload/download
 will fail as CuPy does blind pointer-binding. ⚠️
 
-If HMM is availbale we:
+If HMM is available we:
     - flip `cupy` malloc managed allocator to the system one
     - set the `numpy` allocator to the system one (using the `numpy_allocator` package)
 

--- a/ndsl/internal/hmm.py
+++ b/ndsl/internal/hmm.py
@@ -25,7 +25,7 @@ or configuration limitation.
 import ctypes
 import os
 
-from ndsl.logging import ndsl_log
+from ndsl import ndsl_log
 from ndsl.optional_imports import cupy as cp
 from ndsl.optional_imports import numpy_allocator as np_allocator
 

--- a/ndsl/monitor/netcdf_monitor.py
+++ b/ndsl/monitor/netcdf_monitor.py
@@ -111,7 +111,7 @@ class NetCDFMonitor:
         path: str,
         communicator: Communicator,
         time_chunk_size: int = 1,
-        precision=Float,
+        precision=Float,  # type: ignore[has-type]
     ) -> None:
         """Create a NetCDFMonitor.
 

--- a/ndsl/monitor/netcdf_monitor.py
+++ b/ndsl/monitor/netcdf_monitor.py
@@ -5,10 +5,10 @@ from warnings import warn
 import numpy as np
 import xarray as xr
 
+from ndsl import ndsl_log
 from ndsl.comm.communicator import Communicator
 from ndsl.dsl import NDSL_GLOBAL_PRECISION
 from ndsl.dsl.typing import Float
-from ndsl.logging import ndsl_log
 from ndsl.monitor.convert import to_numpy
 from ndsl.quantity import Quantity
 

--- a/ndsl/monitor/zarr_monitor.py
+++ b/ndsl/monitor/zarr_monitor.py
@@ -7,9 +7,9 @@ import cftime
 import xarray as xr
 
 import ndsl.constants as constants
+from ndsl import ndsl_log
 from ndsl.comm import Comm
 from ndsl.comm.partitioner import Partitioner, subtile_slice
-from ndsl.logging import ndsl_log
 from ndsl.monitor.convert import to_numpy
 from ndsl.optional_imports import cupy, zarr
 from ndsl.utils import list_by_dims

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -26,7 +26,7 @@ SparseNameMapping = dict[str, DataDimensionIndex]
 
 
 class _DataDimensionsFieldDescriptor(gtscript._FieldDescriptor):
-    """Extension to the gt4py.cartesian.Field to account for sparsly
+    """Extension to the gt4py.cartesian.Field to account for sparsely
     named indexed data dimensions.
     """
 
@@ -182,7 +182,7 @@ class DataDimensionsField(StencilTypeRegistrar):
             quantity_factory: Factory carrying the proper data dimensions axis described
                 in `data_dimensions_names`.
             data_dimensions_names: list of name of data dimension axis.
-            name_mapping: for each dimensions, a sparse dictionnary giving a name/index
+            name_mapping: for each dimensions, a sparse dictionary giving a name/index
                 to retrieve 3D fields by name.
             dtype: Inner data type, defaults to Float.
         """

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -148,7 +148,7 @@ class DataDimensionsField(StencilTypeRegistrar):
             sdfg: SDFG,
             state: SDFGState,
             data_dim_index: int,
-        ) -> Int:
+        ) -> Int:  # type: ignore[valid-type]
             size = cls._type_registrar[name].size(data_dim_index)
             return Int(size)
 

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -91,7 +91,7 @@ class DataDimensionsField(StencilTypeRegistrar):
         quantity_factory: QuantityFactory,
         data_dimensions_names: list[str],
         name_mapping: SparseNameMapping | None = None,
-        dtype: npt.DTypeLike = Float,
+        dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
     ) -> _DataDimensionsFieldDescriptor:
         """Register a type by name by giving the size of its data dimensions and
         optionally a sparse mapping of name/index.
@@ -174,7 +174,7 @@ class DataDimensionsField(StencilTypeRegistrar):
         quantity_factory: QuantityFactory,
         data_dimensions_names: list[str],
         name_mapping: SparseNameMapping | None = None,
-        dtype: npt.DTypeLike = Float,
+        dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
     ) -> "DataDimensionsMarkupType":
         """Declare a data dimension field and register it's size
 

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -6,6 +6,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+from ndsl import ndsl_log
 from ndsl.comm.communicator import CubedSphereCommunicator, TileCommunicator
 from ndsl.comm.mpi import MPI, MPIComm
 from ndsl.comm.partitioner import CubedSpherePartitioner, TilePartitioner
@@ -183,8 +184,6 @@ def test_sequential_savepoint(
     if hasattr(case.testobj, "override_input_netcdf_name"):
         import xarray as xr
 
-        from ndsl.logging import ndsl_log
-
         out_data = (
             xr.open_dataset(
                 os.path.join(
@@ -223,8 +222,6 @@ def test_sequential_savepoint(
     passing_names: list[str] = []
     if hasattr(case.testobj, "override_output_netcdf_name"):
         import xarray as xr
-
-        from ndsl.logging import ndsl_log
 
         out_data = (
             xr.open_dataset(

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -1,12 +1,10 @@
-import logging
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
 import ndsl.dsl.gt4py_utils as utils
-from ndsl.config import Backend
-from ndsl.dsl.stencil import StencilFactory
+from ndsl import Backend, StencilFactory, ndsl_log
 from ndsl.optional_imports import cupy
 from ndsl.quantity import Quantity
 from ndsl.stencils.testing.grid import Grid
@@ -15,8 +13,6 @@ from ndsl.stencils.testing.savepoint import DataLoader
 
 if cupy is None:
     import numpy as cupy
-
-logger = logging.getLogger(__name__)
 
 
 def read_serialized_data(serializer, savepoint, variable):
@@ -430,7 +426,7 @@ class TranslateGrid:
                 # TODO: when grid initialization model exists, may want to use
                 # it to inform this
                 istart, jstart = pygrid.horizontal_starts_from_shape(value.shape)
-                logger.debug(
+                ndsl_log.debug(
                     "Storage for Grid variable {}, {}, {}, {}".format(
                         key, istart, jstart, value.shape
                     )

--- a/tests/monitor/test_netcdf_monitor.py
+++ b/tests/monitor/test_netcdf_monitor.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import timedelta
 from typing import List
 
@@ -17,9 +16,6 @@ from ndsl import (
 )
 from ndsl.config import Backend
 from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
-
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("layout", [(1, 1), (1, 2), (4, 4)])

--- a/tests/monitor/test_zarr_monitor.py
+++ b/tests/monitor/test_zarr_monitor.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 import tempfile
 from datetime import datetime, timedelta
 
@@ -22,8 +21,6 @@ from ndsl.constants import (
 from ndsl.monitor.zarr_monitor import ZarrMonitor, array_chunks, get_calendar
 from ndsl.optional_imports import zarr
 
-
-logger = logging.getLogger("test_zarr_monitor")
 
 # pace's K_DIMS doesn't check the soil dimension
 ALL_K_DIMS = ("k", "k_interface", "k_soil")


### PR DESCRIPTION
# Description

Some (mostly mechanical) cleanups around logging:

1. Make sure we use the ndsl logger in all places.
2. Expose `ndsl_log_on_rank_0` from `ndsl/__init__.py`
3. Import ndsl loggers directly `from ndsl`

The type changes in the `QuantityFactory` are just for consistency. The type ignores were necessary because - for whatever reason - these changes triggered `mypy` to scan more code or in a different order. In any case, it started complaining. And since both `Int` and `FloatField` are types which which are only set a runtime, `mypy` can't evaluate them, and thus flags them as invalid types :/

/cc @FlorianDeconinck FYI

## How has this been tested?

Covered by CI.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
