### PR TITLE
ci: fix docs deploy

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: 3.11
-      - run: pip install zensical
+      - run: pip install zensical mkdocstrings[python]
       - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
# Description

After fixing some configuration issues, deploying the new docs now just fails because of missing dependencies (see [this run](https://github.com/NOAA-GFDL/NDSL/actions/runs/28082976371/job/83225442376)). This PR remedies the problem by installing the same dependencies (in particular `mkdocstrings` with `python` support) as in the "Build docs" step that already runs successfully.

## How has this been tested?

Not really ;)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
