### PR TITLE
update dace to c++20

### DIFF
--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -250,7 +250,7 @@ class DaceConfig:
                 "compiler",
                 "cpu",
                 "args",
-                value=f"-march={march_cpu} -std=c++17 -fPIC {warnings_policy} -O{optimization_level} {cxx_defaults.cxx_compile_flags}",
+                value=f"-march={march_cpu} -std=c++20 -fPIC {warnings_policy} -O{optimization_level} {cxx_defaults.cxx_compile_flags}",
             )
             # Potentially buggy - deactivate
             dace.config.Config.set(


### PR DESCRIPTION
# Description

While DaCe requires `C++20` since [PR#2253](https://github.com/spcl/dace/pull/2253) this was not yet used, but the recently merged [PR#2455](https://github.com/spcl/dace/pull/2455) introduced a dependency to `std::bit_cast` which is a C++20 feature.
This PR ensures that the cartesion compilation passes the respective flag.

