### PR TITLE
refactor: remove logging of storage layout for every grid variable

### DIFF
--- a/ndsl/stencils/testing/translate.py
+++ b/ndsl/stencils/testing/translate.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 
 import ndsl.dsl.gt4py_utils as utils
-from ndsl import Backend, StencilFactory, ndsl_log
+from ndsl import Backend, StencilFactory
 from ndsl.optional_imports import cupy
 from ndsl.quantity import Quantity
 from ndsl.stencils.testing.grid import Grid
@@ -431,11 +431,6 @@ class TranslateGrid:
                 # TODO: when grid initialization model exists, may want to use
                 # it to inform this
                 istart, jstart = pygrid.horizontal_starts_from_shape(value.shape)
-                ndsl_log.debug(
-                    "Storage for Grid variable {}, {}, {}, {}".format(
-                        key, istart, jstart, value.shape
-                    )
-                )
                 origin = (istart, jstart, 0)
                 self.data[key] = utils.make_storage_data(
                     value,


### PR DESCRIPTION
# Description

Currently, loggin in `DEBUG` mode drops a line with the storage layout for every grid variable initialized (see screenshot)

<img width="1626" height="566" alt="image" src="https://github.com/user-attachments/assets/f74c4bb3-7c6e-416f-914f-303889ffc1ad" />

There isn't much to gain from that and it just clutters the log. We thus decided to remove it.

## How has this been tested?

Self-review of the code changes.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
