### PR TITLE
build: ignore non-version tags in setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools >= 80", "setuptools-scm>=8"]
+requires = ["setuptools >= 80", "setuptools-scm>=10"]
 
 [project]
 authors = [{name = "NOAA/NASA"}]
@@ -147,3 +147,4 @@ include = ["ndsl", "ndsl.*"]
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"
+tag.strict = "true"  # only consider tags with at least one dot (e.g. v1.0, 2025.06.03)


### PR DESCRIPTION
# Description

We use `setuptools-scm` for automatic versioning based on git tags. This package gets confused by the `OPTI_V*` tags recently introduced to tag optimization versions for the June/July presentation.

In this commit we enforce a stricter matching of version tags. This stricter matching only considers tags with at least one dot, e.g. `1.0` or `2026.06.00` get a match while `OPTI_V9` gets ignored. According to `setuptools_scm` docs, `tag.scrict = True` will become the default in future versions.

We need to update the minimal version of `setuptools_scm` to have access to this stricter tag matching.

## How has this been tested?

Tested with our current working branches on NDSL and pyFV3. [before](https://github.com/NOAA-GFDL/pyFV3/actions/runs/27968227439/job/82767490274) and [after](https://github.com/NOAA-GFDL/pyFV3/actions/runs/27968227439/job/82884056863) pipelines of our pyFV3 working branch.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
