### PR TITLE
fix: force kwargs when registering DataDimensionsField

### DIFF
--- a/ndsl/quantity/data_dimensions_field.py
+++ b/ndsl/quantity/data_dimensions_field.py
@@ -87,6 +87,7 @@ class DataDimensionsField(StencilTypeRegistrar):
         cls,
         pre_registration_type: "DataDimensionsMarkupType",
         quantity_factory: QuantityFactory,
+        *,
         data_dimensions_names: list[str],
         name_mapping: SparseNameMapping | None = None,
         dtype: npt.DTypeLike = Float,
@@ -194,7 +195,7 @@ class DataDimensionsField(StencilTypeRegistrar):
         cls.register(
             markup_type,
             quantity_factory,
-            data_dimensions_names,
+            data_dimensions_names=data_dimensions_names,
             axes=axes,
             name_mapping=name_mapping,
             dtype=dtype,

--- a/tests/quantity/test_data_dimensions_field.py
+++ b/tests/quantity/test_data_dimensions_field.py
@@ -27,25 +27,25 @@ TracersAndPlumes = DataDimensionsField.declare()
 GlobalTable = DataDimensionsField.declare()
 
 
-def _the_stencil_5D(in_field: TracersAndPlumes, out_field: FloatField, add: FloatField):
+def _the_stencil_5D(in_field: TracersAndPlumes, out_field: FloatField, add: FloatField) -> None:  # type: ignore
     with computation(PARALLEL), interval(...):
         out_field = in_field.A[1, 1] + add
 
 
-def _the_stencil_4D(in_tracers: Tracers, out_field: FloatField, add: FloatField):
+def _the_stencil_4D(in_tracers: Tracers, out_field: FloatField, add: FloatField) -> None:  # type: ignore
     with computation(PARALLEL), interval(...):
-        from __externals__ import C
+        from __externals__ import C  # type: ignore
 
         out_field = in_tracers[0, 0, 0][C] + add
 
 
-def _the_stencil_3D(in_field: FloatField, out_field: FloatField, add: FloatField):
+def _the_stencil_3D(in_field: FloatField, out_field: FloatField, add: FloatField) -> None:  # type: ignore
     with computation(PARALLEL), interval(...):
         out_field = in_field + add
 
 
-def _the_stencil_table(in_field: FloatField, table: GlobalTable, out_field: Tracers):
-    from __externals__ import tracer_count
+def _the_stencil_table(in_field: FloatField, table: GlobalTable, out_field: Tracers) -> None:  # type: ignore
+    from __externals__ import tracer_count  # type: ignore
 
     with computation(PARALLEL), interval(...):
         tracer_id = 0
@@ -55,12 +55,12 @@ def _the_stencil_table(in_field: FloatField, table: GlobalTable, out_field: Trac
 
 
 @function
-def _compute_function(in_field: FloatField, tracer_id: int, table: GlobalTable):  # type: ignore
+def _compute_function(in_field: FloatField, tracer_id: int, table: GlobalTable) -> None:  # type: ignore
     return in_field * tracer_id + table.A[5]
 
 
 def _the_stencil_function_with_table(
-    in_field: FloatField, table: GlobalTable, out_field: Tracers
+    in_field: FloatField, table: GlobalTable, out_field: Tracers  # type: ignore
 ) -> None:
     with computation(PARALLEL), interval(...):
         tracer_id = 0
@@ -72,9 +72,9 @@ def _the_stencil_function_with_table(
 
 
 def _the_stencil_function_with_table_and_externals(
-    in_field: FloatField, table: GlobalTable, out_field: Tracers
+    in_field: FloatField, table: GlobalTable, out_field: Tracers  # type: ignore
 ) -> None:
-    from __externals__ import tracer_count
+    from __externals__ import tracer_count  # type: ignore
 
     with computation(PARALLEL), interval(...):
         tracer_id = 0
@@ -88,7 +88,7 @@ def _the_stencil_function_with_table_and_externals(
 SETUP_DDIMS_ONCE = False
 
 
-def setup_data_dimensions(quantity_factory: QuantityFactory):
+def setup_data_dimensions(quantity_factory: QuantityFactory) -> None:
     quantity_factory.add_data_dimensions({"tracers": 8, "plumes": 3})
     quantity_factory.add_data_dimensions({"table_size": 42})
 
@@ -100,13 +100,23 @@ def setup_data_dimensions(quantity_factory: QuantityFactory):
 
     mappings = {"A": 0, "C": 2, "D": 3, "G": 6, "H": 7}
     DataDimensionsField.register(
-        Tracers, quantity_factory, ["tracers"], name_mapping=mappings
+        Tracers,
+        quantity_factory,
+        data_dimensions_names=["tracers"],
+        name_mapping=mappings,
     )
     DataDimensionsField.register(
-        TracersAndPlumes, quantity_factory, ["tracers", "plumes"], name_mapping=mappings
+        TracersAndPlumes,
+        quantity_factory,
+        data_dimensions_names=["tracers", "plumes"],
+        name_mapping=mappings,
     )
     DataDimensionsField.register(
-        GlobalTable, quantity_factory, ["table_size"], axes=[], dtype=np.int64
+        GlobalTable,
+        quantity_factory,
+        data_dimensions_names=["table_size"],
+        axes=[],
+        dtype=np.int64,
     )
 
 
@@ -191,26 +201,17 @@ class Code(NDSLRuntime):
         )
 
     def stencil_with_table(
-        self,
-        in_field: FloatField,
-        table: GlobalTable,
-        out_field: Tracers,  # type: ignore
+        self, in_field: FloatField, table: GlobalTable, out_field: Tracers  # type: ignore
     ) -> None:
         self._the_stencil_table(in_field, table, out_field)
 
     def function_with_table(
-        self,
-        in_field: FloatField,
-        table: GlobalTable,
-        out_field: Tracers,  # type: ignore
+        self, in_field: FloatField, table: GlobalTable, out_field: Tracers  # type: ignore
     ) -> None:
         self._the_stencil_function_with_table(in_field, table, out_field)
 
     def function_with_table_and_externals(
-        self,
-        in_field: FloatField,
-        table: GlobalTable,
-        out_field: Tracers,  # type: ignore
+        self, in_field: FloatField, table: GlobalTable, out_field: Tracers  # type: ignore
     ) -> None:
         self._the_stencil_function_with_table_and_externals(in_field, table, out_field)
 
@@ -234,7 +235,10 @@ def test_data_dimensions_registration_errors(domain: Domain) -> None:
         ),
     ):
         DataDimensionsField.register(
-            TracersAndPlumes, quantity_factory, ["tracers"], name_mapping={}
+            TracersAndPlumes,
+            quantity_factory,
+            data_dimensions_names=["tracers"],
+            name_mapping={},
         )
 
     with pytest.raises(


### PR DESCRIPTION
# Description

This is a follow-up from PR https://github.com/NOAA-GFDL/NDSL/pull/520, which supposed to enforce kwargs when registering data dimensions fields. The PR only forced it in case of `daclare_and_register()` and missed to place the `*` in case of `register()`.

Related PRs:

- https://github.com/NOAA-GFDL/pyFV3/pull/156
- https://github.com/NOAA-GFDL/pace/pull/203

## How has this been tested?

kwargs will be enforced by the python language now.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
