### PR TITLE
fix: text representation of `Local`s

### DIFF
--- a/ndsl/quantity/local.py
+++ b/ndsl/quantity/local.py
@@ -48,3 +48,10 @@ class Local(Quantity):
         data = dace.data.create_datadescriptor(self._data)
         data.transient = True if not self._on_gpu else False
         return data
+
+    def __repr__(self) -> str:
+        return (
+            f"Local(\n    data=\n{self._data},\n    dims={self.dims},\n"
+            f"    units={self.units},\n    origin={self.origin},\n"
+            f"    extent={self.extent}\n)"
+        )

--- a/tests/quantity/test_local.py
+++ b/tests/quantity/test_local.py
@@ -32,6 +32,20 @@ def test_dace_data_descriptor_is_transient() -> None:
     assert array.transient
 
 
+def test_string_representation() -> None:
+    nx = 5
+    shape = (nx,)
+    local = Local(
+        data=np.empty(shape),
+        origin=(0,),
+        extent=(nx,),
+        dims=("dim_X",),
+        units="n/a",
+        backend=Backend.python(),
+    )
+    assert f"{local}".startswith("Local(")
+
+
 @dataclasses.dataclass
 class GoodLocals(LocalState):
     my_local: Local = dataclasses.field(

--- a/tests/quantity/test_quantity.py
+++ b/tests/quantity/test_quantity.py
@@ -346,3 +346,7 @@ def test_data_setter():
     # Expected fail: new array is not even an array
     with pytest.raises(TypeError, match="Quantity.data buffer swap failed.*"):
         quantity.swap_buffer("meh")
+
+
+def test_string_representation(quantity: Quantity) -> None:
+    assert f"{quantity}".startswith("Quantity(")


### PR DESCRIPTION
# Description

` Quantity`  has a custom string representation function (`__repr__()`). `Local` inherits from `Qantity` but didn't override it, so it would show "Quantity" even it's a local. This PR just copies the `__repr()`  function and changes the name to match the class.

## How has this been tested?

New unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
