### PR TITLE
[Fix | Opt II] Exclude top level Labeler from the LocalOptimization scheme

### DIFF
--- a/ndsl/dsl/dace/stree/optimizations/common/__init__.py
+++ b/ndsl/dsl/dace/stree/optimizations/common/__init__.py
@@ -3,6 +3,7 @@ from .loops import is_axis_for, is_axis_map, is_cartesian_axis
 from .topology import (
     detect_cycle,
     get_next_node,
+    is_first_node,
     is_last_node,
     list_index,
     swap_node_position_in_tree,
@@ -17,6 +18,7 @@ __all__ = [
     "is_axis_for",
     "get_next_node",
     "is_last_node",
+    "is_first_node",
     "swap_node_position_in_tree",
     "detect_cycle",
     "list_index",

--- a/ndsl/dsl/dace/stree/optimizations/common/topology.py
+++ b/ndsl/dsl/dace/stree/optimizations/common/topology.py
@@ -64,3 +64,8 @@ def get_next_node(
 def is_last_node(nodes: list[tn.ScheduleTreeNode], node: tn.ScheduleTreeNode) -> bool:
     """Check if the node is the last node of the list."""
     return list_index(nodes, node) >= len(nodes) - 1
+
+
+def is_first_node(nodes: list[tn.ScheduleTreeNode], node: tn.ScheduleTreeNode) -> bool:
+    """Check if the node is the first node of the list."""
+    return list_index(nodes, node) == 0

--- a/ndsl/dsl/dace/stree/optimizations/local_optimizations.py
+++ b/ndsl/dsl/dace/stree/optimizations/local_optimizations.py
@@ -2,6 +2,7 @@ from dace.sdfg.analysis.schedule_tree import treenodes as tn
 
 from ndsl import Backend, OptimizationConfig, ndsl_log
 from ndsl.dsl.dace.stree.optimizations.cartesian_merge import CartesianMerge
+from ndsl.dsl.dace.stree.optimizations.common import is_first_node, is_last_node
 from ndsl.dsl.dace.stree.optimizations.kernelize_maps import KernelizeMaps
 from ndsl.dsl.dace.stree.optimizations.remove_loops import InlineVertical2DWrite
 
@@ -186,6 +187,13 @@ class _LabelSections(ScheduleTreeScopeTransformer):
             if not child.node.name == "NDSLRuntime_Label":
                 # Leave other library call nodes alone.
                 children_stack[-1].append(child)
+                continue
+
+            # The very first Labeler
+            if child.parent == child.get_root() and (
+                is_last_node(child.parent.children, child)
+                or is_first_node(child.parent.children, child)
+            ):
                 continue
 
             if child.node.unique_name.startswith("Enter__"):

--- a/tests/dsl/dace/stree/optimizations/test_pipeline.py
+++ b/tests/dsl/dace/stree/optimizations/test_pipeline.py
@@ -1,9 +1,13 @@
+from dace.sdfg.state import LoopRegion
+from gt4py.cartesian.gtscript import FORWARD
+
 from ndsl import OptimizationConfig, StencilFactory, orchestrate
 from ndsl.boilerplate import get_factories_single_tile_orchestrated
 from ndsl.config import Backend
 from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField
+from tests.dsl.dace.stree import get_SDFG_and_purge
 
 
 def double_map(in_field: FloatField, out_field: FloatField):
@@ -48,3 +52,100 @@ def test_stree_roundtrip():
     code(in_qty, out_qty)
 
     assert (out_qty.field[:] == 4).all()
+
+
+def single_K_map(field: FloatField):
+    with computation(FORWARD), interval(0, 1):
+        field = 2.0
+
+
+class LocalOptimizationsCode_Child:
+    def __init__(self, stencil_factory: StencilFactory):
+        config = OptimizationConfig(
+            stree=OptimizationConfig.Tree(
+                enabled=True,
+                merger=OptimizationConfig.Tree.Merger(enabled=False),
+                kernelize=False,
+                inline_K_loops_size_one=True,
+            )
+        )
+        orchestrate(
+            obj=self,
+            config=stencil_factory.config.dace_config,
+            optimization_config=config,
+        )
+        self.stencil = stencil_factory.from_dims_halo(
+            func=single_K_map,
+            compute_dims=[I_DIM, J_DIM, K_DIM],
+        )
+
+    def __call__(self, field):
+        self.stencil(field)
+
+
+class LocalOptimizationsCode_ChildNoOpt:
+    def __init__(self, stencil_factory: StencilFactory):
+        orchestrate(
+            obj=self,
+            config=stencil_factory.config.dace_config,
+        )
+        self.stencil = stencil_factory.from_dims_halo(
+            func=single_K_map,
+            compute_dims=[I_DIM, J_DIM, K_DIM],
+        )
+
+    def __call__(self, field):
+        self.stencil(field)
+
+
+class LocalOptimizationsCode_TopLevel:
+    def __init__(self, stencil_factory: StencilFactory):
+        config = OptimizationConfig(
+            stree=OptimizationConfig.Tree(
+                enabled=True,
+                merger=OptimizationConfig.Tree.Merger(enabled=True),
+                kernelize=False,
+                inline_K_loops_size_one=False,
+            )
+        )
+        orchestrate(
+            obj=self,
+            config=stencil_factory.config.dace_config,
+            optimization_config=config,
+        )
+        self.stencil = stencil_factory.from_dims_halo(
+            func=single_K_map,
+            compute_dims=[I_DIM, J_DIM, K_DIM],
+        )
+        self.child = LocalOptimizationsCode_Child(stencil_factory)
+        self.no_opt_child = LocalOptimizationsCode_ChildNoOpt(stencil_factory)
+
+    def __call__(self, field: FloatField):
+        self.stencil(field)
+        self.child(field)
+        self.no_opt_child(field)
+
+
+def test_stree_local_optimization():
+    domain = (3, 3, 4)
+    stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
+        domain[0], domain[1], domain[2], 0, backend=Backend.cpu()
+    )
+
+    code = LocalOptimizationsCode_TopLevel(stencil_factory)
+    qty = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "")
+
+    code(qty)
+
+    precompiled_sdfg = get_SDFG_and_purge(stencil_factory)
+
+    all_loop_region = [
+        (me, state)
+        for me, state in precompiled_sdfg.sdfg.all_nodes_recursive()
+        if isinstance(me, LoopRegion)
+    ]
+
+    # The above code has three K loops of over a single unit element
+    # Child level optimization `LocalOptimizationsCode_Child` does `inline_K_loops_size_one` but
+    # the top level doesn't leading to a single loop left
+    assert len(all_loop_region) == 2


### PR DESCRIPTION
# Description

The local optimizer first version code triggers on top level code, which means that the next piece of the optimizer is running on _already_ global optimized code.

We introduce a quick fix to exclude the top level `Labeler` from the `LabelSection` transform which restore original intent.

A larger fix, as written in the code, is to merge the `LocalOptimization` in the larger "pipeline" concept, since this is in essence a localized pipeline.

Note: I introduce another topology function, without a test. I will write all tests in #524 as well as refactoring their API.

## How has this been tested?

Introduced a test for local optimization which test the local optimization is done properly. It doesn't _actually_ reflect the bug, but it checks that local optimization are indeed applied.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
