### PR TITLE
translate tests: remove extra `f` in result report header

### DIFF
--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -466,7 +466,7 @@ def _report_results(
     os.makedirs(detail_dir, exist_ok=True)
 
     # Summary
-    header = f"{savepoint_name} w/ f{backend.as_humanly_readable()}"
+    header = f"{savepoint_name} w/ {backend.as_humanly_readable()}"
     lines = []
     for varname, metric in results.items():
         lines.append(f"{varname}: {metric.one_line_report()}")


### PR DESCRIPTION
# Description

Translate test report header currently prints an extra `f` before the backend name. Looks like an oversight from expanding the f-string. This PR fixes that.

## How has this been tested?

As part of https://github.com/NOAA-GFDL/NDSL/pull/465.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
