### PR TITLE
[Feature | Language] Deprecate stencils

### DIFF
--- a/ndsl/__init__.py
+++ b/ndsl/__init__.py
@@ -11,7 +11,13 @@ from .constants import ConstantVersions
 from .dsl.caches.codepath import FV3CodePath
 from .quantity import Quantity
 from .dsl.ndsl_runtime import NDSLRuntime
-from .dsl.stencil import FrozenStencil, GridIndexing, StencilFactory, TimingCollector
+from .dsl.stencil import (
+    FrozenStencil,
+    GridIndexing,
+    StencilFactory,
+    TimingCollector,
+    deprecated_stencil,
+)
 from .dsl.stencil_config import CompilationConfig, RunMode, StencilConfig
 from .halo.data_transformer import HaloExchangeSpec
 from .halo.updater import HaloUpdater, HaloUpdateRequest, VectorInterfaceHaloUpdater
@@ -95,4 +101,5 @@ __all__ = [
     "DiagManagerMonitor",
     "DataDimensionsField",
     "DataDimensionsMarkupType",
+    "deprecated_stencil",
 ]

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -4,6 +4,7 @@ import copy
 import dataclasses
 import inspect
 import numbers
+import warnings
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, cast
 
@@ -255,6 +256,16 @@ def compare_ranks(comm: Comm, data: dict) -> Mapping[str, int]:
     return differences
 
 
+_DEPRECATED_STENCILS = []
+"""Collect deprecrated stencils"""
+
+
+def deprecated_stencil(func: Callable) -> Callable:
+    """Wrapper (use as @deprecated_stencil) to mark a stencil as deprecated"""
+    _DEPRECATED_STENCILS.append(func)
+    return func
+
+
 class FrozenStencil(SDFGConvertible):
     """
     Wrapper for gt4py stencils which stores origin and domain at compile time,
@@ -288,6 +299,17 @@ class FrozenStencil(SDFGConvertible):
             comm: if given, inputs and outputs will be compared to the "twin"
                 rank of this rank
         """
+        # Check for deprecation
+        if func in _DEPRECATED_STENCILS:
+            # We use a UserWarning because this is not meant for DSL internals but
+            # for user code
+            warnings.warn(
+                f"Stencil {func} is deprecated and will be removed in a future version.",
+                UserWarning,
+                stacklevel=2,
+            )
+            _DEPRECATED_STENCILS.remove(func)  # Warn only once
+
         if isinstance(origin, tuple):
             origin = cast_to_index3d(origin)
         self.origin = origin

--- a/ndsl/stencils/basic_operations.py
+++ b/ndsl/stencils/basic_operations.py
@@ -1,6 +1,7 @@
 import typing
 
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, function, interval
+from ndsl.dsl.stencil import deprecated_stencil
 from ndsl.dsl.typing import (
     Bool,
     BoolFieldIJ,
@@ -256,54 +257,6 @@ def set_value(field: FloatField, value: Float) -> None:
         field = value
 
 
-def set_value_2D(field: FloatFieldIJ, value: Float) -> None:
-    """
-    Sets every element of a field to a single value - 2D variant.
-
-    Args:
-        field: output field
-        value: value of Float type
-    """
-    with computation(FORWARD), interval(...):
-        field = value
-
-
-def set_IJ_mask_value(field: BoolFieldIJ, value: Bool) -> None:
-    """
-    Sets every element of buffer to either True or False.
-
-    Args:
-        field: output field
-        value: value of Bool type
-    """
-    with computation(FORWARD), interval(0, 1):
-        field = value
-
-
-def adjustmentfactor_stencil(adjustment: FloatFieldIJ, field: FloatField) -> None:
-    """
-    Multiplies a field by an adjustment factor, modifying the original field.
-
-    Args:
-        adjustment: adjustment factor
-        field: field to be modified
-    """
-    with computation(PARALLEL), interval(...):
-        field = field * adjustment
-
-
-def adjust_divide_stencil(adjustment: FloatField, field: FloatField) -> None:
-    """
-    Divides a field by an adjustment factor, modifying the original field.
-
-    Args:
-        adjustment: adjustment factor
-        field: field to be modified
-    """
-    with computation(PARALLEL), interval(...):
-        field = field / adjustment
-
-
 def select_k(
     in_field: FloatField,
     out_field: FloatFieldIJ,
@@ -326,6 +279,51 @@ def select_k(
             out_field = in_field
 
 
+#############################
+# Deprecated stencils       #
+#############################
+
+
+@deprecated_stencil
+def set_value_2D(field: FloatFieldIJ, value: Float) -> None:
+    """
+    Sets every element of a field to a single value - 2D variant.
+
+    Args:
+        field: output field
+        value: value of Float type
+    """
+    with computation(FORWARD), interval(...):
+        field = value
+
+
+@deprecated_stencil
+@typing.no_type_check
+@function
+def sign(a, b):
+    """
+    Defines a_sign_b as the absolute value of a, and checks if b is positive or
+    negative, assigning the analogous sign value to a_sign_b. a_sign_b is returned.
+
+    Args:
+        a: A number
+        b: A number
+    """
+    a_sign_b = abs(a)
+    return a_sign_b if b > 0 else -a_sign_b
+
+
+@deprecated_stencil
+@typing.no_type_check
+@function
+def dim(a, b):
+    """
+    Calculates a - b, camped to 0, i.e. max(a - b, 0).
+    """
+    return max(a - b, 0)
+
+
+@deprecated_stencil
 def average_in(
     q_out: FloatField,
     adjustment: FloatField,
@@ -342,25 +340,40 @@ def average_in(
         q_out = (q_out + adjustment) * 0.5
 
 
-@typing.no_type_check
-@function
-def sign(a, b):
+@deprecated_stencil
+def set_IJ_mask_value(field: BoolFieldIJ, value: Bool) -> None:
     """
-    Defines a_sign_b as the absolute value of a, and checks if b is positive or
-    negative, assigning the analogous sign value to a_sign_b. a_sign_b is returned.
+    Sets every element of buffer to either True or False.
 
     Args:
-        a: A number
-        b: A number
+        field: output field
+        value: value of Bool type
     """
-    a_sign_b = abs(a)
-    return a_sign_b if b > 0 else -a_sign_b
+    with computation(FORWARD), interval(0, 1):
+        field = value
 
 
-@typing.no_type_check
-@function
-def dim(a, b):
+@deprecated_stencil
+def adjustmentfactor_stencil(adjustment: FloatFieldIJ, field: FloatField) -> None:
     """
-    Calculates a - b, camped to 0, i.e. max(a - b, 0).
+    Multiplies a field by an adjustment factor, modifying the original field.
+
+    Args:
+        adjustment: adjustment factor
+        field: field to be modified
     """
-    return max(a - b, 0)
+    with computation(PARALLEL), interval(...):
+        field = field * adjustment
+
+
+@deprecated_stencil
+def adjust_divide_stencil(adjustment: FloatField, field: FloatField) -> None:
+    """
+    Divides a field by an adjustment factor, modifying the original field.
+
+    Args:
+        adjustment: adjustment factor
+        field: field to be modified
+    """
+    with computation(PARALLEL), interval(...):
+        field = field / adjustment

--- a/tests/dsl/test_stencil.py
+++ b/tests/dsl/test_stencil.py
@@ -21,6 +21,7 @@ from ndsl.constants import (
     K_INTERFACE_DIM,
 )
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, Field, computation, interval
+from ndsl.dsl.stencil import _DEPRECATED_STENCILS, deprecated_stencil
 from ndsl.dsl.typing import (
     BoolFieldIJ,
     FloatField,
@@ -204,3 +205,38 @@ def test_validation_call_count(iterations: tuple[int]):
             stencil(quantity, quantity)
 
     assert counting_mock.call_count == 1
+
+
+def test_deprecated_stencil() -> None:
+
+    @deprecated_stencil
+    def stencil_to_deprecate(q_in: FloatField, q_out: FloatField) -> None:  # type: ignore
+        with computation(PARALLEL), interval(...):
+            q_out = q_in
+
+    assert stencil_to_deprecate in _DEPRECATED_STENCILS
+
+    domain = (2, 2, 5)
+    quantity = Quantity(
+        np.zeros(domain),
+        [I_DIM, J_DIM, K_DIM],
+        "n/a",
+        extent=domain,
+        backend=Backend.python(),
+    )
+    stencil_config = StencilConfig(
+        compilation_config=CompilationConfig(Backend.python(), rebuild=True)
+    )
+    with pytest.warns(
+        UserWarning, match="is deprecated and will be removed in a future version"
+    ):
+        stencil = FrozenStencil(
+            stencil_to_deprecate,
+            origin=(0, 0, 0),
+            domain=domain,
+            stencil_config=stencil_config,
+        )
+
+    stencil(quantity, quantity)
+
+    _DEPRECATED_STENCILS.clear()


### PR DESCRIPTION
# Description

NDSL ships with some basic operations in `ndsl/stencils/basic_operations.py` - but we are working on breaking name and API change. To deal with the disruption, we introduce here a `@deprecate_stencil` decorator that will warn user of the impending deprecation.

We also deprecate the `basic_operations` flagged for removal version after next.

## How has this been tested?

New utest.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
