### PR TITLE
feat: support for custom dimensions in `DataDimensionsField`

### DIFF
--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -1,6 +1,6 @@
-import collections
 import inspect
 from dataclasses import dataclass
+from typing import Sequence
 
 import numpy.typing as npt
 from dace import SDFG, SDFGState
@@ -33,8 +33,8 @@ class _DataDimensionsFieldDescriptor(gtscript._FieldDescriptor):
     def __init__(
         self,
         dtype: npt.DTypeLike,
-        axes: gtscript.Axis | collections.abc.Collection,
-        data_dims: tuple[int] | collections.abc.Collection = tuple(),
+        axes: Sequence[gtscript.Axis],
+        data_dims: Sequence[int] = tuple(),
     ) -> None:
         super().__init__(dtype, axes, data_dims)
         self._mapping: SparseNameMapping = {}
@@ -61,7 +61,7 @@ class _DataDimensionFieldMaker(_FieldDescriptorMaker):
     """Factory for DataDimensionsField"""
 
     def __getitem__(
-        self, field_spec: gtscript.Axis | collections.abc.Collection
+        self, field_spec: Sequence[gtscript.Axis]
     ) -> _DataDimensionsFieldDescriptor:
         field_descriptor = super().__getitem__(field_spec)
         return _DataDimensionsFieldDescriptor(
@@ -89,10 +89,11 @@ class DataDimensionsField(StencilTypeRegistrar):
         cls,
         pre_registration_type: "DataDimensionsMarkupType",
         quantity_factory: QuantityFactory,
-        axes: gtscript.Axis,
         data_dimensions_names: list[str],
+        *,
         name_mapping: SparseNameMapping | None = None,
         dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
+        axes: Sequence[gtscript.Axis] = gtscript.IJK,
     ) -> _DataDimensionsFieldDescriptor:
         """Register a type by name by giving the size of its data dimensions and
         optionally a sparse mapping of name/index.
@@ -174,8 +175,10 @@ class DataDimensionsField(StencilTypeRegistrar):
         cls,
         quantity_factory: QuantityFactory,
         data_dimensions_names: list[str],
+        *,
         name_mapping: SparseNameMapping | None = None,
         dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
+        axes: Sequence[gtscript.Axis] = gtscript.IJK,
     ) -> "DataDimensionsMarkupType":
         """Declare a data dimension field and register it's size.
 
@@ -194,8 +197,9 @@ class DataDimensionsField(StencilTypeRegistrar):
             markup_type,
             quantity_factory,
             data_dimensions_names,
-            name_mapping,
-            dtype,
+            axes=axes,
+            name_mapping=name_mapping,
+            dtype=dtype,
         )
         return markup_type
 

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -108,6 +108,7 @@ class DataDimensionsField(StencilTypeRegistrar):
             name_mapping: for each dimensions, a sparse dictionary giving a name/index
                 to retrieve 3D fields by name.
             dtype: Inner data type, defaults to Float.
+            axes: Cartesian axes, defaults to `IJK` i.e. all of them.
         """
         name = pre_registration_type.name
         if name in cls._type_registrar.keys():
@@ -189,6 +190,7 @@ class DataDimensionsField(StencilTypeRegistrar):
             name_mapping: for each dimensions, a sparse dictionary giving a name/index
                 to retrieve 3D fields by name.
             dtype: Inner data type, defaults to Float.
+            axes: Cartesian axes, defaults to `IJK` i.e. all of them.
         """
 
         name = get_lhs_name(inspect.currentframe())

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -89,6 +89,7 @@ class DataDimensionsField(StencilTypeRegistrar):
         cls,
         pre_registration_type: "DataDimensionsMarkupType",
         quantity_factory: QuantityFactory,
+        axes: gtscript.Axis,
         data_dimensions_names: list[str],
         name_mapping: SparseNameMapping | None = None,
         dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
@@ -121,7 +122,7 @@ class DataDimensionsField(StencilTypeRegistrar):
             data_dims_size.append(quantity_factory.sizer.data_dimensions[ddim_name])
 
         cls._type_registrar[name] = _DataDimensionDescriptor[
-            gtscript.IJK, (dtype, tuple(data_dims_size))
+            axes, (dtype, tuple(data_dims_size))
         ]
         if name_mapping is not None:
             cls._type_registrar[name].mapping = name_mapping

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -74,6 +75,27 @@ class _DataDimensionFieldMaker(_FieldDescriptorMaker):
 _DataDimensionDescriptor = _DataDimensionFieldMaker()
 
 
+def _check_to_be_kwargs(func):  # type: ignore
+    """Temporary function to enforce `name_mapping`, `dtype`, and `axes` as kwargs in the next release."""
+
+    def inner(*args, **kwargs):  # type: ignore
+        to_be_kwargs = ["name_mapping", "dtype", "axes"]
+        min_lengths = (
+            (3, 4, 5) if func.__name__ == "declare_and_register" else (4, 5, 6)
+        )
+        for to_be_kwarg, min_length in zip(to_be_kwargs, min_lengths):
+            if len(args) > min_length and to_be_kwarg not in kwargs:
+                warnings.warn(
+                    f"`{to_be_kwarg}` is not passed as keyword argument; use `{func.__name__}(..., {to_be_kwarg}=...). This will be enforced in the next version.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+        return func(*args, **kwargs)
+
+    return inner
+
+
 class DataDimensionsField(StencilTypeRegistrar):
     """Type allowing semi-dynamic sizing of field with data dimensions.
 
@@ -85,12 +107,12 @@ class DataDimensionsField(StencilTypeRegistrar):
     _type_registrar: dict[str, _DataDimensionsFieldDescriptor] = {}
 
     @classmethod
+    @_check_to_be_kwargs
     def register(
         cls,
         pre_registration_type: "DataDimensionsMarkupType",
         quantity_factory: QuantityFactory,
         data_dimensions_names: list[str],
-        *,
         name_mapping: SparseNameMapping | None = None,
         dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
         axes: Sequence[gtscript.Axis] = gtscript.IJK,
@@ -172,11 +194,11 @@ class DataDimensionsField(StencilTypeRegistrar):
         return DataDimensionsMarkupType(name)
 
     @classmethod
+    @_check_to_be_kwargs
     def declare_and_register(
         cls,
         quantity_factory: QuantityFactory,
         data_dimensions_names: list[str],
-        *,
         name_mapping: SparseNameMapping | None = None,
         dtype: npt.DTypeLike = Float,  # type: ignore[has-type]
         axes: Sequence[gtscript.Axis] = gtscript.IJK,
@@ -192,8 +214,10 @@ class DataDimensionsField(StencilTypeRegistrar):
             dtype: Inner data type, defaults to Float.
             axes: Cartesian axes, defaults to `IJK` i.e. all of them.
         """
-
-        name = get_lhs_name(inspect.currentframe())
+        # We have to go an additional frame back because now there's a (temporary)
+        # decorator to check the arguments. Remove `.f_back` from the next line when
+        # the decorator `@_check_to_be_kwargs` is removed and the breaking change is made.
+        name = get_lhs_name(inspect.currentframe().f_back)  # type: ignore
         markup_type = DataDimensionsMarkupType(name)
         cls.register(
             markup_type,

--- a/tests/quantity/test_data_dimensions_field.py
+++ b/tests/quantity/test_data_dimensions_field.py
@@ -267,6 +267,39 @@ def test_data_dim_multi_line_declare(domain: Domain) -> None:
     )
 
 
+def test_register_deprecations(domain: Domain) -> None:
+    _, quantity_factory = get_factories_single_tile(
+        nx=domain[0],
+        ny=domain[1],
+        nz=domain[2],
+        nhalo=0,
+        backend=Backend("st:dace:cpu:IJK"),
+    )
+    quantity_factory.update_data_dimensions({"asdf": 3})
+
+    # case: declare() and register() separately
+    Field1 = DataDimensionsField.declare()
+    Field2 = DataDimensionsField.declare()
+    Field3 = DataDimensionsField.declare()
+
+    with pytest.deprecated_call(match="is not passed as keyword argument") as warnings:
+        DataDimensionsField.register(Field1, quantity_factory, ["asdf"], {})
+    assert len(warnings) == 1
+
+    with pytest.deprecated_call(match="is not passed as keyword argument") as warnings:
+        DataDimensionsField.register(Field2, quantity_factory, ["asdf"], {}, Float)
+    assert len(warnings) == 2
+
+    with pytest.deprecated_call(match="is not passed as keyword argument") as warnings:
+        DataDimensionsField.register(Field3, quantity_factory, ["asdf"], {}, Float, [])
+    assert len(warnings) == 3
+
+    # case declare_and_register()
+    with pytest.deprecated_call(match="is not passed as keyword argument") as warnings:
+        F = DataDimensionsField.declare_and_register(quantity_factory, ["asdf"], {})
+    assert len(warnings) == 1
+
+
 def test_data_dim_ndsl_type(domain: Domain) -> None:
     _, quantity_factory = get_factories_single_tile(
         nx=domain[0],

--- a/tests/quantity/test_data_dimensions_field.py
+++ b/tests/quantity/test_data_dimensions_field.py
@@ -1,6 +1,7 @@
 import re
 from typing import TypeAlias
 
+import numpy as np
 import pytest
 from dace.frontend.python.common import DaceSyntaxError
 
@@ -24,6 +25,7 @@ from ndsl.dsl.typing import Float, FloatField, Int
 
 Tracers = DataDimensionsField.declare()
 TracersAndPlumes = DataDimensionsField.declare()
+GlobalTable = DataDimensionsField.declare()
 
 
 def _the_stencil_5D(in_field: TracersAndPlumes, out_field: FloatField, add: FloatField):
@@ -43,11 +45,22 @@ def _the_stencil_3D(in_field: FloatField, out_field: FloatField, add: FloatField
         out_field = in_field + add
 
 
+def _the_stencil_table(in_field: FloatField, table: GlobalTable, out_field: Tracers):
+    from __externals__ import tracer_count
+
+    with computation(PARALLEL), interval(...):
+        tracer_id = 0
+        while tracer_id < tracer_count:
+            out_field[0, 0, 0][tracer_id] = in_field * tracer_id + table.A[5]
+            tracer_id += 1
+
+
 SETUP_DDIMS_ONCE = False
 
 
 def setup_data_dimensions(quantity_factory: QuantityFactory):
     quantity_factory.add_data_dimensions({"tracers": 8, "plumes": 3})
+    quantity_factory.add_data_dimensions({"table_size": 42})
 
     # Make sure this is called once
     global SETUP_DDIMS_ONCE
@@ -56,9 +69,14 @@ def setup_data_dimensions(quantity_factory: QuantityFactory):
     SETUP_DDIMS_ONCE = True
 
     mappings = {"A": 0, "C": 2, "D": 3, "G": 6, "H": 7}
-    DataDimensionsField.register(Tracers, quantity_factory, ["tracers"], mappings)
     DataDimensionsField.register(
-        TracersAndPlumes, quantity_factory, ["tracers", "plumes"], mappings
+        Tracers, quantity_factory, ["tracers"], name_mapping=mappings
+    )
+    DataDimensionsField.register(
+        TracersAndPlumes, quantity_factory, ["tracers", "plumes"], name_mapping=mappings
+    )
+    DataDimensionsField.register(
+        GlobalTable, quantity_factory, ["table_size"], axes=[], dtype=np.int64
     )
 
 
@@ -67,11 +85,16 @@ class Code(NDSLRuntime):
         self, stencil_factory: StencilFactory, quantity_factory: QuantityFactory
     ) -> None:
         super().__init__(stencil_factory)
-        orchestrate(
-            obj=self,
-            config=stencil_factory.config.dace_config,
-            method_to_orchestrate="bad_call",
-        )
+        methods_to_orchestrate = [
+            "bad_call",
+            "stencil_with_table",
+        ]
+        for method_to_orchestrate in methods_to_orchestrate:
+            orchestrate(
+                obj=self,
+                config=stencil_factory.config.dace_config,
+                method_to_orchestrate=method_to_orchestrate,
+            )
         self._the_stencil_4D = stencil_factory.from_dims_halo(
             func=_the_stencil_4D,
             compute_dims=[I_DIM, J_DIM, K_DIM],
@@ -84,6 +107,11 @@ class Code(NDSLRuntime):
         self._the_stencil_5D = stencil_factory.from_dims_halo(
             func=_the_stencil_5D,
             compute_dims=[I_DIM, J_DIM, K_DIM],
+        )
+        self._the_stencil_table = stencil_factory.from_dims_halo(
+            func=_the_stencil_table,
+            compute_dims=[I_DIM, J_DIM, K_DIM],
+            externals={"tracer_count": 8},
         )
         self._my_local = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
         self._my_local.field[:] = 2.0
@@ -119,6 +147,11 @@ class Code(NDSLRuntime):
             in_tracers[:, :, :, another_index], out_field, self._my_local
         )
 
+    def stencil_with_table(
+        self, in_field: FloatField, table: GlobalTable, out_field: Tracers
+    ) -> None:
+        self._the_stencil_table(in_field, table, out_field)
+
 
 Domain: TypeAlias = tuple[int, int, int]
 
@@ -139,7 +172,7 @@ def test_data_dimensions_registration_errors(domain: Domain) -> None:
         ),
     ):
         DataDimensionsField.register(
-            TracersAndPlumes, quantity_factory, ["tracers"], {}
+            TracersAndPlumes, quantity_factory, ["tracers"], name_mapping={}
         )
 
     with pytest.raises(
@@ -248,3 +281,27 @@ def test_data_dim_ndsl_type(domain: Domain) -> None:
         # type here. To support this, we'll need changes GT4Py as well as in DaCe.
         # For now, we are thus making sure that NDSL users get a clear error message.
         quantity_factory.update_data_dimensions({"data_dimension": Int(3)})
+
+
+def test_data_dimension_table(domain: Domain) -> None:
+    stencil_factory, quantity_factory = get_factories_single_tile(
+        nx=domain[0],
+        ny=domain[1],
+        nz=domain[2],
+        nhalo=0,
+        backend=Backend("st:python:cpu:IJK"),
+    )
+
+    setup_data_dimensions(quantity_factory)
+
+    in_field = quantity_factory.ones(dims=[I_DIM, J_DIM, K_DIM], units="n/a")
+    table = quantity_factory.from_array(np.arange(0, 42), ["table_size"], units="n/a")
+    tracer_field = quantity_factory.zeros(
+        dims=[I_DIM, J_DIM, K_DIM, "tracers"], units="n/a"
+    )
+
+    code = Code(stencil_factory, quantity_factory)
+    code.stencil_with_table(in_field, table, tracer_field)
+
+    for tracer_id in range(0, 8):
+        assert tracer_field[0, 0, 0][tracer_id] == tracer_id + 5

--- a/tests/quantity/test_data_dimensions_field.py
+++ b/tests/quantity/test_data_dimensions_field.py
@@ -114,11 +114,12 @@ class Code(NDSLRuntime):
             externals={"tracer_count": 8},
         )
         self._my_local = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
-        self._my_local.field[:] = 2.0
 
     def __call__(
         self, in_tracers: Quantity, in_tracers_and_plumes, out_field: Quantity
     ) -> None:
+        self._my_local[:] = 2.0
+
         # Literal access, multi-axis access and external indexation
         self._the_stencil_4D(in_tracers, out_field, self._my_local)
         self._the_stencil_5D(in_tracers_and_plumes, out_field, self._my_local)
@@ -141,7 +142,6 @@ class Code(NDSLRuntime):
     def bad_call(
         self, in_tracers: Quantity, in_tracers_and_plumes, out_field: Quantity
     ) -> None:
-
         another_index = Tracers.index("H")  # BAD in orchestration
         self._the_stencil_3D(
             in_tracers[:, :, :, another_index], out_field, self._my_local


### PR DESCRIPTION
# Description

This PR extends `DataDimensionsFields` to support not only `IJK` axes but any (including none) cartesian axis. In particular, this allows to declare and register data dimensions tables, i.e. global tables where we only know the size of the table at runtime.

## How has this been tested?

New test case based on @CharlesKrop's work.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
