### PR TITLE
translate tests: fix crash in reporting when comparing scalars

### DIFF
--- a/ndsl/testing/comparison.py
+++ b/ndsl/testing/comparison.py
@@ -339,7 +339,7 @@ class MultiModalFloatMetric(BaseMetric):
             return f"❌ Numerical failures: {failed_indices}/{all_indices} failed - metric: {metric_thresholds}"
 
     def report(self, file_path: str | None = None) -> list[str]:
-        failed_indices = np.logical_not(self.success).nonzero()
+        failed_indices = np.atleast_1d(np.logical_not(self.success)).nonzero()
         # List all errors to terminal and file
         bad_indices_count = len(failed_indices[0])
         if self.changing_column_map is not None:


### PR DESCRIPTION
# Description

UW translate test compares a scalar value (`dotransport`) as part of the translate test. Doing so trips reporting and this change makes it work again \o/

This PR is part of pulling unrelated changes out of https://github.com/NOAA-GFDL/NDSL/pull/465/ in the hopes that we get it eventually down to a manageable size.

## How has this been tested?

Running translate tests of `UW` locally.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
