### PR TITLE
build: drop support for python 3.11

### DIFF
--- a/.github/workflows/create-cache.yaml
+++ b/.github/workflows/create-cache.yaml
@@ -25,10 +25,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - uses: actions/cache@v5
         id: cache

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install zensical
         run: pip install zensical mkdocstrings[python]

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.12
       - run: pip install zensical mkdocstrings[python]
       - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       # Only restore (don't save) caches on PRs. New caches created from PRs won't be
       # accessible from other PRs, see workflows/create-cache.yaml.

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
         extra: ['test,zarr']
         marker-serial: ['not parallel and not gpu and not pyfms']
         marker-parallel: ['parallel and not gpu and not pyfms']

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Historically, NDSL was developed to port the FV3 dynamical core on the cubed-sph
 
 ## Quickstart
 
-Currently, NDSL requires `python` (versions `3.11`,`3.12`, and `3.13` are supported), a C/C++ compiler and MPI installed. All other dependencies installed during package installation. We recommend using a virtual (or conda) environment.
+Currently, NDSL requires `python` (versions `3.12` and `3.13` are supported), a C/C++ compiler and MPI installed. All other dependencies installed during package installation. We recommend using a virtual (or conda) environment.
 
 ```shell
 # We have submodules for GT4Py and DaCe. Don't forget to pull them
@@ -37,13 +37,13 @@ NDSL is under active development and may only work with specific setups. This is
 
 The run the CPU backends you will need:
 
-- Python: 3.11, 3.12, 3.13
+- Python: 3.12, 3.13
 - CXX compiler: GNU 11.2+
 - Libraries: MPI
 
 To run the GPU backends, you'll need:
 
-- Python: 3.11, 3.12, 3.13
+- Python: 3.12, 3.13
 - CXX compiler: GNU 11.2+
 - Libraries: MPI compiled with CUDA support
 - CUDA 11.2+

--- a/docs/install_ndsl.md
+++ b/docs/install_ndsl.md
@@ -10,7 +10,7 @@ NDSL is a python DSL. You can install NDSL as a python package and write your co
 
     Before installing NDSL, make sure your environment includes:
 
-    - A python environment. We support python versions `3.11`, `3.12`, `3.13`.
+    - A python environment. We support python versions `3.12` and `3.13`.
     - A compiler toolchain for C, C++. Optionally, a Fortran compiler if you're bridging to Fortran code.
     - MPI (can be installed via python, see below)
 

--- a/examples/Fortran_serialization/01_serialize_fortran_data.ipynb
+++ b/examples/Fortran_serialization/01_serialize_fortran_data.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "### **Notebook Requirements**\n",
     "\n",
-    "- Python v3.11.x to v3.12.x\n",
+    "- Python 3.12 or 3.13\n",
     "- [NOAA/NASA Domain Specific Language Middleware](https://github.com/NOAA-GFDL/NDSL)\n",
     "- `ipykernel==6.1.0`\n",
     "- [`ipython_genutils`](https://pypi.org/project/ipython_genutils/)\n",
@@ -659,7 +659,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/examples/Fortran_serialization/02_read_serialized_data_python.ipynb
+++ b/examples/Fortran_serialization/02_read_serialized_data_python.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "### **Notebook Requirements**\n",
     "\n",
-    "- Python v3.11.x to v3.12.x\n",
+    "- Python 3.12 or 3.13\n",
     "- [NOAA/NASA Domain Specific Language Middleware](https://github.com/NOAA-GFDL/NDSL)\n",
     "- `ipykernel==6.1.0`\n",
     "- [`ipython_genutils`](https://pypi.org/project/ipython_genutils/)\n",
@@ -236,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/examples/NDSL/01_gt4py_basics.ipynb
+++ b/examples/NDSL/01_gt4py_basics.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "### Notebook Requirements\n",
     "\n",
-    "- Python v3.11.x\n",
+    "- Python 3.12 or 3.13\n",
     "- [NOAA/NASA Domain Specific Language Middleware](https://github.com/NOAA-GFDL/NDSL)\n",
     "\n",
     "### Quick GT4Py (Cartesian version) Overview\n",
@@ -560,7 +560,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/examples/NDSL/02_NDSL_basics.ipynb
+++ b/examples/NDSL/02_NDSL_basics.ipynb
@@ -341,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/examples/NDSL/03_orchestration_basics.ipynb
+++ b/examples/NDSL/03_orchestration_basics.ipynb
@@ -159,7 +159,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
   "Private :: Do Not Upload",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]
@@ -20,7 +19,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE.txt", "ndsl/viz/fv3/README.md"]
 name = "ndsl"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.12,<3.14"
 
 [project.optional-dependencies]
 cuda12 = ['cupy-cuda12x>=12.0']


### PR DESCRIPTION
# Description

GT4Py (updated to 1.2.0 with this PR) dropped support for python 3.10 and 3.11.

In this PR we are following suit and drop support for python 3.11 in NDSL. CI pipelines are updated to use 3.12 (and 3.13 where applicable).

In terms of GT4Py changes, this just brings the [update of the C++ standard](https://github.com/GridTools/gt4py/pull/2722) in stencil mode. Note that we already use the C++20 standard for orchestration since PR #515.

## How has this been tested?

Searched the codebase for "3.11" and replaced occurrences. All good as long as CI is green.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
