### PR TITLE
refacor: default single_code_path to `False` when detecting code path

### DIFF
--- a/ndsl/dsl/caches/cache_location.py
+++ b/ndsl/dsl/caches/cache_location.py
@@ -5,7 +5,8 @@ from ndsl.dsl.caches.codepath import FV3CodePath
 def identify_code_path(
     rank: int,
     partitioner: Partitioner,
-    single_code_path: bool,
+    *,
+    single_code_path: bool = False,
 ) -> FV3CodePath:
     """
     Determine which code path your rank will hit.

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -361,7 +361,7 @@ class DaceConfig:
             self.code_path = identify_code_path(
                 self.my_rank,
                 communicator.partitioner,
-                self._single_code_path,
+                single_code_path=self._single_code_path,
             )
             self.layout = communicator.partitioner.layout
             self.do_compile = (

--- a/tests/dsl/caches/test_cache_location.py
+++ b/tests/dsl/caches/test_cache_location.py
@@ -28,10 +28,7 @@ def test_single_code_path() -> None:
 def test_1x1_layout() -> None:
     partitioner = TilePartitioner((1, 1))
     for rank in range(0, 6):
-        assert (
-            identify_code_path(rank, partitioner, single_code_path=False)
-            == FV3CodePath.All
-        )
+        assert identify_code_path(rank, partitioner) == FV3CodePath.All
 
 
 def test_2x2_layout() -> None:
@@ -39,25 +36,13 @@ def test_2x2_layout() -> None:
     for rank in range(0, 24):
         match rank % 4:
             case 0:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.BottomLeft
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.BottomLeft
             case 1:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.BottomRight
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.BottomRight
             case 2:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.TopLeft
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.TopLeft
             case 3:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.TopRight
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.TopRight
 
 
 def test_3x3_layout() -> None:
@@ -65,47 +50,20 @@ def test_3x3_layout() -> None:
     for rank in range(0, 54):
         match rank % 9:
             case 0:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.BottomLeft
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.BottomLeft
             case 1:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.Bottom
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.Bottom
             case 2:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.BottomRight
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.BottomRight
             case 3:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.Left
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.Left
             case 4:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.Center
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.Center
             case 5:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.Right
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.Right
             case 6:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.TopLeft
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.TopLeft
             case 7:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.Top
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.Top
             case 8:
-                assert (
-                    identify_code_path(rank, partitioner, single_code_path=False)
-                    == FV3CodePath.TopRight
-                )
+                assert identify_code_path(rank, partitioner) == FV3CodePath.TopRight


### PR DESCRIPTION
# Description

In `identify_code_path()`, default `single_code_path` to `False`. It is assumed that the default usage of this function is for when we are on the cubed sphere and actually need to compute the code path from the partitioner.

This is a follow-up from  https://github.com/NOAA-GFDL/NDSL/pull/493#pullrequestreview-4610540412 where @twicki  suggested the change and https://github.com/NOAA-GFDL/NDSL/pull/311 where the flag was introduced.

## How has this been tested?

Covered by existing unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
