### PR TITLE
[Feat | Lang] Introducing `ConstantQuantity`

### DIFF
--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -520,6 +520,7 @@ def _parse_sdfg(
     dace_program: DaceProgram,
     config: DaceConfig,
     optimization: OptimizationConfig | None,
+    top_level: bool = False,
     *args: Any,
     **kwargs: Any,
 ) -> SDFG | CompiledSDFG | None:
@@ -529,12 +530,15 @@ def _parse_sdfg(
     Attributes:
         dace_program: the DaceProgram carrying reference to the original method/function
         config: the DaceConfig configuration for this execution
+        optimization: the local OptimizationConfig
+        top_level: mark this SDFG as an entry point of parsing, rather than an nested/inner SDFG
     """
     # Check cache for already loaded SDFG
     if dace_program in config.loaded_dace_executables:
         return config.loaded_dace_executables[dace_program].compiled_sdfg
 
-    ndsl_log.info(f"Building DaCe orchestration for {dace_program.f.__qualname__}")
+    if top_level:
+        ndsl_log.info(f"Building DaCe orchestration for {dace_program.f.__qualname__}")
 
     # Build expected path
     sdfg_path = get_sdfg_path(dace_program.name, config)
@@ -612,6 +616,7 @@ class _LazyComputepathFunction(SDFGConvertible):
             self.daceprog,
             self.config,
             self.optimization_config,
+            True,
             *args,
             **kwargs,
         )
@@ -634,7 +639,12 @@ class _LazyComputepathFunction(SDFGConvertible):
 
     def __sdfg__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         return _parse_sdfg(
-            self.daceprog, self.config, self.optimization_config, *args, **kwargs
+            self.daceprog,
+            self.config,
+            self.optimization_config,
+            False,
+            *args,
+            **kwargs,
         )
 
     def __sdfg_closure__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
@@ -683,6 +693,7 @@ class _LazyComputepathMethod:
                 self.daceprog,
                 self.lazy_method.config,
                 self.lazy_method.optimization_config,
+                True,
                 *args,
                 **kwargs,
             )
@@ -700,6 +711,7 @@ class _LazyComputepathMethod:
                 self.daceprog,
                 self.lazy_method.config,
                 self.lazy_method.optimization_config,
+                False,
                 *args,
                 **kwargs,
             )

--- a/ndsl/dsl/ndsl_runtime.py
+++ b/ndsl/dsl/ndsl_runtime.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from collections.abc import Callable
-from typing import Any, Sequence
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy as np
 
 from ndsl import OptimizationConfig
 from ndsl.debug import get_debugger
@@ -11,7 +13,12 @@ from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.stencil import StencilFactory
 from ndsl.dsl.typing import Float
 from ndsl.initialization.allocator import QuantityFactory
+from ndsl.optional_imports import cupy
 from ndsl.quantity import Local, Quantity
+from ndsl.quantity.local import ConstantQuantity
+
+if cupy is None:
+    import numpy as cupy
 
 _TOP_LEVEL: object | None = None
 
@@ -192,5 +199,32 @@ class NDSLRuntime:
             origin=quantity.origin,
             extent=quantity.extent,
             backend=quantity.backend,
+            allow_mismatch_float_precision=allow_mismatch_float_precision,
+        )
+
+    def make_constant_quantity(
+        self,
+        data: np.ndarray | cupy.ndarray | Quantity,
+        quantity_factory: QuantityFactory,
+        dims: Sequence[str],
+        dtype: type = Float,
+        units: str = "unspecified",
+        *,
+        allow_mismatch_float_precision: bool = False,
+    ) -> ConstantQuantity:
+        constant = quantity_factory.zeros(
+            dims,
+            units,
+            dtype,
+            allow_mismatch_float_precision=allow_mismatch_float_precision,
+        )
+        constant.field[:] = data[:]
+        return ConstantQuantity(
+            data=constant._data,
+            dims=constant.dims,
+            units=constant.units,
+            origin=constant.origin,
+            extent=constant.extent,
+            backend=constant.backend,
             allow_mismatch_float_precision=allow_mismatch_float_precision,
         )

--- a/ndsl/quantity/local.py
+++ b/ndsl/quantity/local.py
@@ -54,3 +54,34 @@ class Local(Quantity):
             f"    units={self.units},\n    origin={self.origin},\n"
             f"    extent={self.extent}\n)"
         )
+
+
+class ConstantQuantity(Quantity):
+    """ConstantQuantity is a Quantity that cannot be written to outside of it's allocation
+    (notably with the `NDSLRuntime.make_constant_quantity` method)."""
+
+    def __init__(
+        self,
+        data: np.ndarray | cupy.ndarray | Quantity,
+        dims: Sequence[str],
+        units: str,
+        *,
+        backend: Backend,
+        origin: Sequence[int] | None = None,
+        extent: Sequence[int] | None = None,
+        allow_mismatch_float_precision: bool = False,
+    ):
+        super().__init__(
+            data,
+            dims,
+            units,
+            origin=origin,
+            extent=extent,
+            allow_mismatch_float_precision=allow_mismatch_float_precision,
+            backend=backend,
+        )
+
+    def __setitem__(self, subscript: Any, value: Any) -> None:
+        raise RuntimeError(
+            "ConstantQuantity cannot be written too after initialization"
+        )

--- a/tests/quantity/test_local.py
+++ b/tests/quantity/test_local.py
@@ -116,6 +116,9 @@ class TheCode(NDSLRuntime):
         self._quantity_factory = quantity_factory
         self._locals = GoodLocals.make_locals(quantity_factory)
         self._a_local = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._a_constant = self.make_constant_quantity(
+            np.array([1.0, 2.0, 3.0, 4.0, 5.0]), self._quantity_factory, [K_DIM]
+        )
 
     def allocate_bad_locals(self) -> None:
         self._bad = BadLocals.make_locals(self._quantity_factory)
@@ -203,3 +206,23 @@ def test_nested_local_state_as_regular_state() -> None:
 
     # Ensure that locals have been correctly reset
     NestedLocals._check_only_locals()
+
+
+def test_constant_quantity() -> None:
+    stencil_factory, quantity_factory = get_factories_single_tile(
+        3, 3, 5, 0, backend=Backend.python()
+    )
+
+    the_code = TheCode(stencil_factory, quantity_factory)
+
+    the_code()
+
+    # Allow read outside of Code without a warning
+    _ = the_code._a_constant[:]
+
+    # Disallow writes
+    with pytest.raises(
+        RuntimeError,
+        match="ConstantQuantity cannot be written too after initialization*",
+    ):
+        the_code._a_constant[:] = 3


### PR DESCRIPTION
# Description

With `Local` being a new symbolic way to flag for "temporary" memory to be optimized later. We also have implemented a warning showing any memory living on a `NDSLRuntime` and that is _not_ flagged as a `Local`.

We are still seeing the warnings pop in and some are pointing to a missing use case: constants buffer. E.g. the following damping coefficient in the column calculated during `__init__` and used afterwards:

```python
class DelnFlux(NDSLRuntime):
    def __init__(...):
        [...]
        self._damp = calc_damp(
            damp_c=damp_c, da_min=damping_coefficients.da_min, nord=nord_col
        )
```

We propose a `ConstantQuantity` that forbids writing into it past it's initialization and flags the usage so that following optimization can be done (not part of this PR).

## How has this been tested?

New utest.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
