### PR TITLE
docs: add documentation for `max_dim` in `make_storage_data()`

### DIFF
--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -88,7 +88,8 @@ def make_storage_data(
         start: Starting points for slices in data copies
         dummy: Dummy axes
         axis: Axis for 2D to 3D arrays
-        max_dim: ?
+        max_dim: Number of cartesian dimensions. Those will be index-aligned,
+            while additional "data" dimensions are considered "en block".
         read_only: ?
 
     Returns:


### PR DESCRIPTION
# Description

Quick follow-up from https://github.com/NOAA-GFDL/NDSL/pull/473 to add a docstring for `max_dims` in `make_storage_data()` of `gt4py_utils.py`.

## How has this been tested?

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings: N/A
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
