### PR TITLE
docs: some typos and markdown fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,5 +26,5 @@ Describe the system environment, include:
 - If this bug came from a model run, which model
 
 **Additional context**
-Add any other context about the problem.  If applicable, include where any files
+Add any other context about the problem. If applicable, include where any files
 that help describe, or reproduce the problem exist.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -10,5 +10,5 @@ assignees: ''
 A clear and concise description of what the problem is.
 
 **Describe what you have tried**
-A clear and concise description of what steps you have taken.  Include command
+A clear and concise description of what steps you have taken. Include command
 lines, and any messages from the command.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ NDSL is under active development and may only work with specific setups. This is
 The run the CPU backends you will need:
 
 - Python: 3.11, 3.12, 3.13
-- CXX compiler:  GNU 11.2+
+- CXX compiler: GNU 11.2+
 - Libraries: MPI
 
 To run the GPU backends, you'll need:
 
 - Python: 3.11, 3.12, 3.13
-- CXX compiler:  GNU 11.2+
+- CXX compiler: GNU 11.2+
 - Libraries: MPI compiled with CUDA support
 - CUDA 11.2+
 - Python package:
@@ -94,7 +94,7 @@ mpirun -np 6 pytest -m "parallel and not gpu" tests/
 
 ### Code/contribution guidelines
 
-1. Code quality is enforced by `pre-commit` (which is part of the "dev" extra). Run `pre-commit install`  to install the pre-commit hooks locally or make sure to run `pre-commit run -a`  before submitting a pull request.
+1. Code quality is enforced by `pre-commit` (which is part of the "dev" extra). Run `pre-commit install` to install the pre-commit hooks locally or make sure to run `pre-commit run -a` before submitting a pull request.
 2. While we don't strictly enforce type hints, we add them on new code.
 3. Pull requests have to merged as "squash merge" to keep the `git` history clean.
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -3,7 +3,6 @@
 The NDSL community is a collaborative space for scientists, developers, and researchers working on next-generation Earth system modeling. Whether you're getting
 started, contributing code, or running experiments, we’re here to support you.
 
-
 <div class="two-col" markdown>
 <div class="section-card" markdown>
 ## Get Involved
@@ -28,6 +27,7 @@ Join the NDSL community for discussions, questions, collaboration opportunities,
 For collaboration opportunities, technical support, or project inquiries, please reach out to the NDSL team.
 
 ### Primary Contacts
+
 <div class="three-col wide-grid" markdown>
 <div class="section-card tight-card" markdown>
 ## Florian Deconinck
@@ -60,5 +60,6 @@ rusty.benson@noaa.gov
 | Support Scientist | Katrina Fandrich | katrina.fandrich@nasa.gov |
 | Support Scientist | Janice Kim | janice.kim@noaa.gov
 | Support Scientist | Charles Kropiewnicki | charles.kropiewnicki@nasa.gov |
-| Support Scientist | Frank Malatino | frank.malatino@noaa.gov
+| Support Scientist | Frank Malatino | frank.malatino@noaa.gov |
+
 </div>

--- a/docs/download/local_build.md
+++ b/docs/download/local_build.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 * `tcsh` for GEOS workflow
-* A `gcc/g++/gfortran` compiler (gcc-12 is our current workhorse in Linux.  macOS has been tested using gcc-14 via Homebrew)
+* A `gcc/g++/gfortran` compiler (gcc-12 is our current workhorse in Linux. macOS has been tested using gcc-14 via Homebrew)
     * As of macOS Sequoia 15.5, `clang/clang++` can also be used in place of `gcc/g++`.
 * If using macOS, [Homebrew](https://brew.sh/) is needed to install certain packages
 

--- a/docs/ndsl_in_action/index.md
+++ b/docs/ndsl_in_action/index.md
@@ -9,7 +9,7 @@ the development of a standalone model.
 <div class="section-card" markdown>
 ### NASA
 
-NDSL is being used to accerate the Goddard Earth Observing System
+NDSL is being used to accelerate the Goddard Earth Observing System.
 
 [See How →](./nasa/index.md){ .pretty-link }
 </div>
@@ -17,7 +17,7 @@ NDSL is being used to accerate the Goddard Earth Observing System
 <div class="section-card" markdown>
 ### NOAA
 
-NDSL has been used to create an accelerate version of the Finite Volume Cubed dynamical core and run the standalone PACE model
+NDSL has been used to create an accelerate version of the Finite Volume Cubed dynamical core and run the standalone PACE model.
 
 [NDSL at NOAA →](https://www.gfdl.noaa.gov/wp-content/uploads/2025/01/2025ReviewQ1-2_PaceDSLModeling.pdf){ .pretty-link }
 </div>

--- a/docs/ndsl_in_action/nasa/full_results.md
+++ b/docs/ndsl_in_action/nasa/full_results.md
@@ -1,6 +1,7 @@
 # GEOS Integration Results
 
 Four components of GEOS has been ported to NDSL:
+
 - Finite Volume Cubed (FV3) Dynamical Core
 - Geophysical Fluid Dynamics Lab Single-Moment Microphysics
 - Grell-Freitas Convection Parameterization
@@ -12,14 +13,13 @@ has errors of no more than six orders of magnitude less than the observed value 
 that numerical accuracy is maintained.
 
 Ported code is tested for numerical accuracy by running "translate tests" - a numerical comparison of the ported code and the original Fortran code on a single timestep
-in isolation from the rest of the model. Validation has been performed using Single Column Model (SCM) runs and General Cirtulation Model (GCM) runs. For SCM experiments,
+in isolation from the rest of the model. Validation has been performed using Single Column Model (SCM) runs and General Circulation Model (GCM) runs. For SCM experiments,
 the ported code is verified independently on each of the first 20 timesteps. For GCM runs (at C24 horizontal resolution), only the first ten timesteps are verified.
 A successful, or "passed" test signals that numerical accuracy has been maintained in the ported code.
 
-Next, scientific validity is assesed by comparing the output of a full model runs (SCM or GCM) using either the Fortran and NDSL component. This analysis has been
+Next, scientific validity is assessed by comparing the output of a full model runs (SCM or GCM) using either the Fortran and NDSL component. This analysis has been
 performed with three SCM experiments ("bomex", "armtwp-ice", and "armtwp-july97") and a GCM run initialized on 14 April 2000. SCM experiments ran for their entire
 durations, while GCM runs were limited to 10 days.
-
 
 More information on the benchmarking process coming soon...
 
@@ -54,7 +54,9 @@ More information on the benchmarking process coming soon...
         ![V](../../img/gcm_V_gfdl1m_c180_l72_7days.png)
 
 ### Performance Benchmarks
+
 Coming soon...
+
 <!-- | Resolution | Layout | Fortran | NDSL GPU (st:dace:gpu) | NDSL CPU (st:dace:cpu:KJI) | Speedup (GPU) | Speedup (CPU) |
 |---|---|---|---|---|---|---|
 | C180 (~51 km) | 4×4 | 0.23 s | 0.04 s | 0.37 s | 6.29× | -1.62× |
@@ -96,7 +98,9 @@ Coming soon...
         ![V](../../img/gcm_V_uw_c180_l72_7days.png)
 
 ### Performance Benchmarks
+
 Coming soon...
+
 <!-- | Resolution | Layout | Fortran | NDSL GPU (dace:gpu) | NDSL CPU (gt:cpu_kfirst) | Speedup (GPU) | Speedup (CPU) |
 |---|---|---|---|---|---|---|
 | C180 (~51 km) | 4×4 | 0.23 s | 0.04 s | 0.37 s | 6.29× | -1.62× |
@@ -132,7 +136,9 @@ Coming soon...
         ![V](../../img/gcm_V_gf2020_c48_l72_7days.png)
 
 ### Performance Benchmarks
+
 Coming soon...
+
 <!-- | Resolution | Layout | Fortran | NDSL GPU (st:dace:gpu) | NDSL CPU (st:dace:cpu:KJI) | Speedup (GPU) | Speedup (CPU) |
 |---|---|---|---|---|---|---|
 | C180 (~51 km) | 4×4 | 0.23 s | 0.04 s | 0.37 s | 6.29× | -1.62× |
@@ -164,7 +170,9 @@ Work concluded June 2026.
         ![Hovmoller](../../img/scm_moist_armtwp_ice_hovmoller_gpu_72.png)
 
 ### Benchmarks
+
 Coming soon...
+
 <!-- | Resolution | Layout | Fortran | NDSL GPU (st:dace:gpu) | NDSL CPU (st:dace:cpu:KJI) | Speedup (GPU) | Speedup (CPU) |
 |---|---|---|---|---|---|---|
 | C180 (~51 km) | 4×4 | 0.23 s | 0.04 s | 0.37 s | 6.29× | -1.62× |

--- a/docs/ndsl_in_action/nasa/index.md
+++ b/docs/ndsl_in_action/nasa/index.md
@@ -17,7 +17,6 @@ the Fortran and NDSL.
 A selection of results can be seen below. More details on how numerical validation is performed and access to full results and associated data sets can be
 found [here](./full_results.md).
 
-
 ##### Benchmarking
 
 Coming soon...

--- a/docs/ndsl_in_action/noaa/index.md
+++ b/docs/ndsl_in_action/noaa/index.md
@@ -1,3 +1,0 @@
-information about noaa's work goes here
-
-https://www.gfdl.noaa.gov/wp-content/uploads/2025/01/2025ReviewQ1-2_PaceDSLModeling.pdf

--- a/docs/user_manual/advanced_features.md
+++ b/docs/user_manual/advanced_features.md
@@ -15,7 +15,7 @@ To help illustrate them, let's create a simple stencil where we convert temperat
 to Kelvin:
 
 
-    ``` py linenums="1"
+    ```py linenums="1"
     from ndsl.dsl.gt4py import PARALLEL, computation, interval
     from ndsl import StencilFactory
     from ndsl.boilerplate import get_factories_single_tile
@@ -88,7 +88,7 @@ where a constant is referenced numerous times throughout a stencil.
 
 To build the stencil with an external, we just need to add a single argument to the build command:
 
-``` py linenums="19"
+```py linenums="19"
         self.constructed_copy_stencil = stencil_factory.from_dims_halo(
             func=celsius_to_kelvin,
             compute_dims=[X_DIM, Y_DIM, Z_DIM],
@@ -100,7 +100,7 @@ To build the stencil with an external, we just need to add a single argument to 
 
 And then to load in the external within the stencil:
 
-``` py linenums="9"
+```py linenums="9"
 def celsius_to_kelvin(temperature_Celsius: FloatField, temperature_Kelvin: FloatField):
     # read in the external
     from __externals__ import C_TO_K
@@ -134,7 +134,7 @@ includes the entire domain. There is another method - `from_origin_domain`, whic
 flexibility (in fact, `from_dims_halo` calls this method with fixed arguments). Modifying our
 example above:
 
-``` py linenums="15"
+```py linenums="15"
 class Convert:
     def __init__(self, stencil_factory: StencilFactory, domain):
 
@@ -150,7 +150,7 @@ class Convert:
 
 and now we need to pass in an additional argument to the class:
 
-``` py linenums="43"
+```py linenums="43"
     convert = Convert(stencil_factory, domain)
 ```
 

--- a/docs/user_manual/backends.md
+++ b/docs/user_manual/backends.md
@@ -11,7 +11,7 @@
 
 Throughout this user manual, we have been building our factories with some version of the following code:
 
-``` py linenums="1"
+```py linenums="1"
 domain = (5, 5, 3)
 nhalo = 0
 backend = "numpy"
@@ -27,7 +27,7 @@ stencil_factory, quantity_factory = get_factories_single_tile(
 but we have thus far glossed over what "backend" means. It is now time to address that term.
 
 "Backend" refers to the underlying infrastructure that NDSL uses to construct and execute stencils.
-Each backend approaches acceleration in a slightly different way, and by extention has different
+Each backend approaches acceleration in a slightly different way, and by extension has different
 benefits and drawbacks. NDSL has a total of four backends:
 
 - `dace:cpu`: stencils are compiled in C and has multiple optimization passes tailored to CPU execution.

--- a/docs/user_manual/common_patterns.md
+++ b/docs/user_manual/common_patterns.md
@@ -25,7 +25,7 @@ the `Z_INTERFACE_DIM` instead of the `Z_DIM`, and then restrict your interval an
 stencil reads accordingly:
 
 Example "Fortran code":
-    ``` fortran linenums="1"
+    ```fortran linenums="1"
     program compute_height
         implicit none
 
@@ -42,7 +42,7 @@ Example "Fortran code":
         real, dimension(X_DIM, Y_DIM, Z_DIM) :: d_height
         real, dimension(X_DIM, Y_DIM, Z_DIM+1) :: height
 
-        ! initalize data
+        ! initialize data
         do i = 1, X_DIM
             do j = 1, Y_DIM
                 do k = 1, Z_DIM
@@ -68,7 +68,7 @@ Example "Fortran code":
 
 Example "NDSL Code"
 
-``` py linenums="1"
+```py linenums="1"
 from ndsl.dsl.gt4py import (
     computation,
     interval,
@@ -151,7 +151,7 @@ one or more operations based on that level (e.g. identify LCL, compute convectiv
 
 Example "Fortran Code":
 
-``` fortran linenums="1"
+```fortran linenums="1"
 program average_below_level
     implicit none
 
@@ -169,7 +169,7 @@ program average_below_level
     integer, dimension(X_DIM, Y_DIM) :: desired_level
     real, dimension(X_DIM, Y_DIM) :: average_temperature
 
-    ! initalize data
+    ! initialize data
     p_crit = 500
     do k = 1, Z_DIM
         pressure(:, :, k) = 1000 - (k-1) * 100 ! pressure decreases by 100mb per level
@@ -215,7 +215,7 @@ end program average_below_level
 
 Example "NDSL Code"
 
-``` py linenums="1"
+```py linenums="1"
 from ndsl.dsl.gt4py import (
     FORWARD,
     computation,
@@ -324,7 +324,7 @@ NDSL systems:
 
 Example "Fortran Code"
 
-``` fortran linenums="1"
+```fortran linenums="1"
 program make_table
 
     implicit none
@@ -352,7 +352,7 @@ end program make_table
 
 Example "NDSL Code"
 
-``` py linenums="1"
+```py linenums="1"
 from ndsl.dsl.gt4py import (
     computation,
     interval,
@@ -416,7 +416,7 @@ class ConstructTable:
 
 
 if __name__ == "__main__":
-    # consider the following model domain and factories are presnet
+    # consider the following model domain and factories are present
     domain = (10, 10, 10)
     nhalo = 0
     stencil_factory, quantity_factory = get_factories_single_tile(
@@ -456,7 +456,7 @@ if __name__ == "__main__":
         compute_dims=[X_DIM, Y_DIM, Z_DIM],
     )
 
-    # # initalize array for calculation using table
+    # initialize array for calculation using table
     out_field = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], "n/a")
 
     use_table(out_field, construct_table.table)
@@ -472,12 +472,14 @@ to the larger model grid specifications:
 Example "NDSL Code"
 
 This type is defined using the following pattern:
-``` py
+
+```py
 GlobalTable_local_type = GlobalTable[(<data type (Float/Int/Bool)>, int(table_size))]
 ```
 
 And accurately typed and referenced within the stencil:
-``` py
+
+```py
 def stencil(data: FloatField, table: GlobalTable_local_type):
     with computation(PARALLEL), interval(...):
         data = table.A[desired_index]
@@ -490,18 +492,18 @@ support optional field inputs (a quantity with one or more dimensions) but it is
 optional scalar inputs.
 
 For a field, the best way to create an "optional" input in NDSL is to create a situation where an input
-(which is always suppled) has the option of being used - a calculation tied to some boolean, perhaps.
+(which is always supplied) has the option of being used - a calculation tied to some boolean, perhaps.
 Furthermore, the field supplied need not be relevant. If the option will never be used, a dummy
 field can be passed to satisfy the API of the function and simply never touched (or touched, with the result
 discarded upon completion of the function).
 
 For scalar inputs, the notation is quite similar to that of traditional Python. Note that NDSL requires
-that all scalars - if not suppled - have a default value, and that default value must be of the declared type
+that all scalars - if not supplied - have a default value, and that default value must be of the declared type
 (see line 19 of the example below):
 
 Example "NDSL Code"
 
-``` py linenums="1"
+```py linenums="1"
 
 from ndsl.dsl.gt4py import (
     computation,
@@ -583,7 +585,7 @@ program conditional_calculation
     logical, dimension(X_DIM, Y_DIM) :: mask
 
     critical_value = 5
-    ! initalize data
+    ! initialize data
     do i = 1, X_DIM
         do j = 1, Y_DIM
             do k = 1, Z_DIM
@@ -622,7 +624,7 @@ end program conditional_calculation
 
 Example "NDSL Code"
 
-``` py linenums="1"
+```py linenums="1"
 from ndsl.dsl.gt4py import PARALLEL, FORWARD, computation, interval, exp, function
 from ndsl import StencilFactory
 from ndsl.boilerplate import get_factories_single_tile
@@ -729,7 +731,7 @@ program nested_k_loop
     ! allocate arrays
     integer, dimension(X_DIM, Y_DIM, Z_DIM) :: in_data, out_data
 
-    ! initalize data
+    ! initialize data
     do i = 1, X_DIM
         do j = 1, Y_DIM
             do k = 1, Z_DIM
@@ -760,7 +762,7 @@ end program nested_k_loop
 
 Example "NDSL Code"
 
-``` py linenums="1"
+```py linenums="1"
 from ndsl.dsl.gt4py import (
     computation,
     interval,

--- a/docs/user_manual/data.md
+++ b/docs/user_manual/data.md
@@ -51,7 +51,7 @@ therefore do not have access to the following functionality.
 
 Below is an example of how to initialize an NDSL quantity with three dimensions:
 
-``` py linenums="1"
+```py linenums="1"
 from ndsl.boilerplate import get_factories_single_tile
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 
@@ -76,7 +76,7 @@ the type of data stored in the quantity, and can be `Float`/`Int`/`Bool`.
 
 Finally, we can print the quantity we have just created to check our work. Based on the code above,
 
-``` py linenums="11"
+```py linenums="11"
 print(quantity_example)
 ```
 

--- a/docs/user_manual/why_use_classes.md
+++ b/docs/user_manual/why_use_classes.md
@@ -11,16 +11,18 @@
 
 ## What is a Python Class?
 
-A Python `class` is like a template or blueprint for creating objects — in this example, our class
+A Python `class` is like a template or blueprint for creating objects. In this example, our class
 creates tools to check if the condensation is likely to occur based on temperature and dew point at
 a certain location.
 
-Think of it like this: <br>
-- A `function` does one task. <br>
+Think of it like this:
+
+- A `function` does one task.
 - A `class` bundles together data and functions (called methods) that relate to a single concept —
 like checking condensation.
 
 For example:
+
 ```py
 class CondensationChecker:
     def __init__(self, location, temperature_c, dew_point_c):
@@ -33,11 +35,10 @@ class CondensationChecker:
 
     def report(self):
         # Prints the current condition and whether condensation is likely
+        ...
 ```
 
-Here: <br>
-The data: temperature, dew point, location <br>
-The behavior: check_condensation(), report() <br>
+Here we bundle temperature, dew point and location as _data_ with the `check_condensation()` and `report()` as behavior.
 
 ## What are Classes used for?
 
@@ -50,7 +51,6 @@ station.report()
 ```
 
 The object `station` holds its own data and can run its own analysis on the data provided.
-
 
 ## Why use a Class instead of just functions?
 
@@ -67,10 +67,12 @@ You’d need to manually pass temperature and dew point every single time, and i
 group this data together. You also can't easily add more features like location, time, or logging.
 
 With a `class`:
+
 ```py
 station = CondensationChecker("Berlin", 12.0, 12.5)
 station.report()
 ```
+
 This is a much cleaner option — all related data is stored inside the object, and methods operate
 on that data.
 
@@ -80,13 +82,12 @@ on that data.
 
 A class brings data and the functions that operate on it together in one place.
 
-In CondensationChecker: <br>
+In `CondensationChecker`: <br>
 The data: temperature, dew point, location <br>
 The behavior: check_condensation(), report() <br>
 
 These things belong together logically. Instead of keeping temperature and dew point as separate
 variables and writing separate functions, the class keeps them bundled as one logical unit.
-
 
 **Reusability**
 
@@ -94,6 +95,7 @@ You can reuse the same class to create multiple objects representing different c
 without repeating code.
 
 Example:
+
 ```py
 station1 = CondensationChecker("London", 15, 12)
 station2 = CondensationChecker("Barcelona", 28, 27)
@@ -107,35 +109,35 @@ Each station is independent, and the logic to check condensation is shared and r
 Without a class, you'd have to manage multiple sets of variables manually and pass them into
 functions every time — more error-prone and harder to manage.
 
-
 **Easy to Add New Features**
 
 When your code grows in complexity, classes make it easy to add new functionality without breaking
 existing logic.
 
 For example, you can add a method to estimate relative humidity based on existing data:
+
 ```py
 def estimate_relative_humidity(self):
     # Use formula here
+    ...
 ```
 
 This method now becomes part of the condensation checker — you don’t have to touch outside code.
-
 
 **Modularity**
 
 Classes act like building blocks for larger systems. You can isolate pieces of your program into
 logical units.
 
-
 **Maintainability and Cleanliness: Easier to Read, Debug, and Scale**
 
 When your project grows, keeping code maintainable is very important.
 
-With a class: <br>
-- Each part of the program has a clear purpose. <br>
-- You can fix or update just one class without affecting others. <br>
-- You don’t have to trace global variables across multiple files. <br>
+With a class:
 
-If someone new joins your team, they can understand what CondensationChecker does just by reading
+- Each part of the program has a clear purpose.
+- You can fix or update just one class without affecting others.
+- You don’t have to trace global variables across multiple files.
+
+If someone new joins your team, they can understand what `CondensationChecker` does just by reading
 that one class.

--- a/docs/user_manual/writing_ndsl_code.md
+++ b/docs/user_manual/writing_ndsl_code.md
@@ -37,7 +37,7 @@ an example of a stencil that copies the values of one field into another field.
 
 First, we import several packages:
 
-``` py linenums="1"
+```py linenums="1"
 from ndsl import StencilFactory
 from ndsl.boilerplate import get_factories_single_tile
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
@@ -48,7 +48,7 @@ from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
 Next, we define our stencil template:
 
-``` py linenums="7"
+```py linenums="7"
 def copy_stencil(in_field: FloatField, out_field: FloatField):
     with computation(PARALLEL):
         with interval(...):
@@ -67,7 +67,7 @@ does not match the declared type.
 Looking into the stencil code, we can see the two most important keywords in NDSL.
 
 The statement `with computation(argument)` sets the iteration policy of the nested code. In this case,
-we have declared `with computation(PARALLEL), signaling that *all three* dimensions can be executed in
+we have declared `with computation(PARALLEL)`, signaling that *all three* dimensions can be executed in
 parallel. The statement `with interval(argument)` sets the domain of the nested code. Once again, in this case,
 we have declared `with interval(...)`, signaling that the computation should apply to all vertical levels
 in the compute domain.
@@ -77,7 +77,7 @@ intervals.
 
 Now we set up our class:
 
-``` py linenums="11"
+```py linenums="11"
 class CopyData:
     def __init__(self, stencil_factory: StencilFactory):
 
@@ -101,7 +101,7 @@ scenes, `from_dims_halo` computes these and calls `from_origin_domain` automatic
 
 Finally we can run the program:
 
-``` py linenums="21"
+```py linenums="21"
 if __name__ == "__main__":
 
     domain = (5, 5, 3)
@@ -134,7 +134,7 @@ quantities. In this small-scale example, we use the boilerplate function `get_fa
 supplying it the domain size, halo size, and backend. This function has limited capabilities, but is
 sufficient for most small scale cases - testing code, debugging specific issues, etc. For larger projects
 (such as a full Earth system model), it may be necessary to move away from the boilerplate code to get
-more control over how these factoris are generated - but for now, just focus on using
+more control over how these factories are generated - but for now, just focus on using
 `get_factories_single_tile`, as that will serve you well while you are learning the systems.
 
 ### Temporary Fields
@@ -157,7 +157,7 @@ same statement (e.g. `field = field[0, 0, 1]` is illegal).
 
 With this knowledge, we can now create a stencil that copies data from the level above:
 
-``` py linenums="1"
+```py linenums="1"
 def copy_with_offset(in_field: FloatField, out_field: FloatField):
     with computation(PARALLEL):
         with interval(0, -1):
@@ -195,7 +195,7 @@ opposite (begins at 9, ends at 0).
 `FORWARD` and `BACKWARD` are useful for more complex situations where data is being read with an
 offset and written in the same stencil:
 
-``` py linenums="1"
+```py linenums="1"
 def offset_read_with_write(in_field: FloatField, out_field: FloatField):
     with computation(FORWARD):
         with interval(0, -1):
@@ -234,11 +234,12 @@ each point within the domain.
 
 Functions in NDSL - much like traditional Python functions - serve as a way to store commonly used code so
 that it can be referenced easily from multiple places. NDSL functions (hereafter referred to as "functions")
-can only be used from within stencils, and often act as extentions of the stencil, performing repetitive or
-particualrly detailed operations. Critically, however, functions have a additional set of rules which make
-them different in both appearence and operation stencils which house them.
+can only be used from within stencils, and often act as extensions of the stencil, performing repetitive or
+particularly detailed operations. Critically, however, functions have a additional set of rules which make
+them different in both appearance and operation stencils which house them.
 
 Functions:
+
 - cannot be called outside of a stencil
 - cannot contain the keywords `computation` or `interval` (they rely on the host stencil for this info)
 - are "point operations" - the are executed independently at each point in the compute domain (see below)
@@ -251,12 +252,12 @@ two important ideas which come along with this concept: functions perform operat
 compute domain independently, in isolation from all other points; and (despite this) functions may take
 scalar or fields as inputs. Functions take an entire field as an import (despite only operating on a
 single point in any particular instance) to allow for offset reads of these inputs. It may be necessary
-read an offset from a field within a stencil, and it would be overly combersome to require a series of scalar
+read an offset from a field within a stencil, and it would be overly cumbersome to require a series of scalar
 inputs for each of these offsets.
 
 Beyond their use for potentially reading offsets from the inputs, the concept of a field is effectively
 banned within a stencil. All calculations are performed using scalars. There are no arrays, lists, fields,
-etc. Furthermore, reading a offset (such as `field[0, 0, 1]`) will alwyas produce a scalar, which fits
+etc. Furthermore, reading a offset (such as `field[0, 0, 1]`) will always produce a scalar, which fits
 this paradigm as the rest of the field is effectively discarded.
 
 As a consequence of these rules, functions always return a scalar value. The *stencil* then takes this value
@@ -264,7 +265,7 @@ and writes it to the correct place in the field.
 
 Below is an example of a NDSL function, called from within a stencil:
 
-``` py linenums="1"
+```py linenums="1"
 @gtscript.function
 def add_five(in_field: FloatField):
     out_value = in_field + 5
@@ -277,16 +278,16 @@ def copy_stencil(in_field: FloatField, out_field: FloatField):
             out_field = add_five(in_field)
 ```
 
-It is worth reiterating that, while functions can only have a single return statment, they can return multiple
+It is worth reiterating that, while functions can only have a single return statement, they can return multiple
 value. Such a case would take the following pattern:
-``` py
+
+```py
     field_1, field_2 = my_function(input_1, input_2, input_3)
 ```
 
 Note that functions with multiple returns
 cannot be integrated into larger expressions - they must be written on their own line, and each output must
-be recieved (or discarded with `_`).
-
+be received (or discarded with `_`).
 
 ### Builtin Functions
 
@@ -339,9 +340,7 @@ the following logic applies:
 - It is not possible to call one stencil from within another, as that would create a situation where
 there are two layers of parallelization. If you want to reuse code across multiple stencils, it
 should be put into a function.
-
 - For similar reasons, it is not possible to call a stencil from within a function.
-
 - It is possible to call one function from within another function, and there is no limit on maximum depth.
 
 ## Summary

--- a/zensical.toml
+++ b/zensical.toml
@@ -40,8 +40,7 @@ nav = [
   # Real-world results from running NDSL in GEOS model configurations.
   {"<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.75' stroke-linecap='round' stroke-linejoin='round'><path d='M4 19V5'/><path d='M10 19V9'/><path d='M16 19v-4'/><path d='M22 19V3'/></svg> NDSL In Action" = [
     "ndsl_in_action/index.md",
-    {"NASA" = ["ndsl_in_action/nasa/index.md"]},
-    {"NOAA" = ["ndsl_in_action/noaa/index.md"]}
+    {"NASA" = ["ndsl_in_action/nasa/index.md"]}
   ]},
   # ── API Docs ──────────────────────────────────────────────────────────────
   # Auto-generated reference docs from NDSL Python docstrings (via mkdocstrings).


### PR DESCRIPTION
# Description

Minor changes to the docs, fixing typos and doing some common markdown fixes.

This commit deletes the unused page about NDSL in action at NOAA. The link from the parent page goes directly to the presentation, so this site is unused (and shouldn't be in there).

## How has this been tested?

Locally by running `zensical serve`.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
