### PR TITLE
[Fix | Lang] Re-add Float64 et al. type with proper name

### DIFF
--- a/ndsl/comm/decomposition.py
+++ b/ndsl/comm/decomposition.py
@@ -48,7 +48,7 @@ def unblock_waiting_tiles(comm: MPI.Comm) -> None:
     size = comm.Get_size()
     if comm and size > 1:
         for tile in range(1, 6):
-            tile_size = size / 6
+            tile_size = int(size / 6)
             message = "compilation finished"
             comm.send(message, dest=tile * tile_size + rank)
 

--- a/ndsl/comm/mpi.py
+++ b/ndsl/comm/mpi.py
@@ -84,12 +84,10 @@ class MPIComm(Comm):
     def allreduce(
         self, sendobj: T, op: ReductionOperator = ReductionOperator.NO_OP
     ) -> T:
-        return self._comm.allreduce(sendobj, self._op_mapping[op])  # type: ignore[arg-type]
+        return self._comm.allreduce(sendobj, self._op_mapping[op])
 
     def Allreduce(self, sendobj: T, recvobj: T, op: ReductionOperator) -> T:
-        return self._comm.Allreduce(sendobj, recvobj, self._op_mapping[op])  # type: ignore[arg-type]
+        return self._comm.Allreduce(sendobj, recvobj, self._op_mapping[op])
 
     def Allreduce_inplace(self, recvobj: T, op: ReductionOperator) -> T:
-        return self._comm.Allreduce(
-            MPI.IN_PLACE, recvobj, self._op_mapping[op]  # type: ignore[arg-type]
-        )
+        return self._comm.Allreduce(MPI.IN_PLACE, recvobj, self._op_mapping[op])

--- a/ndsl/comm/mpi.py
+++ b/ndsl/comm/mpi.py
@@ -84,10 +84,12 @@ class MPIComm(Comm):
     def allreduce(
         self, sendobj: T, op: ReductionOperator = ReductionOperator.NO_OP
     ) -> T:
-        return self._comm.allreduce(sendobj, self._op_mapping[op])
+        return self._comm.allreduce(sendobj, self._op_mapping[op])  # type: ignore[arg-type]
 
     def Allreduce(self, sendobj: T, recvobj: T, op: ReductionOperator) -> T:
-        return self._comm.Allreduce(sendobj, recvobj, self._op_mapping[op])
+        return self._comm.Allreduce(sendobj, recvobj, self._op_mapping[op])  # type: ignore[arg-type]
 
     def Allreduce_inplace(self, recvobj: T, op: ReductionOperator) -> T:
-        return self._comm.Allreduce(MPI.IN_PLACE, recvobj, self._op_mapping[op])
+        return self._comm.Allreduce(
+            MPI.IN_PLACE, recvobj, self._op_mapping[op]  # type: ignore[arg-type]
+        )

--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -44,10 +44,10 @@ if NDSL_GLOBAL_PRECISION not in [32, 64]:
     raise NotImplementedError(
         f"{NDSL_GLOBAL_PRECISION} bit precision not implemented or tested."
     )
-Float: TypeAlias = np.float64 if NDSL_GLOBAL_PRECISION == 64 else np.float32  # type: ignore
-Int: TypeAlias = np.int64 if NDSL_GLOBAL_PRECISION == 64 else np.int32  # type: ignore
-Bool = np.bool_
 
+Float: TypeAlias = np.float64 if NDSL_GLOBAL_PRECISION == 64 else np.float32  # type: ignore
+Float64 = np.float64
+Float32 = np.float32
 FloatField = Field[gtscript.IJK, Float]
 FloatField64 = Field[gtscript.IJK, np.float64]
 FloatField32 = Field[gtscript.IJK, np.float32]
@@ -64,6 +64,9 @@ FloatFieldK = Field[gtscript.K, Float]
 FloatFieldK64 = Field[gtscript.K, np.float64]
 FloatFieldK32 = Field[gtscript.K, np.float32]
 
+Int: TypeAlias = np.int64 if NDSL_GLOBAL_PRECISION == 64 else np.int32  # type: ignore
+Int64 = np.int64
+Int32 = np.int32
 IntField = Field[gtscript.IJK, Int]
 IntField64 = Field[gtscript.IJK, np.int64]
 IntField32 = Field[gtscript.IJK, np.int32]
@@ -80,6 +83,7 @@ IntFieldK = Field[gtscript.K, Int]
 IntFieldK64 = Field[gtscript.K, np.int64]
 IntFieldK32 = Field[gtscript.K, np.int32]
 
+Bool = np.bool_
 BoolField = Field[gtscript.IJK, Bool]
 BoolFieldI = Field[gtscript.I, Bool]
 BoolFieldJ = Field[gtscript.J, Bool]

--- a/ndsl/performance/report.py
+++ b/ndsl/performance/report.py
@@ -122,9 +122,9 @@ def get_sypd(timing_info: dict[str, TimeReport], dt_atmos: float) -> float:
             isinstance(el, list) for el in timing_info["mainloop"].times
         )
         if is_list_of_list:
-            mainloop = np.mean(sum(timing_info["mainloop"].times, []))
+            mainloop = np.mean(sum(timing_info["mainloop"].times, []), dtype=float)
         else:
-            mainloop = np.mean(timing_info["mainloop"].times)
+            mainloop = np.mean(timing_info["mainloop"].times, dtype=float)
         speedup = dt_atmos / mainloop
         sypd = 1.0 / 365.0 * speedup
     else:

--- a/ndsl/xumpy/count_nonzero.py
+++ b/ndsl/xumpy/count_nonzero.py
@@ -11,7 +11,7 @@ from ndsl.optional_imports import cupy as cp
 def count_nonzero(
     in_buffer: npt.NDArray | Quantity,
     axis: int | tuple[int, ...] | None = None,
-) -> int:
+) -> np.integer:
     """Count non zero element in buffer."""
     raise NotImplementedError("`count_nonzero` called with not supported type")
 
@@ -20,7 +20,7 @@ def count_nonzero(
 def _(
     buffer: npt.NDArray,
     axis: int | tuple[int, ...] | None = None,
-) -> int:
+) -> np.integer:
     return np.count_nonzero(buffer, axis)
 
 
@@ -28,7 +28,7 @@ def _(
 def _(
     in_quantity: Quantity,
     axis: int | tuple[int, ...] | None = None,
-) -> int:
+) -> np.integer:
     return count_nonzero(in_quantity.field, axis)
 
 
@@ -38,5 +38,6 @@ if cp is not None:
     def _(
         buffer: npt.NDArray,
         axis: int | tuple[int, ...] | None = None,
-    ) -> int:
+    ) -> np.integer:
+        assert cp
         return cp.count_nonzero(buffer, axis)

--- a/tests/dsl/test_types.py
+++ b/tests/dsl/test_types.py
@@ -1,0 +1,21 @@
+import importlib
+
+import numpy as np
+
+import ndsl.dsl
+
+
+def test_type_precision_select():
+    original_precision = ndsl.dsl.NDSL_GLOBAL_PRECISION
+
+    ndsl.dsl.NDSL_GLOBAL_PRECISION = 32
+    importlib.reload(ndsl.dsl.typing)
+    assert ndsl.dsl.typing.Float == np.float32
+    assert ndsl.dsl.typing.Int == np.int32
+
+    ndsl.dsl.NDSL_GLOBAL_PRECISION = 64
+    importlib.reload(ndsl.dsl.typing)
+    assert ndsl.dsl.typing.Float == np.float64
+    assert ndsl.dsl.typing.Int == np.int64
+
+    ndsl.dsl.NDSL_GLOBAL_PRECISION = original_precision


### PR DESCRIPTION
# Description

Release of `2026.07.00` lead to a regression showing only in `pyfv3/develop__GEOSv_11_4_2` which was using `NDSL_64BIT_FLOAT_TYPE`. We restore the specific precision type and match them to the other (e.g. `Float64` matching `FloatField64`)

Also: random `mypy` / `ruff` type fixing

## How has this been tested?

New unit tests testing type precision selection

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
