### PR TITLE
ci: update pre-commit tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,25 +4,27 @@ default_language_version:
 repos:
   # Use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
       - id: black-jupyter
+        args: ["--target-version", "py312"]
+        additional_dependencies: ["black[jupyter]"]
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pycqa/isort
+    rev: 8.0.1
     hooks:
       - id: isort
         args: ["--profile", "black"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: v2.3.0
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
         additional_dependencies: [types-PyYAML]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -38,7 +40,7 @@ repos:
         additional_dependencies: [Flake8-pyproject, flake8-bugbear]
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.15.0
+    rev: v2.16.0
     hooks:
       - id: pretty-format-toml
         args: [--autofix, --indent, "2"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,12 @@ repos:
     rev: 26.5.1
     hooks:
       - id: black-jupyter
-        args: ["--target-version", "py312"]
         additional_dependencies: ["black[jupyter]"]
 
   - repo: https://github.com/pycqa/isort
     rev: 8.0.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0

--- a/examples/mpi/zarr_monitor.py
+++ b/examples/mpi/zarr_monitor.py
@@ -16,7 +16,6 @@ from ndsl.config import backend_python
 from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.monitor import ZarrMonitor
 
-
 OUTPUT_PATH = "output/zarr_monitor.zarr"
 
 

--- a/ndsl/__init__.py
+++ b/ndsl/__init__.py
@@ -46,7 +46,6 @@ from .dsl.dace.utils import (
 from .dsl.dace.dace_config import DaceConfig, DaCeOrchestration
 from .dsl.dace.orchestration import orchestrate, orchestrate_function
 
-
 __all__ = [
     "hmm",
     "dsl",

--- a/ndsl/boilerplate/__init__.py
+++ b/ndsl/boilerplate/__init__.py
@@ -3,7 +3,6 @@ from .boilerplate import (
     get_factories_single_tile_orchestrated,
 )
 
-
 __all__ = [
     "get_factories_single_tile",
     "get_factories_single_tile_orchestrated",

--- a/ndsl/boilerplate/generate_code.py
+++ b/ndsl/boilerplate/generate_code.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import argparse
 import textwrap
 
-
-TEMPLATE = textwrap.dedent(
-    """\
+TEMPLATE = textwrap.dedent("""\
     from ndsl import NDSLRuntime
     from ndsl.boilerplate import get_factories_single_tile
     from ndsl.config import Backend
@@ -37,11 +35,9 @@ TEMPLATE = textwrap.dedent(
         def __call__(self, input_field: FloatField, output_field: FloatField):
             self._copy(input_field, output_field)
     {main_section}
-    """
-)
+    """)
 
-MAIN_SECTION = textwrap.dedent(
-    """\
+MAIN_SECTION = textwrap.dedent("""\
 
     def main() -> None:
 
@@ -66,8 +62,7 @@ MAIN_SECTION = textwrap.dedent(
 
     if __name__ == "__main__":
         main()
-    """
-)
+    """)
 
 
 def instance_name_from_class(class_name: str) -> str:

--- a/ndsl/buffer.py
+++ b/ndsl/buffer.py
@@ -16,7 +16,6 @@ from ndsl.utils import (
     safe_mpi_allocate,
 )
 
-
 BufferKey = tuple[Callable, Iterable[int], npt.DTypeLike]
 BUFFER_CACHE: dict[BufferKey, list["Buffer"]] = {}
 

--- a/ndsl/checkpointer/__init__.py
+++ b/ndsl/checkpointer/__init__.py
@@ -8,7 +8,6 @@ from .thresholds import (
 )
 from .validation import ValidationCheckpointer
 
-
 __all__ = [
     "NullCheckpointer",
     "SnapshotCheckpointer",

--- a/ndsl/checkpointer/base.py
+++ b/ndsl/checkpointer/base.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from ndsl import Quantity
 
-
 SavepointName: TypeAlias = str
 VariableName: TypeAlias = str
 ArrayLike: TypeAlias = Quantity | np.ndarray

--- a/ndsl/comm/__init__.py
+++ b/ndsl/comm/__init__.py
@@ -7,7 +7,6 @@ from .caching_comm import (
 )
 from .comm_abc import Comm, ReductionOperator, Request
 
-
 __all__ = [
     "CachingCommData",
     "CachingCommReader",

--- a/ndsl/comm/caching_comm.py
+++ b/ndsl/comm/caching_comm.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from ndsl.comm.comm_abc import Comm, ReductionOperator, Request
 
-
 T = TypeVar("T")
 
 

--- a/ndsl/comm/comm_abc.py
+++ b/ndsl/comm/comm_abc.py
@@ -4,7 +4,6 @@ import abc
 import enum
 from typing import Generic, TypeVar
 
-
 T = TypeVar("T")
 
 

--- a/ndsl/comm/decomposition.py
+++ b/ndsl/comm/decomposition.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from gt4py.cartesian import config as gt_config
 from mpi4py import MPI
 
-
 if TYPE_CHECKING:
     from ndsl.dsl.stencil_config import CompilationConfig
 

--- a/ndsl/comm/local_comm.py
+++ b/ndsl/comm/local_comm.py
@@ -7,7 +7,6 @@ from ndsl import ndsl_log
 from ndsl.comm.comm_abc import Comm, ReductionOperator
 from ndsl.utils import ensure_contiguous, safe_assign_array
 
-
 T = TypeVar("T")
 
 

--- a/ndsl/comm/mpi.py
+++ b/ndsl/comm/mpi.py
@@ -11,7 +11,6 @@ from mpi4py import MPI
 
 from ndsl.comm.comm_abc import Comm, ReductionOperator, Request
 
-
 T = TypeVar("T")
 
 

--- a/ndsl/comm/partitioner.py
+++ b/ndsl/comm/partitioner.py
@@ -24,7 +24,6 @@ from ndsl.constants import (
 from ndsl.quantity import QuantityMetadata
 from ndsl.utils import list_by_dims
 
-
 # we're caching slice objects which are pretty small, and the number we
 # generate depends on the number of different array shapes/sizes which
 # should not be that many

--- a/ndsl/config/__init__.py
+++ b/ndsl/config/__init__.py
@@ -9,7 +9,6 @@ from .backend import (
     backend_python,
 )
 
-
 __all__ = [
     "Backend",
     "BackendFramework",

--- a/ndsl/constants.py
+++ b/ndsl/constants.py
@@ -28,7 +28,7 @@ def _get_constant_version(
             f"Constants '{constants_as_str}' is not implemented, abort. Valid values are {expected}."
         )
 
-    return constants_as_str  # type: ignore
+    return constants_as_str
 
 
 CONST_VERSION = ConstantVersions[_get_constant_version()]

--- a/ndsl/debug/__init__.py
+++ b/ndsl/debug/__init__.py
@@ -1,4 +1,3 @@
 from .config import get_debugger
 
-
 __all__ = ["get_debugger"]

--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -6,7 +6,6 @@ from typing import Literal
 from ndsl import ndsl_log
 from ndsl.comm.mpi import MPI
 
-
 gt4py_config_module = "gt4py.cartesian.config"
 if gt4py_config_module in sys.modules:
     raise RuntimeError(
@@ -23,7 +22,7 @@ def _get_literal_precision(default: Literal["32", "64"] = "64") -> Literal["32",
 
     expected: list[Literal["32", "64"]] = ["32", "64"]
     if precision in expected:
-        return precision  # type: ignore
+        return precision
 
     ndsl_log.warning(
         f"Unexpected literal precision '{precision}', falling back to '{default}'. Valid values are {expected}."
@@ -39,7 +38,6 @@ os.environ["GT4PY_LITERAL_FLOAT_PRECISION"] = str(NDSL_GLOBAL_PRECISION)
 # Set cache names for default gt backends workflow
 import gt4py.cartesian.config  # noqa: E402
 
-
 if MPI is not None:
     import os
 
@@ -50,7 +48,6 @@ if MPI is not None:
 
 # Raise an error if DaCe backends aren't registered in GT4Py.
 import gt4py.cartesian.backend as gt_backend  # noqa: E402
-
 
 if not any([name.startswith("dace") for name in gt_backend.REGISTRY.names]):
     raise RuntimeError(

--- a/ndsl/dsl/caches/__init__.py
+++ b/ndsl/dsl/caches/__init__.py
@@ -1,7 +1,6 @@
 from .cache_location import identify_code_path
 from .codepath import FV3CodePath
 
-
 __all__ = [
     "identify_code_path",
     "FV3CodePath",

--- a/ndsl/dsl/dace/__init__.py
+++ b/ndsl/dsl/dace/__init__.py
@@ -1,5 +1,4 @@
 from .dace_config import DaceConfig
 from .orchestration import orchestrate, orchestrate_function
 
-
 __all__ = ["DaceConfig", "orchestrate", "orchestrate_function"]

--- a/ndsl/dsl/dace/build.py
+++ b/ndsl/dsl/dace/build.py
@@ -7,7 +7,6 @@ from ndsl.config import Backend
 from ndsl.dsl.caches.cache_location import get_cache_directory, get_cache_fullpath
 from ndsl.dsl.dace.dace_config import DaceConfig, DaCeOrchestration
 
-
 ################################################
 # Distributed compilation
 

--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -25,7 +25,6 @@ from ndsl.performance.collector import (
     PerformanceCollector,
 )
 
-
 if TYPE_CHECKING:
     from ndsl.dsl.dace.dace_executable import DaceExecutables
 

--- a/ndsl/dsl/dace/hardware_config.py
+++ b/ndsl/dsl/dace/hardware_config.py
@@ -6,7 +6,6 @@ from typing import Literal
 from ndsl import ndsl_log
 from ndsl.optional_imports import cupy as cp
 
-
 GPUVendor = Literal["Nvidia"] | Literal["AMD"] | Literal["Intel"] | Literal["Unknown"]
 
 # Taken straight out of https://pcisig.com/membership/member-companies

--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -52,7 +52,6 @@ from ndsl.dsl.dace.utils import (
 from ndsl.optional_imports import cupy as cp
 from ndsl.quantity import Quantity, State
 
-
 _INTERNAL__SCHEDULE_TREE_OPTIMIZATION_PASSES: list[tn.ScheduleNodeVisitor] | None = None
 
 

--- a/ndsl/dsl/dace/stree/__init__.py
+++ b/ndsl/dsl/dace/stree/__init__.py
@@ -1,4 +1,3 @@
 from .default_pipeline import CPUPipeline, GPUPipeline
 
-
 __all__ = ["CPUPipeline", "GPUPipeline"]

--- a/ndsl/dsl/dace/stree/common/__init__.py
+++ b/ndsl/dsl/dace/stree/common/__init__.py
@@ -17,7 +17,6 @@ from .topology import (
     swap_node_position_in_tree,
 )
 
-
 __all__ = [
     "AxisIterator",
     "no_data_dependencies_on_cartesian_axis",

--- a/ndsl/dsl/dace/stree/optimizations/__init__.py
+++ b/ndsl/dsl/dace/stree/optimizations/__init__.py
@@ -11,7 +11,6 @@ from .off_grid_conditionals import (
 from .refine_transients import CartesianRefineTransients
 from .remove_loops import InlineVertical2DWrite
 
-
 __all__ = [
     "CartesianAxisMerge",
     "CartesianMergePipeline",

--- a/ndsl/dsl/gt4py/__init__.py
+++ b/ndsl/dsl/gt4py/__init__.py
@@ -63,7 +63,6 @@ from gt4py.cartesian.gtscript import (
 
 from ndsl.internal.deferred_type import resolve_deferred_types
 
-
 function = lazy_function(before_annotation=resolve_deferred_types)
 
 __all__ = [

--- a/ndsl/dsl/gt4py_utils.py
+++ b/ndsl/dsl/gt4py_utils.py
@@ -12,7 +12,6 @@ from ndsl.constants import N_HALO_DEFAULT
 from ndsl.dsl.typing import Float
 from ndsl.optional_imports import cupy as cp
 
-
 # If True, automatically transfers memory between CPU and GPU (see gt4py.storage)
 managed_memory = True
 

--- a/ndsl/dsl/ndsl_runtime.py
+++ b/ndsl/dsl/ndsl_runtime.py
@@ -13,7 +13,6 @@ from ndsl.dsl.typing import Float
 from ndsl.initialization.allocator import QuantityFactory
 from ndsl.quantity import Local, Quantity
 
-
 _TOP_LEVEL: object | None = None
 
 

--- a/ndsl/dsl/stencil.py
+++ b/ndsl/dsl/stencil.py
@@ -256,12 +256,12 @@ def compare_ranks(comm: Comm, data: dict) -> Mapping[str, int]:
     return differences
 
 
-_DEPRECATED_STENCILS = []
-"""Collect deprecrated stencils"""
+_DEPRECATED_STENCILS: list[Callable] = []
+"""Collect deprecated stencils"""
 
 
 def deprecated_stencil(func: Callable) -> Callable:
-    """Wrapper (use as @deprecated_stencil) to mark a stencil as deprecated"""
+    """Wrapper to mark a stencil as deprecated: use as `@deprecated_stencil`."""
     _DEPRECATED_STENCILS.append(func)
     return func
 

--- a/ndsl/dsl/typing.py
+++ b/ndsl/dsl/typing.py
@@ -6,7 +6,6 @@ from gt4py.cartesian import gtscript
 
 from ndsl.dsl import NDSL_GLOBAL_PRECISION
 
-
 # A Field
 Field = gtscript.Field
 """A gt4py field"""

--- a/ndsl/grid/__init__.py
+++ b/ndsl/grid/__init__.py
@@ -10,7 +10,6 @@ from .helper import (
     VerticalGridData,
 )
 
-
 __all__ = [
     "HybridPressureCoefficients",
     "GridDefinitions",

--- a/ndsl/grid/eta.py
+++ b/ndsl/grid/eta.py
@@ -7,7 +7,6 @@ import xarray as xr
 
 from ndsl import ndsl_log
 
-
 ETA_0 = 0.252
 SURFACE_PRESSURE = 1.0e5  # units of (Pa), from Table VI of DCMIP2016
 

--- a/ndsl/grid/helper.py
+++ b/ndsl/grid/helper.py
@@ -160,10 +160,8 @@ class VerticalGridData:
 
         ak_bk_data_file = pathlib.Path(restart_path) / data_file
         if not ak_bk_data_file.is_file():
-            raise ValueError(
-                """vertical_grid_from_restart is true,
-                but no fv_core.res.nc in restart data file."""
-            )
+            raise ValueError("""vertical_grid_from_restart is true,
+                but no fv_core.res.nc in restart data file.""")
 
         ak = quantity_factory.zeros([K_INTERFACE_DIM], units="Pa")
         bk = quantity_factory.zeros([K_INTERFACE_DIM], units="")

--- a/ndsl/grid/mirror.py
+++ b/ndsl/grid/mirror.py
@@ -1,6 +1,5 @@
 from ndsl.constants import PI, RADIUS
 
-
 __all__ = ["mirror_grid"]
 
 RIGHT_HAND_GRID = False

--- a/ndsl/grid/stretch_transformation.py
+++ b/ndsl/grid/stretch_transformation.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from ndsl.quantity import Quantity
 
-
 T = TypeVar("T", bound=Quantity | np.ndarray)
 
 

--- a/ndsl/halo/__init__.py
+++ b/ndsl/halo/__init__.py
@@ -4,7 +4,6 @@ from .data_transformer import (
     HaloDataTransformerGPU,
 )
 
-
 __all__ = [
     "HaloDataTransformer",
     "HaloDataTransformerCPU",

--- a/ndsl/halo/cuda_kernels.py
+++ b/ndsl/halo/cuda_kernels.py
@@ -28,9 +28,7 @@ def pack_scalar_code(float_dtype: str) -> str:
         o_destinationBuffer[i_offset+tid] = i_sourceArray[i_indexes[tid]];
     }}
 
-    """.format(
-        fdtype=float_dtype
-    )
+    """.format(fdtype=float_dtype)
 
 
 def unpack_scalar_code(float_dtype: str) -> str:
@@ -57,9 +55,7 @@ def unpack_scalar_code(float_dtype: str) -> str:
                 o_destinationArray[i_indexes[tid]] = i_sourceBuffer[i_offset+tid];
             }}
 
-            """.format(
-        fdtype=float_dtype
-    )
+            """.format(fdtype=float_dtype)
 
 
 pack_scalar_f64_kernel = (
@@ -161,9 +157,7 @@ def pack_vector_code(float_dtype: str) -> str:
 
     }}
 
-    """.format(
-        fdtype=float_dtype
-    )
+    """.format(fdtype=float_dtype)
 
 
 def unpack_vector_code(float_dtype: str) -> str:
@@ -194,9 +188,7 @@ def unpack_vector_code(float_dtype: str) -> str:
                 o_destinationArrayY[i_indexesY[tid-i_nIndexX]] = i_sourceBuffer[i_offset+tid];
         }}
 
-        """.format(
-        fdtype=float_dtype
-    )
+        """.format(fdtype=float_dtype)
 
 
 pack_vector_f64_kernel = (

--- a/ndsl/halo/data_transformer.py
+++ b/ndsl/halo/data_transformer.py
@@ -26,7 +26,6 @@ from ndsl.optional_imports import cupy as cp
 from ndsl.quantity import Quantity, QuantityHaloSpec
 from ndsl.utils import device_synchronize
 
-
 # ------------------------------------------------------------------------
 # Simple pool of streams to lower the driver pressure
 # Use _pop/_push_stream to manipulate the pool

--- a/ndsl/halo/updater.py
+++ b/ndsl/halo/updater.py
@@ -18,7 +18,6 @@ from ndsl.quantity import Quantity, QuantityHaloSpec
 from ndsl.types import AsyncRequest
 from ndsl.utils import device_synchronize
 
-
 if TYPE_CHECKING:
     from ndsl.comm.communicator import Communicator
 

--- a/ndsl/initialization/__init__.py
+++ b/ndsl/initialization/__init__.py
@@ -2,7 +2,6 @@ from .grid_sizer import DataDimensions, GridSizer  # isort: skip
 from .allocator import QuantityFactory
 from .subtile_grid_sizer import SubtileGridSizer
 
-
 __all__ = [
     "DataDimensions",
     "GridSizer",

--- a/ndsl/initialization/grid_sizer.py
+++ b/ndsl/initialization/grid_sizer.py
@@ -5,7 +5,6 @@ from typing import TypeAlias
 
 from ndsl.types import IntegralNumber
 
-
 DataDimensions: TypeAlias = dict[str, IntegralNumber]
 
 

--- a/ndsl/internal/hmm.py
+++ b/ndsl/internal/hmm.py
@@ -29,7 +29,6 @@ from ndsl import ndsl_log
 from ndsl.optional_imports import cupy as cp
 from ndsl.optional_imports import numpy_allocator as np_allocator
 
-
 _IS_HMM_AVAILABLE: bool | None = None
 
 

--- a/ndsl/io.py
+++ b/ndsl/io.py
@@ -5,7 +5,6 @@ import xarray as xr
 
 from ndsl.quantity import Quantity
 
-
 # Calendar constant values copied from time_manager in FMS
 THIRTY_DAY_MONTHS = 1
 JULIAN = 2

--- a/ndsl/logging.py
+++ b/ndsl/logging.py
@@ -7,7 +7,6 @@ from typing import Annotated
 
 from ndsl.comm.mpi import MPI
 
-
 # Python log levels are hierarchical. The following dict is sorted by
 # severity. Setting the log level to "info" means that "info" and everything
 # more severe (e.g. "warning") will be logged.

--- a/ndsl/monitor/__init__.py
+++ b/ndsl/monitor/__init__.py
@@ -1,7 +1,6 @@
 from .protocol import Monitor
 from .zarr_monitor import ZarrMonitor
 
-
 __all__ = [
     "Monitor",
     "ZarrMonitor",

--- a/ndsl/monitor/diag_manager_monitor.py
+++ b/ndsl/monitor/diag_manager_monitor.py
@@ -5,7 +5,6 @@ import numpy.typing as npt
 
 from ndsl.monitor.protocol import Monitor
 
-
 try:
     from pyfms import diag_manager
 

--- a/ndsl/monitor/zarr_monitor.py
+++ b/ndsl/monitor/zarr_monitor.py
@@ -14,7 +14,6 @@ from ndsl.monitor.convert import to_numpy
 from ndsl.optional_imports import cupy, zarr
 from ndsl.utils import list_by_dims
 
-
 __all__ = ["ZarrMonitor"]
 
 T = TypeVar("T")

--- a/ndsl/performance/__init__.py
+++ b/ndsl/performance/__init__.py
@@ -1,5 +1,4 @@
 from .config import PerformanceConfig
 from .timer import NullTimer, Timer
 
-
 __all__ = ["PerformanceConfig", "NullTimer", "Timer"]

--- a/ndsl/performance/tools.py
+++ b/ndsl/performance/tools.py
@@ -6,7 +6,6 @@ from ndsl.dsl.dace.utils import (
     memory_static_analysis_from_path,
 )
 
-
 # Count the memory from a given SDFG
 ACTION_SDFG_MEMORY_STATIC_ANALYSIS = "sdfg_memory_static_analysis"
 ACTION_SDFG_KERNEL_THEORETICAL_TIMING = "sdfg_kernel_theoretical_timing"

--- a/ndsl/quantity/__init__.py
+++ b/ndsl/quantity/__init__.py
@@ -3,7 +3,6 @@ from .quantity import Quantity  # isort: skip
 from .local import Local  # isort: skip
 from .state import State, LocalState  # isort: skip
 
-
 __all__ = [
     "Local",
     "Quantity",

--- a/ndsl/quantity/bounds.py
+++ b/ndsl/quantity/bounds.py
@@ -6,7 +6,6 @@ import ndsl.constants as constants
 from ndsl.comm._boundary_utils import bound_default_slice, shift_boundary_slice_tuple
 from ndsl.optional_imports import cupy
 
-
 if cupy is None:
     import numpy as cupy
 

--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -16,10 +16,8 @@ from ndsl.internal.deferred_type import (
     get_lhs_name,
 )
 
-
 from gt4py.cartesian import gtscript  # isort: skip
 from gt4py.cartesian.gtscript import _FieldDescriptorMaker  # isort: skip
-
 
 DataDimensionIndex = int
 SparseNameMapping = dict[str, DataDimensionIndex]

--- a/ndsl/quantity/local.py
+++ b/ndsl/quantity/local.py
@@ -8,7 +8,6 @@ from ndsl.config import Backend
 from ndsl.optional_imports import cupy
 from ndsl.quantity import Quantity
 
-
 if cupy is None:
     import numpy as cupy
 

--- a/ndsl/quantity/metadata.py
+++ b/ndsl/quantity/metadata.py
@@ -10,7 +10,6 @@ import numpy.typing as npt
 from ndsl.config.backend import Backend
 from ndsl.optional_imports import cupy
 
-
 if cupy is None:
     import numpy as cupy
 

--- a/ndsl/quantity/quantity.py
+++ b/ndsl/quantity/quantity.py
@@ -19,7 +19,6 @@ from ndsl.optional_imports import cupy
 from ndsl.quantity.bounds import BoundedArrayView
 from ndsl.quantity.metadata import QuantityHaloSpec, QuantityMetadata
 
-
 if cupy is None:
     import numpy as cupy
 

--- a/ndsl/quantity/state.py
+++ b/ndsl/quantity/state.py
@@ -15,7 +15,6 @@ from ndsl.initialization import DataDimensions, QuantityFactory
 from ndsl.quantity import Local, Quantity
 from ndsl.types import Number
 
-
 _ArrayLike: TypeAlias = Quantity | np.ndarray
 StateMemoryMapping: TypeAlias = dict[str, dict | _ArrayLike | None]
 OptionalQuantityType: TypeAlias = Quantity | None

--- a/ndsl/restart/_legacy_restart.py
+++ b/ndsl/restart/_legacy_restart.py
@@ -12,7 +12,6 @@ from ndsl.comm.partitioner import get_tile_index
 from ndsl.quantity import Quantity
 from ndsl.restart._properties import RESTART_PROPERTIES, RestartProperties
 
-
 __all__ = ["open_restart"]
 
 RESTART_NAMES = ("fv_core.res", "fv_srf_wnd.res", "fv_tracer.res")

--- a/ndsl/restart/_properties.py
+++ b/ndsl/restart/_properties.py
@@ -10,7 +10,6 @@ from ..constants import (
     K_SOIL_DIM,
 )
 
-
 RestartProperties = Mapping[str, Mapping[str, str | Iterable[str]]]
 RESTART_PROPERTIES: RestartProperties = {
     "accumulated_x_courant_number": {

--- a/ndsl/stencils/__init__.py
+++ b/ndsl/stencils/__init__.py
@@ -29,7 +29,6 @@ from .basic_operations import (
 )
 from .corners import FillCornersBGrid
 
-
 __all__ = [
     "FillCornersBGrid",
     "add",

--- a/ndsl/stencils/c2l_ord.py
+++ b/ndsl/stencils/c2l_ord.py
@@ -18,7 +18,6 @@ from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid.helper import GridData
 from ndsl.initialization.allocator import QuantityFactory
 
-
 A1 = 0.5625
 A2 = -0.0625
 C1 = 1.125

--- a/ndsl/stencils/corners.py
+++ b/ndsl/stencils/corners.py
@@ -8,7 +8,6 @@ from ndsl.constants import I_INTERFACE_DIM, J_INTERFACE_DIM, K_INTERFACE_DIM
 from ndsl.dsl.stencil import GridIndexing
 from ndsl.dsl.typing import FloatField
 
-
 FillCornersDirection: TypeAlias = Literal["i", "j"]
 GridType: TypeAlias = Literal["A", "B"]  # Arakawa grid type
 

--- a/ndsl/stencils/testing/__init__.py
+++ b/ndsl/stencils/testing/__init__.py
@@ -15,7 +15,6 @@ from .translate import (
     read_serialized_data,
 )
 
-
 __all__ = [
     "Grid",
     "ParallelTranslate",

--- a/ndsl/stencils/testing/grid.py
+++ b/ndsl/stencils/testing/grid.py
@@ -24,7 +24,6 @@ from ndsl.halo.data_transformer import QuantityHaloSpec
 from ndsl.initialization import QuantityFactory, SubtileGridSizer
 from ndsl.quantity import Quantity
 
-
 TRACER_DIM = "tracers"
 
 

--- a/ndsl/stencils/testing/serialbox_to_netcdf.py
+++ b/ndsl/stencils/testing/serialbox_to_netcdf.py
@@ -8,7 +8,6 @@ import f90nml
 import numpy as np
 import xarray as xr
 
-
 try:
     import serialbox
 except ModuleNotFoundError:

--- a/ndsl/stencils/testing/test_translate.py
+++ b/ndsl/stencils/testing/test_translate.py
@@ -18,7 +18,6 @@ from ndsl.stencils.testing.savepoint import DataLoader, SavepointCase, dataset_t
 from ndsl.testing.comparison import BaseMetric, LegacyMetric, MultiModalFloatMetric
 from ndsl.testing.perturbation import perturb
 
-
 # this only matters for manually-added print statements
 np.set_printoptions(threshold=4096)
 

--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -10,7 +10,6 @@ from ndsl.quantity import Quantity
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 
-
 if cupy is None:
     import numpy as cupy
 

--- a/ndsl/types.py
+++ b/ndsl/types.py
@@ -4,7 +4,6 @@ from typing import TypeAlias
 import numpy as np
 from typing_extensions import Protocol
 
-
 Number: TypeAlias = int | float | np.int32 | np.int64 | np.float32 | np.float64
 IntegralNumber: TypeAlias = int | np.int8 | np.int16 | np.int32 | np.int64
 

--- a/ndsl/utils.py
+++ b/ndsl/utils.py
@@ -11,7 +11,6 @@ import ndsl.constants as constants
 from ndsl.optional_imports import cupy as cp
 from ndsl.types import Allocator
 
-
 # Run a deviceSynchronize() to check
 # that the GPU is present and ready to run
 if cp is not None:
@@ -108,7 +107,7 @@ def safe_mpi_allocate(
     if cp and (allocator is cp.empty or allocator is cp.zeros):
         original_allocator = cp.cuda.get_allocator()
         cp.cuda.set_allocator(cp.get_default_memory_pool().malloc)
-        array = allocator(shape, dtype=dtype)  # type: ignore # np.ndarray
+        array = allocator(shape, dtype=dtype)
         cp.cuda.set_allocator(original_allocator)
     else:
         array = allocator(shape, dtype=dtype)  # type: ignore # np.ndarray

--- a/ndsl/viz/__init__.py
+++ b/ndsl/viz/__init__.py
@@ -1,4 +1,3 @@
 from .cube_sphere import plot_cube_sphere
 
-
 __all__ = ["plot_cube_sphere"]

--- a/ndsl/viz/fv3/__init__.py
+++ b/ndsl/viz/fv3/__init__.py
@@ -18,7 +18,6 @@ from ._timestep_histograms import (
     plot_hourly_hist,
 )
 
-
 __all__ = [
     "plot_daily_and_hourly_hist",
     "plot_daily_hist",

--- a/ndsl/viz/fv3/_plot_cube.py
+++ b/ndsl/viz/fv3/_plot_cube.py
@@ -29,7 +29,6 @@ from ._plot_helpers import (
 )
 from .grid_metadata import GridMetadata, GridMetadataFV3, GridMetadataScream
 
-
 if os.getenv("CARTOPY_EXTERNAL_DOWNLOADER") != "natural_earth":
     # workaround to host our own global-scale coastline shapefile instead
     # of unreliable cartopy source
@@ -435,10 +434,8 @@ def center_longitudes(lon_array, central_longitude):
 
 def _validate_cube_shape(lat_shape, lon_shape, latb_shape, lonb_shape, array_shape):
     if (lon_shape[-1] != 6) or (lat_shape[-1] != 6) or (array_shape[-1] != 6):
-        raise ValueError(
-            """Last axis of each array must have six elements for
-            cubed-sphere tiles."""
-        )
+        raise ValueError("""Last axis of each array must have six elements for
+            cubed-sphere tiles.""")
 
     if (
         (lon_shape[0] != lat_shape[0])
@@ -446,10 +443,8 @@ def _validate_cube_shape(lat_shape, lon_shape, latb_shape, lonb_shape, array_sha
         or (lon_shape[1] != lat_shape[1])
         or (lat_shape[1] != array_shape[1])
     ):
-        raise ValueError(
-            """Horizontal axis lengths of lat and lon must be equal to
-            those of array."""
-        )
+        raise ValueError("""Horizontal axis lengths of lat and lon must be equal to
+            those of array.""")
 
     if (len(lonb_shape) != 3) or (len(latb_shape) != 3) or (len(array_shape) != 3):
         raise ValueError("Lonb, latb, and data_var each must be 3-dimensional.")
@@ -465,10 +460,8 @@ def _validate_cube_shape(lat_shape, lon_shape, latb_shape, lonb_shape, array_sha
         or (lonb_shape[1] != latb_shape[1])
         or (latb_shape[1] != (array_shape[1] + 1))
     ):
-        raise ValueError(
-            """Horizontal axis lengths of latb and lonb
-            must be one greater than those of array."""
-        )
+        raise ValueError("""Horizontal axis lengths of latb and lonb
+            must be one greater than those of array.""")
 
     if (len(lon_shape) != 3) or (len(lat_shape) != 3) or (len(array_shape) != 3):
         raise ValueError("Lon, lat, and data_var each must be 3-dimensional.")
@@ -522,10 +515,8 @@ def _plot_cube_axes(
     if plotting_function in ["pcolormesh", "contour", "contourf"]:
         _plotting_function = getattr(ax, plotting_function)
     else:
-        raise ValueError(
-            """Plotting functions only include pcolormesh, contour,
-            and contourf."""
-        )
+        raise ValueError("""Plotting functions only include pcolormesh, contour,
+            and contourf.""")
 
     if "vmin" not in kwargs:
         kwargs["vmin"] = np.nanmin(array)
@@ -588,10 +579,8 @@ def _plot_scream_axes(
         }
         _plotting_function = getattr(ax, mapping[plotting_function])
     else:
-        raise ValueError(
-            """Plotting functions only include pcolormesh, contour,
-            and contourf."""
-        )
+        raise ValueError("""Plotting functions only include pcolormesh, contour,
+            and contourf.""")
     if "vmin" not in kwargs:
         kwargs["vmin"] = np.nanmin(array)
 

--- a/ndsl/viz/fv3/_plot_diagnostics.py
+++ b/ndsl/viz/fv3/_plot_diagnostics.py
@@ -18,7 +18,6 @@ from scipy.stats import binned_statistic
 
 from ._constants import COORD_I_CENTER, COORD_J_CENTER, INIT_TIME_DIM
 
-
 STACK_DIMS = ["tile", INIT_TIME_DIM, COORD_I_CENTER, COORD_J_CENTER]
 
 

--- a/ndsl/viz/fv3/_styles.py
+++ b/ndsl/viz/fv3/_styles.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 from cycler import cycler
 
-
 # adapted from https://davidmathlogic.com/colorblind
 wong_palette = [
     "#56B4E9",

--- a/ndsl/xumpy/__init__.py
+++ b/ndsl/xumpy/__init__.py
@@ -13,7 +13,6 @@ from ndsl.xumpy.alloc import empty, full, ones, random, zeros
 from ndsl.xumpy.count_nonzero import count_nonzero
 from ndsl.xumpy.minmax import max, max_on_horizontal_plane, min
 
-
 __all__ = [
     "max",
     "min",

--- a/ndsl/xumpy/alloc.py
+++ b/ndsl/xumpy/alloc.py
@@ -7,7 +7,6 @@ from ndsl.config import Backend
 from ndsl.dsl.typing import Float
 from ndsl.optional_imports import cupy as cp
 
-
 if cp is None:
     cp = np
 

--- a/ndsl/xumpy/minmax.py
+++ b/ndsl/xumpy/minmax.py
@@ -7,7 +7,6 @@ import numpy.typing as npt
 from ndsl import Quantity
 from ndsl.optional_imports import cupy as cp
 
-
 if cp is None:
     cp = np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ max-line-length = 88
 [tool.isort]
 default_section = "THIRDPARTY"
 known_third_party = "f90nml,pytest,xarray,numpy,mpi4py,gt4py,dace"
-lines_after_imports = 2
 profile = "black"
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ Repository = "https://github.com/NOAA-GFDL/NDSL"
 
 [tool.aliases]
 
+[tool.black]
+target-version = ["py312", "py313"]
+
 [tool.coverage.run]
 branch = true
 omit = ["tests/*", "*gt_cache*", ".dacecache*", "external/*", "__init__.py"]

--- a/tests/dsl/dace/stree/__init__.py
+++ b/tests/dsl/dace/stree/__init__.py
@@ -1,6 +1,5 @@
 from .sdfg_stree_tools import StreePipeline, get_SDFG_and_purge
 
-
 __all__ = [
     "StreePipeline",
     "get_SDFG_and_purge",

--- a/tests/dsl/dace/stree/optimizations/__init__.py
+++ b/tests/dsl/dace/stree/optimizations/__init__.py
@@ -2,5 +2,4 @@ from typing import TypeAlias
 
 from ndsl import QuantityFactory, StencilFactory
 
-
 Factories: TypeAlias = tuple[StencilFactory, QuantityFactory]

--- a/tests/dsl/dace/stree/optimizations/test_kernelize_maps.py
+++ b/tests/dsl/dace/stree/optimizations/test_kernelize_maps.py
@@ -26,7 +26,7 @@ def stencil_kernelize(in_field: FloatField, out_field: FloatField) -> None:  # t
 
 def stencil_only_serial_noop(
     in_field: FloatField, out_field: FloatField
-) -> None:  # type:ignore
+) -> None:  # type: ignore
     with computation(FORWARD), interval(...):
         tmp = in_field
 
@@ -36,7 +36,7 @@ def stencil_only_serial_noop(
 
 def stencil_only_parallel_noop(
     in_field: FloatField, out_field: FloatField
-) -> None:  # type:ignore
+) -> None:  # type: ignore
     with computation(PARALLEL), interval(0, 2):
         out_field = in_field
 

--- a/tests/dsl/dace/stree/optimizations/test_transient_refine.py
+++ b/tests/dsl/dace/stree/optimizations/test_transient_refine.py
@@ -13,7 +13,6 @@ from ndsl.dsl.gt4py import IJK, PARALLEL, Field, J, K, computation, interval
 from ndsl.dsl.typing import Float, FloatField
 from tests.dsl.dace.stree import get_SDFG_and_purge
 
-
 DATADIM_SIZE = 8
 DDIM_NAME = "DDIM"
 DDIM_TYPE = Field[IJK, (Float, (DATADIM_SIZE))]

--- a/tests/dsl/test_dace_config.py
+++ b/tests/dsl/test_dace_config.py
@@ -6,7 +6,6 @@ from ndsl.config import Backend
 from ndsl.dsl.dace.dace_config import _determine_compiling_ranks
 from ndsl.dsl.dace.orchestration import orchestrate, orchestrate_function
 
-
 """
 Tests that the dace configuration ndsl.dsl.dace.dace_config
 which determines whether we use dace to run wrapped functions.

--- a/tests/dsl/test_stencil_factory.py
+++ b/tests/dsl/test_stencil_factory.py
@@ -16,7 +16,6 @@ from ndsl.dsl.gt4py_utils import make_storage_from_shape
 from ndsl.dsl.stencil import CompareToNumpyStencil, get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Field, FloatField
 
-
 BACKENDS = [Backend.python(), Backend("st:dace:cpu:KIJ")]
 
 

--- a/tests/dsl/test_stencil_wrapper.py
+++ b/tests/dsl/test_stencil_wrapper.py
@@ -29,7 +29,6 @@ from ndsl.dsl.typing import (
     IntFieldIJ64,
 )
 
-
 # GT4Py direct import need to be down after any `ndsl`
 import gt4py.cartesian.gtscript  # isort: skip
 from gt4py.cartesian import definitions  # isort: skip

--- a/tests/grid/test_eta.py
+++ b/tests/grid/test_eta.py
@@ -13,7 +13,6 @@ from ndsl import (
 from ndsl.config import Backend
 from ndsl.grid import MetricTerms
 
-
 """
 This test checks to ensure that ak and bk values are read-in and stored properly. In
 addition, this test checks to ensure that the function set_hybrid_pressure_coefficients

--- a/tests/monitor/test_zarr_monitor.py
+++ b/tests/monitor/test_zarr_monitor.py
@@ -21,7 +21,6 @@ from ndsl.constants import (
 from ndsl.monitor.zarr_monitor import ZarrMonitor, array_chunks, get_calendar
 from ndsl.optional_imports import zarr
 
-
 # pace's K_DIMS doesn't check the soil dimension
 ALL_K_DIMS = ("k", "k_interface", "k_soil")
 

--- a/tests/mpi/test_mpi_mock.py
+++ b/tests/mpi/test_mpi_mock.py
@@ -6,7 +6,6 @@ from ndsl.buffer import recv_buffer
 from ndsl.comm.local_comm import ConcurrencyError
 from ndsl.comm.mpi import MPI
 
-
 worker_function_list = []
 
 MAX_WORKER_ITERATIONS = 16

--- a/tests/quantity/test_data_dimensions_field.py
+++ b/tests/quantity/test_data_dimensions_field.py
@@ -22,7 +22,6 @@ from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import PARALLEL, computation, function, interval
 from ndsl.dsl.typing import Float, FloatField, Int
 
-
 Tracers = DataDimensionsField.declare()
 TracersAndPlumes = DataDimensionsField.declare()
 GlobalTable = DataDimensionsField.declare()

--- a/tests/stencils/test_stencils.py
+++ b/tests/stencils/test_stencils.py
@@ -14,7 +14,6 @@ from ndsl.stencils.column_operations import (
     column_min_ddim,
 )
 
-
 FloatField_ddim = set_4d_field_size(2, Float)
 
 

--- a/tests/test_4d_fields.py
+++ b/tests/test_4d_fields.py
@@ -7,7 +7,6 @@ from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import PARALLEL, computation, interval, max
 from ndsl.dsl.typing import Float, FloatField, set_4d_field_size
 
-
 TRACER_DIM = "n_tracers"
 FloatFieldTracer = set_4d_field_size(9, Float)
 ntracers = 9

--- a/tests/test_legacy_restart.py
+++ b/tests/test_legacy_restart.py
@@ -22,7 +22,6 @@ from ndsl.restart._legacy_restart import (
     open_restart,
 )
 
-
 TEST_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 DATA_DIRECTORY = os.path.join(TEST_DIRECTORY, "data")
 

--- a/tests/test_partitioner.py
+++ b/tests/test_partitioner.py
@@ -18,7 +18,6 @@ from ndsl.constants import (
     TILE_DIM,
 )
 
-
 rank_list = []
 total_rank_list = []
 tile_index_list = []

--- a/tests/test_partitioner_boundaries.py
+++ b/tests/test_partitioner_boundaries.py
@@ -16,7 +16,6 @@ from ndsl.constants import (
     WEST,
 )
 
-
 # the test examples for the 2x2 cube here were recorded by manually inspecting
 # a paper cube with printed ranks
 


### PR DESCRIPTION
# Description

We haven't updated our linting tools in a long-ish time. In particular, `isort`  was pointing to a repo that is archived by now. List of updates:

- black: 25.1.0 -> 26.5.1
- isort: 5.10.1 -> 8.0.1
- mypy: 1.18.2 -> 2.3.0
- pre-commit hooks: 5.0.0 -> 6.0.0
- yaml/toml formatter: 2.15.0 -> 2.16.0

Mypy found a couple `# type: ignore` that now are missing. It was complaining about `_DEPRECATED_STENCILS`  not being typed, so I added a `list[Callable]`  type. Otherwise just whitespace changes.

## How has this been tested?

All good as long as CI (in particular the linting workflow) is green.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
