### PR TITLE
Remove `lineinfo` in `DaCe`

### DIFF
--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -346,6 +346,9 @@ class DaceConfig:
                     value="c",
                 )
 
+            # Debug lineinfo is incorrect anyway for the stencils
+            dace.config.Config.set("compiler", "lineinfo", value="none")
+
         # Attempt to kill the dace.conf to avoid confusion
         dace_conf_to_kill = dace.config.Config.cfg_filename()
         if dace_conf_to_kill is not None:


### PR DESCRIPTION
# Description

Dace has the option to keep line infos around (from parsing). This works by inspecting the python stack (`inspect()` calls), which is kinda slow and since it happens all the time during parsing, parsing gets slow. In this PR, we turn off that feature (there's a switch in the DaCe config to do so) saving us time during parsing. The argument is not only speed but the reasoning that lininfo is anyway not correct for stencil code (because those go through gt4py we don't end up in the actual source code but somewhere in the parsing where DaCe dispatches to gt4py).

## How has this been tested?

This is part of cleaning up the `opt_cycle_I/loop-merge` branch, i.e. PR #465. Parsing times, e.g. in the FV3 tests is significantly slower on `develop` than in this branch showing the speedup we can get.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
