### PR TITLE
refactor: readability of cache location code

### DIFF
--- a/ndsl/dsl/caches/__init__.py
+++ b/ndsl/dsl/caches/__init__.py
@@ -1,0 +1,8 @@
+from .cache_location import identify_code_path
+from .codepath import FV3CodePath
+
+
+__all__ = [
+    "identify_code_path",
+    "FV3CodePath",
+]

--- a/ndsl/dsl/caches/cache_location.py
+++ b/ndsl/dsl/caches/cache_location.py
@@ -7,46 +7,48 @@ def identify_code_path(
     partitioner: Partitioner,
     single_code_path: bool,
 ) -> FV3CodePath:
-    """Determine which code path your rank will hit.
+    """
+    Determine which code path your rank will hit.
 
-    If single_code_path is True, single_code_path is True,
-    only one code path exists (case of doubly periodic grid).
+    If single_code_path is True, only one code path exists,
+    e.g. in case of a doubly periodic grid.
     If single_code_path is False, we are in the case of the
-    cube-sphere and we will look at our position on the tile."""
+    cube-sphere and we will look at our position on the tile.
+    """
 
     # Doubly-periodic or single tile grid
-    if single_code_path:
+    if single_code_path or partitioner.layout == (1, 1):
         return FV3CodePath.All
 
     # Cube-sphere
-    if partitioner.layout == (1, 1):
-        return FV3CodePath.All
-    elif partitioner.layout[0] == 1 or partitioner.layout[1] == 1:
+    if partitioner.layout[0] <= 1 or partitioner.layout[1] <= 1:
         raise NotImplementedError(
-            f"Build for layout {partitioner.layout} is not handled"
+            f"Build for layout {partitioner.layout} is not handled."
         )
-    else:
-        if partitioner.tile.on_tile_bottom(rank):
-            if partitioner.tile.on_tile_left(rank):
-                return FV3CodePath.BottomLeft
-            if partitioner.tile.on_tile_right(rank):
-                return FV3CodePath.BottomRight
-            else:
-                return FV3CodePath.Bottom
-        if partitioner.tile.on_tile_top(rank):
-            if partitioner.tile.on_tile_left(rank):
-                return FV3CodePath.TopLeft
-            if partitioner.tile.on_tile_right(rank):
-                return FV3CodePath.TopRight
-            else:
-                return FV3CodePath.Top
-        else:
-            if partitioner.tile.on_tile_left(rank):
-                return FV3CodePath.Left
-            if partitioner.tile.on_tile_right(rank):
-                return FV3CodePath.Right
-            else:
-                return FV3CodePath.Center
+
+    # Bottom row
+    if partitioner.tile.on_tile_bottom(rank):
+        if partitioner.tile.on_tile_left(rank):
+            return FV3CodePath.BottomLeft
+        if partitioner.tile.on_tile_right(rank):
+            return FV3CodePath.BottomRight
+        return FV3CodePath.Bottom
+
+    # Top row
+    if partitioner.tile.on_tile_top(rank):
+        if partitioner.tile.on_tile_left(rank):
+            return FV3CodePath.TopLeft
+        if partitioner.tile.on_tile_right(rank):
+            return FV3CodePath.TopRight
+        return FV3CodePath.Top
+
+    # Left & right column with corners already handled
+    if partitioner.tile.on_tile_left(rank):
+        return FV3CodePath.Left
+    if partitioner.tile.on_tile_right(rank):
+        return FV3CodePath.Right
+
+    return FV3CodePath.Center
 
 
 def get_cache_fullpath(code_path: FV3CodePath) -> str:

--- a/tests/dsl/caches/test_cache_location.py
+++ b/tests/dsl/caches/test_cache_location.py
@@ -1,0 +1,111 @@
+from ndsl import TilePartitioner
+from ndsl.dsl.caches import FV3CodePath, identify_code_path
+
+
+def test_single_code_path() -> None:
+    partitioner = TilePartitioner((1, 1))
+    for rank in range(0, 6):
+        assert (
+            identify_code_path(rank, partitioner, single_code_path=True)
+            == FV3CodePath.All
+        )
+
+    partitioner = TilePartitioner((2, 2))
+    for rank in range(0, 24):
+        assert (
+            identify_code_path(rank, partitioner, single_code_path=True)
+            == FV3CodePath.All
+        )
+
+    partitioner = TilePartitioner((3, 3))
+    for rank in range(0, 54):
+        assert (
+            identify_code_path(rank, partitioner, single_code_path=True)
+            == FV3CodePath.All
+        )
+
+
+def test_1x1_layout() -> None:
+    partitioner = TilePartitioner((1, 1))
+    for rank in range(0, 6):
+        assert (
+            identify_code_path(rank, partitioner, single_code_path=False)
+            == FV3CodePath.All
+        )
+
+
+def test_2x2_layout() -> None:
+    partitioner = TilePartitioner((2, 2))
+    for rank in range(0, 24):
+        match rank % 4:
+            case 0:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.BottomLeft
+                )
+            case 1:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.BottomRight
+                )
+            case 2:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.TopLeft
+                )
+            case 3:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.TopRight
+                )
+
+
+def test_3x3_layout() -> None:
+    partitioner = TilePartitioner((3, 3))
+    for rank in range(0, 54):
+        match rank % 9:
+            case 0:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.BottomLeft
+                )
+            case 1:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.Bottom
+                )
+            case 2:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.BottomRight
+                )
+            case 3:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.Left
+                )
+            case 4:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.Center
+                )
+            case 5:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.Right
+                )
+            case 6:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.TopLeft
+                )
+            case 7:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.Top
+                )
+            case 8:
+                assert (
+                    identify_code_path(rank, partitioner, single_code_path=False)
+                    == FV3CodePath.TopRight
+                )


### PR DESCRIPTION
# Description

This PR refactors the cache location code for readability and adds simple test cases for 1x1, 2x2, and 3x3 layouts (with and without `single_code_path` turned on).

This is part of building back the "opt_cycle_I"-branch, i.e. trying to get https://github.com/NOAA-GFDL/NDSL/pull/465 into a smaller changeset.

## How has this been tested?

New test cases.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
