### PR TITLE
ci: show linting issues (in color) in the CI logs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,4 +36,4 @@ jobs:
         run: pip install pre-commit
 
       - name: Run lint via pre-commit
-        run: pre-commit run --all-files
+        run: pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
# Description

Currently, when linting fails, we don't see exactly what's wrong with the code in the CI logs. This small PR fixes that. Similar to e.g. https://github.com/spcl/dace/pull/2337.

## How has this been tested?

Not really, but it's copied straight from https://github.com/spcl/dace/pull/2337, which is basically the same change.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
