### PR TITLE
feature: guard against usage of locals outside orchestrated code

### DIFF
--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -755,6 +755,7 @@ def orchestrate(
 ) -> None:
     """
     Orchestrate a method of an object with DaCe.
+
     The method object is patched in place, replacing the original Callable with
     a wrapper that will trigger orchestration at call time.
     If the model configuration doesn't demand orchestration, this won't do anything.
@@ -766,11 +767,21 @@ def orchestrate(
         dace_compiletime_args: list of names of arguments to be flagged has
                                dace.compiletime for orchestration to behave
     """
-    if not config.is_dace_orchestrated():
-        return
+    if hasattr(obj, "_ndsl_orchestrated_methods"):
+        # Automatically register all orchestrated methods of NDSLRuntime classes
+        # to track where Locals can be used.
+        # See __post_init__() of NDSLRuntime.
+        obj._ndsl_orchestrated_methods.append(method_to_orchestrate)
 
     if config is None:
         raise ValueError("DaCe config cannot be None")
+
+    if not config.is_dace_orchestrated():
+        return
+
+    # We have to un-monkey patch the __call__ (from the debugger)
+    if method_to_orchestrate == "__call__" and hasattr(type(obj), "_original__call__"):
+        type(obj).__call__ = type(obj)._original__call__  # type: ignore[method-assign,attr-defined]
 
     if not hasattr(obj, method_to_orchestrate):
         raise RuntimeError(

--- a/ndsl/dsl/ndsl_runtime.py
+++ b/ndsl/dsl/ndsl_runtime.py
@@ -31,6 +31,9 @@ class NDSLRuntime:
         self._stencil_factory = stencil_factory
         # Use this flag to detect that the init wasn't done properly
         self._base_class_was_properly_super_init = True
+        # Used to track where usage of Locals is safe.
+        self._ndsl_orchestrated_methods: list[str] = []
+
         self._optimization_config = optimization_config
 
     def __init_subclass__(cls: type[NDSLRuntime], **kwargs: dict[str, Any]) -> None:
@@ -121,10 +124,7 @@ class NDSLRuntime:
             check_for_quantity(self)
 
         # Orchestrate __call__ by default
-        if self._stencil_factory.backend.is_orchestrated() and callable(self):
-            # Do we have to un-monkey patch the __call__
-            if hasattr(type(self), "_original__call__"):
-                type(self).__call__ = type(self)._original__call__  # type: ignore[method-assign,attr-defined]
+        if callable(self):
             orchestrate(
                 obj=self,
                 config=self._stencil_factory.config.dace_config,
@@ -137,11 +137,14 @@ class NDSLRuntime:
         # in the locals.
         # All other cases are forbidden.
         if isinstance(attr, Local):
+            class_name = type(self).__name__
             frame = inspect.currentframe()
             if frame is None:
                 raise NotImplementedError(
-                    "Locals check cannot locate frame. Talk to the team."
+                    "Locals check cannot locate frame. Talk to the team. ",
+                    f"Class name: {class_name}",
                 )
+
             caller_frame = frame.f_back
             if (
                 not caller_frame
@@ -150,9 +153,20 @@ class NDSLRuntime:
             ):
                 # We expect the original class to have been monkey-patched
                 # See `dace.dsl.orchestration.orchestrate`
-                class_name = type(self).__name__
                 raise RuntimeError(
                     f"Forbidden Local access: {name} called outside of {class_name}."
+                )
+
+            calling_method = caller_frame.f_code.co_name
+            if (
+                caller_frame.f_code.co_qualname.endswith(
+                    f"{class_name}.{calling_method}"
+                )
+                and calling_method not in self._ndsl_orchestrated_methods
+            ):
+                # Locals can only be safely used inside orchestrated code paths.
+                raise RuntimeError(
+                    f"Forbidden Local access: {name} called in non-orchestrated method {caller_frame.f_code.co_name}."
                 )
 
         return attr

--- a/tests/test_ndsl_runtime.py
+++ b/tests/test_ndsl_runtime.py
@@ -15,6 +15,8 @@ from ndsl.boilerplate import (
 )
 from ndsl.config import Backend
 from ndsl.constants import I_DIM, J_DIM, K_DIM
+from ndsl.dsl.typing import Float, FloatField
+from ndsl.stencils.basic_operations import copy
 
 
 class Code(NDSLRuntime):
@@ -23,31 +25,24 @@ class Code(NDSLRuntime):
     ) -> None:
         super().__init__(stencil_factory)
         self.copy = stencil_factory.from_dims_halo(
-            stencils.copy, compute_dims=[I_DIM, J_DIM, K_DIM]
+            copy, compute_dims=[I_DIM, J_DIM, K_DIM]
         )
         self.local = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
 
     def test_check(self) -> None:
+        # HACK Temporarily mark this function as orchestrated to allow
+        # testing the descriptor (from the python side).
+        self._ndsl_orchestrated_methods.append("test_check")
+
+        # Test the descriptor (with the override in place).
         assert self.local.__descriptor__().transient
+
+        # Restore test override.
+        self._ndsl_orchestrated_methods.remove("test_check")
 
     def __call__(self, A, B) -> None:  # type: ignore[no-untyped-def]
         self.copy(A, self.local)
         self.copy(self.local, B)
-
-
-class BadCode_NoSuperInit(NDSLRuntime):
-    def __init__(self) -> None:
-        # Forget to init
-        pass
-
-
-class Code_NoCall(NDSLRuntime):
-    def __init__(self, stencil_factory: StencilFactory) -> None:
-        super().__init__(stencil_factory)
-        pass
-
-    def run(self, A: Any, B: Any) -> None:
-        pass
 
 
 def test_runtime_make_local() -> None:
@@ -88,6 +83,14 @@ def test_runtime_has_orchestrated_call() -> None:
 
 
 def test_runtime_does_not_orchestrate_when_call_is_not_present() -> None:
+    class Code_NoCall(NDSLRuntime):
+        def __init__(self, stencil_factory: StencilFactory) -> None:
+            super().__init__(stencil_factory)
+            pass
+
+        def run(self, A: Any, B: Any) -> None:
+            pass
+
     stencil_factory, _ = get_factories_single_tile_orchestrated(
         nx=5, ny=5, nz=3, nhalo=0, backend=Backend.cpu()
     )
@@ -99,11 +102,16 @@ def test_runtime_does_not_orchestrate_when_call_is_not_present() -> None:
     assert type(code).__name__ == "Code_NoCall"
 
 
-def test_runtime_fail_when_not_super_init() -> None:
+def test_runtime_fails_when_not_super_init() -> None:
+    class BadCode_NoSuperInit(NDSLRuntime):
+        def __init__(self) -> None:
+            # Forget to call super().__init__(...)
+            pass
+
     with pytest.raises(
         RuntimeError, match="inherit from NDSLRuntime but didn't call super()"
     ):
-        bad_code = BadCode_NoSuperInit()
+        BadCode_NoSuperInit()
 
 
 def test_runtime_with_performance_config() -> None:
@@ -137,3 +145,64 @@ def test_runtime_with_performance_config() -> None:
     code(src, dst)
 
     assert (src.field[:] == dst.field[:]).all()
+
+
+def test_runtime_fails_local_in_non_orchestrated_code_path() -> None:
+    stencil_factory, quantity_factory = get_factories_single_tile(
+        nx=5, ny=5, nz=3, nhalo=0, backend=Backend.python()
+    )
+
+    class NonOrchestratedLocalUsage(NDSLRuntime):
+        def __init__(
+            self, stencil_factory: StencilFactory, quantity_factory: QuantityFactory
+        ) -> None:
+            super().__init__(stencil_factory)
+            self._copy_local = stencil_factory.from_dims_halo(
+                func=copy,
+                compute_dims=[I_DIM, J_DIM, K_DIM],
+            )
+            self.local = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+
+            # Bad usage of Local in non-orchestrated code path
+            self.local[:] = 2.0
+
+        def __call__(self, in_field: FloatField) -> None:  # type: ignore
+            self._copy_local(self._my_local, in_field)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Forbidden Local access: .* called in non-orchestrated method",
+    ):
+        NonOrchestratedLocalUsage(stencil_factory, quantity_factory)
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ["st:python:cpu:IJK", "st:dace:cpu:IJK", "orch:dace:cpu:IJK", "orch:dace:cpu:KJI"],
+)
+def test_runtime_use_local_in_orchestrated_code_path(backend: str) -> None:
+    class Code(NDSLRuntime):
+        def __init__(
+            self, stencil_factory: StencilFactory, quantity_factory: QuantityFactory
+        ) -> None:
+            super().__init__(stencil_factory)
+            self._copy_local = stencil_factory.from_dims_halo(
+                func=copy, compute_dims=[I_DIM, J_DIM, K_DIM]
+            )
+            self._my_local = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+
+        def __call__(self, field: FloatField, value: Float) -> None:  # type: ignore
+            self._my_local[:] = value
+            self._copy_local(self._my_local, field)
+
+    stencil_factory, quantity_factory = get_factories_single_tile(
+        nx=5, ny=5, nz=3, nhalo=0, backend=Backend(backend)
+    )
+
+    array = quantity_factory.ones(dims=[I_DIM, J_DIM, K_DIM], units="n/a")
+    value = 2.0
+
+    code = Code(stencil_factory, quantity_factory)
+    code(array, value)
+
+    assert (array.field == value).all()


### PR DESCRIPTION
# Description

Locals can only safely be used in orchestrated code paths. This is because in orchestration, we'll put DaCe in charge of memory management of Locals on the cpp/cuda side. There's no back-link to the python memory, so any usage of Locals outside orchestrated code paths will result in backend-depending execution as already anticipated as issue in the original Locals PR #266.

Within `NDSLRuntime`, we already check that usage of Locals is restricted to the class they are defined in. In this PR, we refine this check to forbid access from non-orchestrated methods. To do so, we need to know which methods of `NDSLRuntime` classes are orchestrated. We thus keep taps on those with `_ndsl_orchestrated_methods`, which gets automatically populated as part of `orchestrate()` if the property is detected.

Note: This will only worsen the potential performance problem in stencil mode outlined in https://github.com/NOAA-GFDL/NDSL/issues/339. Since guardrails are still contained to the same `__getattr__()` function, all possible solutions outlined there are still possible. That said, I have picked my favourite solution as mentioned in issue #339.

Related issue: https://github.com/GridTools/gt4py/issues/2665

## How has this been tested?

New / updated unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
