### PR TITLE
feat: get equivalent backend with some part different

### DIFF
--- a/ndsl/config/backend.py
+++ b/ndsl/config/backend.py
@@ -189,19 +189,48 @@ class Backend:
         return self._device == BackendTargetDevice.GPU
 
     def equivalent_cpu_backend(self) -> "Backend":
-        """Return the equivalent backend (same strategy, framework and loop order) but for CPU device"""
+        """Return the equivalent backend (same strategy, framework and loop order) but for CPU device."""
         if self._device == BackendTargetDevice.CPU:
             return self
         return Backend(
-            f"{self._strategy}:{self._framework}:{BackendTargetDevice.CPU}:{self._loop_order}"
+            f"{self._strategy.value}:{self._framework.value}:{BackendTargetDevice.CPU.value}:{self._loop_order.value}"
+        )
+
+    def equivalent_gpu_backend(self) -> "Backend":
+        """Return the equivalent backend (same strategy, framework and loop order) but for GPU device."""
+        if self._device == BackendTargetDevice.GPU:
+            return self
+        return Backend(
+            f"{self._strategy.value}:{self._framework.value}:{BackendTargetDevice.GPU.value}:{self._loop_order.value}"
         )
 
     def equivalent_stencil_backend(self) -> "Backend":
-        """Return the equivalent backend (same device, framework and loop order) but for Stencil strategy"""
+        """Return the equivalent backend (same device, framework and loop order) but for Stencil strategy."""
         if self._strategy == BackendStrategy.STENCIL:
             return self
         return Backend(
-            f"{BackendStrategy.STENCIL}:{self._framework}:{self._device}:{self._loop_order}"
+            f"{BackendStrategy.STENCIL.value}:{self._framework.value}:{self._device.value}:{self._loop_order.value}"
+        )
+
+    def equivalent_orchestration_backend(self) -> "Backend":
+        """Return the equivalent backend (same device, framework and loop order) but with orchestration strategy."""
+        if self._strategy == BackendStrategy.ORCHESTRATION:
+            return self
+        return Backend(
+            f"{BackendStrategy.ORCHESTRATION.value}:{self._framework.value}:{self._device.value}:{self._loop_order.value}"
+        )
+
+    def equivalent_backend_with_loop_order(
+        self, loop_order: BackendLoopOrder
+    ) -> "Backend":
+        """
+        Return the equivalent backend (same strategy, framework, and device) with a different loop order.
+        """
+        if self._loop_order == loop_order:
+            return self
+
+        return Backend(
+            f"{self._strategy.value}:{self._framework.value}:{self._device.value}:{loop_order.value}"
         )
 
     def is_fortran_aligned(self) -> bool:

--- a/ndsl/config/backend.py
+++ b/ndsl/config/backend.py
@@ -189,16 +189,20 @@ class Backend:
         return self._device == BackendTargetDevice.GPU
 
     def equivalent_cpu_backend(self) -> "Backend":
-        """Return the equivalent backend (same strategy, framework and loop order) but for CPU device""" 
+        """Return the equivalent backend (same strategy, framework and loop order) but for CPU device"""
         if self._device == BackendTargetDevice.CPU:
             return self
-        return Backend(f"{self._strategy}:{self._framework}:{BackendTargetDevice.CPU}:{self._loop_order}")
+        return Backend(
+            f"{self._strategy}:{self._framework}:{BackendTargetDevice.CPU}:{self._loop_order}"
+        )
 
     def equivalent_stencil_backend(self) -> "Backend":
         """Return the equivalent backend (same device, framework and loop order) but for Stencil strategy"""
         if self._strategy == BackendStrategy.STENCIL:
             return self
-        return Backend(f"{BackendStrategy.STENCIL}:{self._framework}:{self._device}:{self._loop_order}")
+        return Backend(
+            f"{BackendStrategy.STENCIL}:{self._framework}:{self._device}:{self._loop_order}"
+        )
 
     def is_fortran_aligned(self) -> bool:
         """Check that the standard 3D field on cartesian axis is memory-aligned with Fortran

--- a/ndsl/config/backend.py
+++ b/ndsl/config/backend.py
@@ -188,6 +188,18 @@ class Backend:
     def is_gpu_backend(self) -> bool:
         return self._device == BackendTargetDevice.GPU
 
+    def equivalent_cpu_backend(self) -> "Backend":
+        """Return the equivalent backend (same strategy, framework and loop order) but for CPU device""" 
+        if self._device == BackendTargetDevice.CPU:
+            return self
+        return Backend(f"{self._strategy}:{self._framework}:{BackendTargetDevice.CPU}:{self._loop_order}")
+
+    def equivalent_stencil_backend(self) -> "Backend":
+        """Return the equivalent backend (same device, framework and loop order) but for Stencil strategy"""
+        if self._strategy == BackendStrategy.STENCIL:
+            return self
+        return Backend(f"{BackendStrategy.STENCIL}:{self._framework}:{self._device}:{self._loop_order}")
+
     def is_fortran_aligned(self) -> bool:
         """Check that the standard 3D field on cartesian axis is memory-aligned with Fortran
         striding."""

--- a/tests/config/test_backend.py
+++ b/tests/config/test_backend.py
@@ -1,9 +1,10 @@
 import pytest
 
 from ndsl import Backend
+from ndsl.config import BackendLoopOrder
 
 
-def test_backend_building():
+def test_backend_building() -> None:
     Backend("st:python:cpu:IJK")
     Backend("st:numpy:cpu:IJK")
     Backend("st:gt:cpu:IJK")
@@ -23,9 +24,29 @@ def test_backend_building():
         Backend(unknown_backend)
 
 
-def test_backend_operators():
+def test_backend_operators() -> None:
     backend_A = Backend("st:numpy:cpu:IJK")
     backend_B = Backend("st:numpy:cpu:IJK")
 
     assert backend_A == backend_B
     assert not (backend_A != backend_B)
+
+
+def test_equivalent_backend() -> None:
+    orchestrated_backend = Backend("orch:dace:cpu:IJK")
+    stencil_backend = orchestrated_backend.equivalent_stencil_backend()
+    assert stencil_backend.is_stencil()
+    assert stencil_backend.equivalent_orchestration_backend() == orchestrated_backend
+
+    cpu_backend = Backend("orch:dace:cpu:KJI")
+    gpu_backend = cpu_backend.equivalent_gpu_backend()
+    assert gpu_backend.is_gpu_backend()
+    assert gpu_backend.equivalent_cpu_backend() == cpu_backend
+
+    ijk_backend = Backend("st:dace:cpu:IJK")
+    kji_backend = ijk_backend.equivalent_backend_with_loop_order(BackendLoopOrder.KJI)
+    assert kji_backend.loop_order == BackendLoopOrder.KJI
+    assert (
+        kji_backend.equivalent_backend_with_loop_order(BackendLoopOrder.IJK)
+        == ijk_backend
+    )


### PR DESCRIPTION
# Description

This PR extends the backend class with convenience methods to return an "equivalent" backend that differs in just one part (device, loop order, strategy).

## How has this been tested?

New unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
