### PR TITLE
[Fix | Typing] Re-add Float64 et al. type with proper name

### DIFF
--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -44,10 +44,10 @@ if NDSL_GLOBAL_PRECISION not in [32, 64]:
     raise NotImplementedError(
         f"{NDSL_GLOBAL_PRECISION} bit precision not implemented or tested."
     )
-Float: TypeAlias = np.float64 if NDSL_GLOBAL_PRECISION == 64 else np.float32  # type: ignore
-Int: TypeAlias = np.int64 if NDSL_GLOBAL_PRECISION == 64 else np.int32  # type: ignore
-Bool = np.bool_
 
+Float: TypeAlias = np.float64 if NDSL_GLOBAL_PRECISION == 64 else np.float32  # type: ignore
+Float64 = np.float64
+Float32 = np.float32
 FloatField = Field[gtscript.IJK, Float]
 FloatField64 = Field[gtscript.IJK, np.float64]
 FloatField32 = Field[gtscript.IJK, np.float32]
@@ -64,6 +64,9 @@ FloatFieldK = Field[gtscript.K, Float]
 FloatFieldK64 = Field[gtscript.K, np.float64]
 FloatFieldK32 = Field[gtscript.K, np.float32]
 
+Int: TypeAlias = np.int64 if NDSL_GLOBAL_PRECISION == 64 else np.int32  # type: ignore
+Int64 = np.int64
+Int32 = np.int32
 IntField = Field[gtscript.IJK, Int]
 IntField64 = Field[gtscript.IJK, np.int64]
 IntField32 = Field[gtscript.IJK, np.int32]
@@ -80,6 +83,7 @@ IntFieldK = Field[gtscript.K, Int]
 IntFieldK64 = Field[gtscript.K, np.int64]
 IntFieldK32 = Field[gtscript.K, np.int32]
 
+Bool = np.bool_
 BoolField = Field[gtscript.IJK, Bool]
 BoolFieldI = Field[gtscript.I, Bool]
 BoolFieldJ = Field[gtscript.J, Bool]


### PR DESCRIPTION
# Description

`2027.06.00` removed the previous `NDSL_64BIT_FLOAT_TYPE` et al. when refactoring the typing for `Float`. This was used only in the GEOS branch of pyFV3 and escaped testing.

We re-add here the types and mimic the named used for all the other types  (e.g `FloatField64`)

Fixes # (issue)

## How has this been tested?

No test

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
