### PR TITLE
BREAKING CHANGE: Remove `get_precision`

### DIFF
--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -25,15 +25,6 @@ K = gtscript.K  # noqa: E741
 DTypes = bool | np.bool_ | int | np.int32 | np.int64 | float | np.float32 | np.float64
 
 
-def get_precision() -> int:
-    warnings.warn(
-        "`get_precision()` is deprecated in favor of `NDSL_GLOBAL_PRECISION`. This function will be removed in the next version.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return NDSL_GLOBAL_PRECISION
-
-
 # Default float and int types
 # Dev note: the `TypeAlias` of Float/Int depending on a switch has been giving
 #           us linting headaches. We revert to the previous version here that

--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import TypeAlias
 
 import numpy as np


### PR DESCRIPTION
# Description

We deprecated `get_precision` with this [PR](https://github.com/NOAA-GFDL/NDSL/pull/433) and are now removing the deprected work after the release.

## How has this been tested?

CI will complain if something is bad

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
