### PR TITLE
ci: pin version of pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ hmm-cuda13 = ['numpy_allocator', 'ndsl[cuda13]']
 pyfms = ["pyfms @ git+https://github.com/noaa-gfdl/pyfms.git"]
 serialbox = ["serialbox @ git+https://github.com/FlorianDeconinck/serialbox.git@feature/data_ijkbuff#subdirectory=src/serialbox-python"]
 test = [
-  "pytest<9.1.0", # starting with 9.1.0 we get issues with test detection
+  "pytest<9.1.0",  # starting with 9.1.0 we get issues with test detection
   "coverage"
 ]
 zarr = ["zarr<3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ hmm-cuda12 = ['numpy_allocator', 'ndsl[cuda12]']
 hmm-cuda13 = ['numpy_allocator', 'ndsl[cuda13]']
 pyfms = ["pyfms @ git+https://github.com/noaa-gfdl/pyfms.git"]
 serialbox = ["serialbox @ git+https://github.com/FlorianDeconinck/serialbox.git@feature/data_ijkbuff#subdirectory=src/serialbox-python"]
-test = ["pytest", "coverage"]
+test = [
+  "pytest<9.1.0", # starting with 9.1.0 we get issues with test detection
+  "coverage"
+]
 zarr = ["zarr<3"]
 
 [project.scripts]


### PR DESCRIPTION
# Description

Starting with version 9.1.0 of pytest, we get test collection errors in tests that make heavy use of fixtures and parametrizations.

In particular we're seeing

```none
tests/test_halo_update.py::test_halo_update_timer: duplicate parametrization of 'layout'
```

Further reading: [release notes](https://docs.pytest.org/en/stable/changelog.html#pytest-9-1-0-2026-06-13) for `pytest==9.1.0`.

## How has this been tested?

Locally with a fresh checkout / install such that I get the latest version of `pytest` (and all other dependencies).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
