### PR TITLE
BREAKING CHANGE: Force `ddim` to be kwargs

### DIFF
--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -190,7 +190,7 @@ class DataDimensionsField(StencilTypeRegistrar):
             dtype: Inner data type, defaults to Float.
             axes: Cartesian axes, defaults to `IJK` i.e. all of them.
         """
-        name = get_lhs_name(inspect.currentframe())  # type: ignore
+        name = get_lhs_name(inspect.currentframe())
         markup_type = DataDimensionsMarkupType(name)
         cls.register(
             markup_type,

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -75,27 +74,6 @@ class _DataDimensionFieldMaker(_FieldDescriptorMaker):
 _DataDimensionDescriptor = _DataDimensionFieldMaker()
 
 
-def _check_to_be_kwargs(func):  # type: ignore
-    """Temporary function to enforce `name_mapping`, `dtype`, and `axes` as kwargs in the next release."""
-
-    def inner(*args, **kwargs):  # type: ignore
-        to_be_kwargs = ["name_mapping", "dtype", "axes"]
-        min_lengths = (
-            (3, 4, 5) if func.__name__ == "declare_and_register" else (4, 5, 6)
-        )
-        for to_be_kwarg, min_length in zip(to_be_kwargs, min_lengths):
-            if len(args) > min_length and to_be_kwarg not in kwargs:
-                warnings.warn(
-                    f"`{to_be_kwarg}` is not passed as keyword argument; use `{func.__name__}(..., {to_be_kwarg}=...). This will be enforced in the next version.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-        return func(*args, **kwargs)
-
-    return inner
-
-
 class DataDimensionsField(StencilTypeRegistrar):
     """Type allowing semi-dynamic sizing of field with data dimensions.
 
@@ -107,7 +85,6 @@ class DataDimensionsField(StencilTypeRegistrar):
     _type_registrar: dict[str, _DataDimensionsFieldDescriptor] = {}
 
     @classmethod
-    @_check_to_be_kwargs
     def register(
         cls,
         pre_registration_type: "DataDimensionsMarkupType",
@@ -194,7 +171,6 @@ class DataDimensionsField(StencilTypeRegistrar):
         return DataDimensionsMarkupType(name)
 
     @classmethod
-    @_check_to_be_kwargs
     def declare_and_register(
         cls,
         quantity_factory: QuantityFactory,
@@ -214,10 +190,7 @@ class DataDimensionsField(StencilTypeRegistrar):
             dtype: Inner data type, defaults to Float.
             axes: Cartesian axes, defaults to `IJK` i.e. all of them.
         """
-        # We have to go an additional frame back because now there's a (temporary)
-        # decorator to check the arguments. Remove `.f_back` from the next line when
-        # the decorator `@_check_to_be_kwargs` is removed and the breaking change is made.
-        name = get_lhs_name(inspect.currentframe().f_back)  # type: ignore
+        name = get_lhs_name(inspect.currentframe())  # type: ignore
         markup_type = DataDimensionsMarkupType(name)
         cls.register(
             markup_type,

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -178,7 +178,15 @@ class DataDimensionsField(StencilTypeRegistrar):
         name_mapping: SparseNameMapping | None = None,
         dtype: npt.DTypeLike = Float,
         axes: Sequence[gtscript.Axis] = gtscript.IJK,
-    ) -> "DataDimensionsMarkupType":
+def declare_and_register(
+cls,
+quantity_factory: QuantityFactory,
+data_dimensions_names: list[str],
+*,
+name_mapping: SparseNameMapping | None = None,
+dtype: npt.DTypeLike = Float,
+axes: Sequence[gtscript.Axis] = gtscript.IJK,
+) -> "DataDimensionsMarkupType":
         """Declare a data dimension field and register it's size.
 
         Args:

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -175,18 +175,11 @@ class DataDimensionsField(StencilTypeRegistrar):
         cls,
         quantity_factory: QuantityFactory,
         data_dimensions_names: list[str],
+        *,
         name_mapping: SparseNameMapping | None = None,
         dtype: npt.DTypeLike = Float,
         axes: Sequence[gtscript.Axis] = gtscript.IJK,
-def declare_and_register(
-cls,
-quantity_factory: QuantityFactory,
-data_dimensions_names: list[str],
-*,
-name_mapping: SparseNameMapping | None = None,
-dtype: npt.DTypeLike = Float,
-axes: Sequence[gtscript.Axis] = gtscript.IJK,
-) -> "DataDimensionsMarkupType":
+    ) -> "DataDimensionsMarkupType":
         """Declare a data dimension field and register it's size.
 
         Args:

--- a/tests/quantity/test_data_dimensions_field.py
+++ b/tests/quantity/test_data_dimensions_field.py
@@ -192,17 +192,26 @@ class Code(NDSLRuntime):
         )
 
     def stencil_with_table(
-        self, in_field: FloatField, table: GlobalTable, out_field: Tracers  # type: ignore
+        self,
+        in_field: FloatField,
+        table: GlobalTable,
+        out_field: Tracers,  # type: ignore
     ) -> None:
         self._the_stencil_table(in_field, table, out_field)
 
     def function_with_table(
-        self, in_field: FloatField, table: GlobalTable, out_field: Tracers  # type: ignore
+        self,
+        in_field: FloatField,
+        table: GlobalTable,
+        out_field: Tracers,  # type: ignore
     ) -> None:
         self._the_stencil_function_with_table(in_field, table, out_field)
 
     def function_with_table_and_externals(
-        self, in_field: FloatField, table: GlobalTable, out_field: Tracers  # type: ignore
+        self,
+        in_field: FloatField,
+        table: GlobalTable,
+        out_field: Tracers,  # type: ignore
     ) -> None:
         self._the_stencil_function_with_table_and_externals(in_field, table, out_field)
 
@@ -319,39 +328,6 @@ def test_data_dim_multi_line_declare(domain: Domain) -> None:
     FloatField_with_data_dimension = DataDimensionsField.declare_and_register(
         quantity_factory, ["data_dimension"], dtype=Float
     )
-
-
-def test_register_deprecations(domain: Domain) -> None:
-    _, quantity_factory = get_factories_single_tile(
-        nx=domain[0],
-        ny=domain[1],
-        nz=domain[2],
-        nhalo=0,
-        backend=Backend("st:dace:cpu:IJK"),
-    )
-    quantity_factory.update_data_dimensions({"asdf": 3})
-
-    # case: declare() and register() separately
-    Field1 = DataDimensionsField.declare()
-    Field2 = DataDimensionsField.declare()
-    Field3 = DataDimensionsField.declare()
-
-    with pytest.deprecated_call(match="is not passed as keyword argument") as warnings:
-        DataDimensionsField.register(Field1, quantity_factory, ["asdf"], {})
-    assert len(warnings) == 1
-
-    with pytest.deprecated_call(match="is not passed as keyword argument") as warnings:
-        DataDimensionsField.register(Field2, quantity_factory, ["asdf"], {}, Float)
-    assert len(warnings) == 2
-
-    with pytest.deprecated_call(match="is not passed as keyword argument") as warnings:
-        DataDimensionsField.register(Field3, quantity_factory, ["asdf"], {}, Float, [])
-    assert len(warnings) == 3
-
-    # case declare_and_register()
-    with pytest.deprecated_call(match="is not passed as keyword argument") as warnings:
-        F = DataDimensionsField.declare_and_register(quantity_factory, ["asdf"], {})
-    assert len(warnings) == 1
 
 
 def test_data_dim_ndsl_type(domain: Domain) -> None:


### PR DESCRIPTION
# Description

We deprecated the use of non-kwargs ddims  with this [PR](https://github.com/NOAA-GFDL/NDSL/pull/503) and are now removing the deprected work after the release.

## How has this been tested?

CI will complain if something is bad

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
