### PR TITLE
fix: cube-sphere communitcator rank limits

### DIFF
--- a/ndsl/comm/communicator.py
+++ b/ndsl/comm/communicator.py
@@ -786,7 +786,7 @@ class CubedSphereCommunicator(Communicator[CubedSpherePartitioner]):
                 "Communicator needs to be instantiated with communication subsystem"
                 f" derived from `comm_abc.Comm`, got {type(comm)}."
             )
-        if comm.Get_size() != partitioner.total_ranks:
+        if comm.Get_size() < partitioner.total_ranks:
             raise ValueError(
                 f"was given a partitioner for {partitioner.total_ranks} ranks but a "
                 f"comm object with only {comm.Get_size()} ranks, are we running "


### PR DESCRIPTION
# Description

Weaken the cube-sphere communicator hard ranks limit. We need "at least" not "exactly" the rank number. Iirc this has especially been an issue with "io rank" when running integrated into GEOS.

This is part of building back the "opt_cycle_I"-branch, i.e. trying to get https://github.com/NOAA-GFDL/NDSL/pull/465 into a smaller changeset.

## How has this been tested?

Running dynamics as part of the June push. @FlorianDeconinck is there an easy way to test this?

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
     ???
