### PR TITLE
refactor: random cleanups from the `opt_cylcle_I`-branch

### DIFF
--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -7,8 +7,8 @@ import numbers
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, cast
 
-import dace
 import numpy as np
+from dace.config import Config as DaceConfig
 from gt4py.cartesian import config as gt_config
 from gt4py.cartesian import definitions as gt_definitions
 from gt4py.cartesian import gtscript
@@ -321,7 +321,7 @@ class FrozenStencil(SDFGConvertible):
             BackendFramework.DACE
             == self.stencil_config.compilation_config.backend.framework
         ):
-            dace.Config.set(
+            DaceConfig.set(
                 "default_build_folder",
                 value="{gt_root}/{gt_cache}/dacecache".format(
                     gt_root=gt_config.cache_settings["root_path"],
@@ -881,6 +881,8 @@ class GridIndexing:
                 return_origin.append(self.origin[1])
             elif dim in K_DIMS:
                 return_origin.append(self.origin[2])
+            else:
+                raise ValueError(f"Unknown dimension '{dim}'.")
         return return_origin
 
     def _domain_from_dims(self, dimensions: Iterable[str]) -> list[int]:
@@ -888,16 +890,18 @@ class GridIndexing:
         for dimension in dimensions:
             if dimension == I_DIM:
                 result.append(self.domain[0])
-            if dimension == I_INTERFACE_DIM:
+            elif dimension == I_INTERFACE_DIM:
                 result.append(self.domain[0] + 1)
-            if dimension == J_DIM:
+            elif dimension == J_DIM:
                 result.append(self.domain[1])
-            if dimension == J_INTERFACE_DIM:
+            elif dimension == J_INTERFACE_DIM:
                 result.append(self.domain[1] + 1)
-            if dimension == K_DIM:
+            elif dimension == K_DIM:
                 result.append(self.domain[2])
-            if dimension == K_INTERFACE_DIM:
+            elif dimension == K_INTERFACE_DIM:
                 result.append(self.domain[2] + 1)
+            else:
+                raise ValueError(f"Unknown dimension '{dimension}'.")
         return result
 
     def get_shape(

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -6,7 +6,6 @@ from types import ModuleType
 from typing import Any, cast
 
 import dace
-import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from gt4py import storage as gt_storage
@@ -459,6 +458,8 @@ class Quantity:
         return transposed
 
     def plot_k_level(self, k_index: int = 0) -> None:
+        import matplotlib.pyplot as plt
+
         field = self._data
         plt.xlabel("I")
         plt.ylabel("J")

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -286,7 +286,7 @@ class Quantity:
     def data(self) -> np.ndarray | cupy.ndarray:
         """The underlying array of data"""
         warnings.warn(
-            "Quantity.data accessor is now deprecated. Use a slicing operation directly on"
+            "Quantity.data accessor is now deprecated. Use a slicing operation directly on "
             "the quantity, e.g. `my_quantity[:]` instead of `my_quantity.data[:]`",
             category=UserWarning,
             stacklevel=2,


### PR DESCRIPTION
# Description

This PR combines

- disambiguate `dace` import in stencil module
- push lazy-import of `matplotlib`
- and some minor clenaups

which are all technically unrelated to the `opt_cycle_I`-branch but in there nevertheless. This PR is part of building back the "opt_cycle_I"-branch, i.e. trying to get https://github.com/NOAA-GFDL/NDSL/pull/465 into a smaller changeset.

## How has this been tested?

Assumed to be covered in one way or another by current tests. At least, it worked on the `opt_cycle_I`-branch when running integrated in GEOS.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
