### PR TITLE
[Fix | Opt Cycle II] Transient strides and lifetime

### DIFF
--- a/ndsl/config/backend.py
+++ b/ndsl/config/backend.py
@@ -174,12 +174,25 @@ class Backend:
     def as_safe_for_path(self) -> str:
         return self._humanly_readable.replace(":", "_")
 
-    def as_layout_map(self) -> tuple[int, ...]:
+    def as_layout_map(self, data_dimensions_size: int = 0) -> tuple[int, ...]:
+        """Give backe the layout as a tuple of integer signifying the order of
+        the axis in the strides.
+
+        Args:
+            data_dimensions_size: when > 0 extends the map to include the data_dimensions
+            expected layout
+        """
         loop_order_as_string = self._loop_order.value
-        return tuple(
+        cartesian = [
             len(loop_order_as_string) - 1 - loop_order_as_string.index(axis)
             for axis in "IJK"
+        ]
+        data_dimensions = (
+            [ddim + len(cartesian) for ddim in range(data_dimensions_size)]
+            if data_dimensions_size > 0
+            else []
         )
+        return tuple(cartesian + data_dimensions)
 
     def is_orchestrated(self) -> bool:
         return self._strategy == BackendStrategy.ORCHESTRATION

--- a/ndsl/config/backend.py
+++ b/ndsl/config/backend.py
@@ -174,8 +174,8 @@ class Backend:
     def as_safe_for_path(self) -> str:
         return self._humanly_readable.replace(":", "_")
 
-    def as_layout_map(self, data_dimensions_size: int = 0) -> tuple[int, ...]:
-        """Give backe the layout as a tuple of integer signifying the order of
+    def as_layout_map(self, *, data_dimensions_size: int = 0) -> tuple[int, ...]:
+        """Give back the layout as a tuple of integer signifying the order of
         the axis in the strides.
 
         Args:
@@ -187,11 +187,7 @@ class Backend:
             len(loop_order_as_string) - 1 - loop_order_as_string.index(axis)
             for axis in "IJK"
         ]
-        data_dimensions = (
-            [ddim + len(cartesian) for ddim in range(data_dimensions_size)]
-            if data_dimensions_size > 0
-            else []
-        )
+        data_dimensions = [ddim + len(cartesian) for ddim in range(data_dimensions_size)]
         return tuple(cartesian + data_dimensions)
 
     def is_orchestrated(self) -> bool:
@@ -202,6 +198,9 @@ class Backend:
 
     def is_gpu_backend(self) -> bool:
         return self._device == BackendTargetDevice.GPU
+
+    def is_cpu_backend(self) -> bool:
+        return self._device == BackendTargetDevice.CPU
 
     def equivalent_cpu_backend(self) -> "Backend":
         """Return the equivalent backend (same strategy, framework and loop order) but for CPU device."""

--- a/ndsl/config/backend.py
+++ b/ndsl/config/backend.py
@@ -187,7 +187,9 @@ class Backend:
             len(loop_order_as_string) - 1 - loop_order_as_string.index(axis)
             for axis in "IJK"
         ]
-        data_dimensions = [ddim + len(cartesian) for ddim in range(data_dimensions_size)]
+        data_dimensions = [
+            ddim + len(cartesian) for ddim in range(data_dimensions_size)
+        ]
         return tuple(cartesian + data_dimensions)
 
     def is_orchestrated(self) -> bool:

--- a/ndsl/dsl/dace/stree/default_pipeline.py
+++ b/ndsl/dsl/dace/stree/default_pipeline.py
@@ -36,7 +36,7 @@ class CPUPipeline(StreePipeline):
                     )
                 )
             if config.stree.refine_transients:
-                ppl_passes.append(CartesianRefineTransients())
+                ppl_passes.append(CartesianRefineTransients(backend))
         else:
             ppl_passes = passes
         super().__init__(

--- a/ndsl/dsl/dace/stree/optimizations/refine_transients.py
+++ b/ndsl/dsl/dace/stree/optimizations/refine_transients.py
@@ -3,7 +3,7 @@ import warnings
 import dace.data
 from dace.sdfg.analysis.schedule_tree import treenodes as tn
 
-from ndsl import ndsl_log
+from ndsl import Backend, ndsl_log
 from ndsl.dsl.dace.stree.common import AxisIterator
 
 
@@ -24,9 +24,10 @@ def _change_index_of_tuple(
 
 def _reduce_cartesian_axis_size_to_1(
     axis: AxisIterator,
+    backend: Backend,
     transient_map_reads: dace.subsets.Range | None,
     transient_map_writes: dace.subsets.Range | None,
-    transient_data: dace.data.Data,
+    transient_data: dace.data.Array,
 ) -> bool:
     """Reduce dimension size of transient to 1 if all access (reads and writes)
     are atomic"""
@@ -59,7 +60,14 @@ def _reduce_cartesian_axis_size_to_1(
         value=1,
     )
     transient_data.set_shape(new_shape)
-    transient_data.lifetime = dace.dtypes.AllocationLifetime.State
+    transient_data.set_strides_from_layout(*backend.as_layout_map())
+
+    # CPU doesn't carry a memory pool - therefore any allocation will end
+    # up on the scope it is needed. Post refine, this can mean allocation every
+    # loop iteration. We push the transient on Persistent to make sure this does not happen.
+    if not backend.is_gpu_backend():
+        transient_data.lifetime = dace.dtypes.AllocationLifetime.Persistent
+
     return True
 
 
@@ -219,13 +227,14 @@ class CartesianRefineTransients(tn.ScheduleNodeTransformer):
         memory (e.g. halo) for the `RebuildMemletsFromContainers`!
     """
 
-    def __init__(self) -> None:
+    def __init__(self, backend: Backend) -> None:
         warnings.warn(
             "CartesianRefineTransients is a WIP. It's usage is *severely* limited "
             "and will most likely lead to bad numerics. Check the docs, check utest.",
             UserWarning,
             stacklevel=2,
         )
+        self._backend = backend
 
     def __str__(self) -> str:
         return "CartesianRefineTransients"
@@ -256,6 +265,7 @@ class CartesianRefineTransients(tn.ScheduleNodeTransformer):
                 # Refine axis down to 1
                 refined |= _reduce_cartesian_axis_size_to_1(
                     axis,
+                    self._backend,
                     collect_map.transients_range_reads[name],
                     collect_map.transients_range_writes[name],
                     data,

--- a/ndsl/dsl/dace/stree/optimizations/refine_transients.py
+++ b/ndsl/dsl/dace/stree/optimizations/refine_transients.py
@@ -60,7 +60,11 @@ def _reduce_cartesian_axis_size_to_1(
         value=1,
     )
     transient_data.set_shape(new_shape)
-    transient_data.set_strides_from_layout(*backend.as_layout_map())
+    # ⚠️ The below ddim calculation only works because we _know_ it's a 3D field
+    #    We need to somehow carry the information of the cartesian access here to go to 3D
+    transient_data.set_strides_from_layout(
+        *backend.as_layout_map(data_dimensions_size=len(new_shape) - 3)
+    )
 
     # CPU doesn't carry a memory pool - therefore any allocation will end
     # up on the scope it is needed. Post refine, this can mean allocation every

--- a/ndsl/dsl/dace/stree/optimizations/refine_transients.py
+++ b/ndsl/dsl/dace/stree/optimizations/refine_transients.py
@@ -69,7 +69,7 @@ def _reduce_cartesian_axis_size_to_1(
     # CPU doesn't carry a memory pool - therefore any allocation will end
     # up on the scope it is needed. Post refine, this can mean allocation every
     # loop iteration. We push the transient on Persistent to make sure this does not happen.
-    if not backend.is_gpu_backend():
+    if backend.is_cpu_backend():
         transient_data.lifetime = dace.dtypes.AllocationLifetime.Persistent
 
     return True

--- a/tests/config/test_backend.py
+++ b/tests/config/test_backend.py
@@ -50,3 +50,14 @@ def test_equivalent_backend() -> None:
         kji_backend.equivalent_backend_with_loop_order(BackendLoopOrder.IJK)
         == ijk_backend
     )
+
+
+def test_backup_as_layout_map() -> None:
+    ijk_backend = Backend("st:python:cpu:IJK")
+    assert ijk_backend.as_layout_map() == (2, 1, 0)
+    assert ijk_backend.as_layout_map(data_dimensions_size=3) == (2, 1, 0, 3, 4, 5)
+    assert ijk_backend.as_layout_map(data_dimensions_size=0) == (2, 1, 0)
+    assert ijk_backend.as_layout_map(data_dimensions_size=-1) == (2, 1, 0)
+    kji_backend = Backend("orch:dace:cpu:KJI")
+    assert kji_backend.as_layout_map() == (0, 1, 2)
+    assert kji_backend.as_layout_map(data_dimensions_size=3) == (0, 1, 2, 3, 4, 5)

--- a/tests/dsl/dace/stree/optimizations/test_transient_refine.py
+++ b/tests/dsl/dace/stree/optimizations/test_transient_refine.py
@@ -113,7 +113,9 @@ class TransientRefineableCode(NDSLRuntime):
 
 def _check_strides(array: Array, backend: Backend):
     old_strides = array.strides
-    array.set_strides_from_layout(*backend.as_layout_map(len(array.shape) - 3))
+    array.set_strides_from_layout(
+        *backend.as_layout_map(data_dimensions_size=len(array.shape) - 3)
+    )
     assert old_strides == array.strides
 
 

--- a/tests/dsl/dace/stree/optimizations/test_transient_refine.py
+++ b/tests/dsl/dace/stree/optimizations/test_transient_refine.py
@@ -1,3 +1,5 @@
+from dace.data import Array
+
 from ndsl import (
     NDSLRuntime,
     OptimizationConfig,
@@ -8,7 +10,7 @@ from ndsl import (
 )
 from ndsl.boilerplate import get_factories_single_tile_orchestrated
 from ndsl.config import Backend
-from ndsl.constants import I_DIM, J_DIM, K_DIM
+from ndsl.constants import I_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
 from ndsl.dsl.gt4py import IJK, PARALLEL, Field, J, K, computation, interval
 from ndsl.dsl.typing import Float, FloatField
 from tests.dsl.dace.stree import get_SDFG_and_purge
@@ -33,6 +35,11 @@ def stencil_with_JK_offset(in_field: FloatField, out_field: FloatField) -> None:
         out_field = in_field[J + 1, K + 1] + 3
 
 
+def stencil_with_J_offset(in_field: FloatField, out_field: FloatField) -> None:
+    with computation(PARALLEL), interval(...):
+        out_field = in_field[J + 1] + 3
+
+
 def stencil_with_ddim(in_field: DDIM_TYPE, out_field: DDIM_TYPE) -> None:
     with computation(PARALLEL), interval(...):
         n = 0
@@ -49,6 +56,7 @@ class TransientRefineableCode(NDSLRuntime):
             stree=OptimizationConfig.Tree(
                 enabled=True,
                 merger=OptimizationConfig.Tree.Merger(enabled=True),
+                refine_transients=True,
             )
         )
         super().__init__(stencil_factory, optimization_config=config)
@@ -103,10 +111,17 @@ class TransientRefineableCode(NDSLRuntime):
         self.stencil_with_ddim(self.tmp_ddim, out_field)
 
 
+def _check_strides(array: Array, backend: Backend):
+    old_strides = array.strides
+    array.set_strides_from_layout(*backend.as_layout_map(len(array.shape) - 3))
+    assert old_strides == array.strides
+
+
 def test_stree_roundtrip_transient_is_refined() -> None:
     domain = (3, 3, 4)
+    backend = Backend.cpu()
     stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
-        domain[0], domain[1], domain[2], 0, backend=Backend.cpu()
+        domain[0], domain[1], domain[2], 0, backend=backend
     )
 
     in_qty = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "")
@@ -124,6 +139,7 @@ def test_stree_roundtrip_transient_is_refined() -> None:
     for array in precompiled_sdfg.sdfg.arrays.values():
         if array.transient:
             assert array.shape == (1, 1, 1)
+            _check_strides(array, backend)
 
     # Refine cartesian axis to buffers
     #   IJ merges - K is a buffer
@@ -136,6 +152,7 @@ def test_stree_roundtrip_transient_is_refined() -> None:
                 1,
                 domain[2] + 1,  # Quantity are domain size + 1
             )
+            _check_strides(array, backend)
 
     # I merges - JK buffer
     code.refine_to_JK_buffer(in_qty, out_qty)
@@ -147,10 +164,72 @@ def test_stree_roundtrip_transient_is_refined() -> None:
                 domain[1] + 1,  # Quantity are domain size + 1
                 domain[2] + 1,
             )
+            _check_strides(array, backend)
 
     # Refine to remaining data dimensions
     code.do_not_refine_datadims(in_qty_ddim, out_qty_ddim)
     precompiled_sdfg = get_SDFG_and_purge(stencil_factory)
     for array in precompiled_sdfg.sdfg.arrays.values():
-        if array.transient:
-            assert array.shape == (1, 1, 1, DATADIM_SIZE) or len(array.shape) == 1
+        if array.transient and isinstance(array, Array):
+            assert array.shape == (1, 1, 1, DATADIM_SIZE)
+            _check_strides(array, backend)
+
+
+class TransientStrideTestCode(NDSLRuntime):
+    def __init__(
+        self, stencil_factory: StencilFactory, quantity_factory: QuantityFactory
+    ) -> None:
+        config = OptimizationConfig(
+            stree=OptimizationConfig.Tree(
+                enabled=True,
+                merger=OptimizationConfig.Tree.Merger(enabled=True),
+                refine_transients=True,
+            )
+        )
+        super().__init__(stencil_factory, optimization_config=config)
+        self.tmp = self.make_local(quantity_factory, [I_DIM, J_INTERFACE_DIM, K_DIM])
+        self.stencil = stencil_factory.from_dims_halo(
+            func=stencil,
+            compute_dims=[I_DIM, J_DIM, K_DIM],
+        )
+        self.stencil_with_J_offset = stencil_factory.from_dims_halo(
+            func=stencil_with_J_offset,
+            compute_dims=[I_DIM, J_DIM, K_DIM],
+        )
+
+    def __call__(self, in_field: Quantity, out_field: Quantity) -> None:
+        self.stencil(in_field, self.tmp)
+        self.stencil_with_J_offset(self.tmp, out_field)
+
+
+def test_stree_refined_strides_and_lifetime() -> None:
+    domain = (3, 4, 5)
+
+    stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
+        domain[0], domain[1], domain[2], 0, backend=Backend("orch:dace:cpu:IJK")
+    )
+    in_qty = quantity_factory.ones([I_DIM, J_INTERFACE_DIM, K_DIM], "")
+    out_qty = quantity_factory.zeros([I_DIM, J_DIM, K_DIM], "")
+    code_ijk = TransientStrideTestCode(stencil_factory, quantity_factory)
+    code_ijk(in_qty, out_qty)
+    precompiled_sdfg_ijk = get_SDFG_and_purge(stencil_factory)
+
+    stencil_factory, quantity_factory = get_factories_single_tile_orchestrated(
+        domain[0], domain[1], domain[2], 0, backend=Backend("orch:dace:cpu:KJI")
+    )
+    in_qty = quantity_factory.ones([I_DIM, J_INTERFACE_DIM, K_DIM], "")
+    out_qty = quantity_factory.zeros([I_DIM, J_DIM, K_DIM], "")
+    code_kji = TransientStrideTestCode(stencil_factory, quantity_factory)
+    code_kji(in_qty, out_qty)
+    precompiled_sdfg_kji = get_SDFG_and_purge(stencil_factory)
+
+    for array_ijk, array_kji in zip(
+        precompiled_sdfg_ijk.sdfg.arrays.values(),
+        precompiled_sdfg_kji.sdfg.arrays.values(),
+    ):
+        if array_ijk.transient and isinstance(array_ijk, Array):
+            # Both first axis refined - shape are differnt now - but J is the same
+            assert array_ijk.shape != array_kji.shape
+            assert array_ijk.shape[1] == array_kji.shape[1]
+            # Strides are still different
+            assert array_ijk.strides != array_kji.strides


### PR DESCRIPTION
# Description

`RefineTransient` recomputes strides for refined data.
We also force transient to be Persistent on CPU since we have no memory pool. When refining, the transient can be pushed _within_ a loop, and if the lifetime is kept at the default `Scope` it will allocate every time. GPU has a memory pool to alleviate this, CPU doesn't.

Also:
- `Backend.as_layout_map` now knows how to give a map taking a data dimensions into account.

## How has this been tested?

New and adjusted utests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
