### PR TITLE
refactor: orchestration pipeline tweaks

### DIFF
--- a/ndsl/dsl/dace/orchestration.py
+++ b/ndsl/dsl/dace/orchestration.py
@@ -141,7 +141,11 @@ def _tree_as_sdfg(stree: tn.ScheduleTreeRoot) -> SDFG:
     This function wraps `stree.as_sdfg()` with a configuration that is suitable for
     NDSL, e.g. skipping certain passes of `sdfg.simplify()`.
     """
-    return stree.as_sdfg(skip={"ScalarToSymbolPromotion", "ControlFlowRaising"})
+    return stree.as_sdfg(
+        validate=False,
+        simplify=True,
+        skip={"ScalarToSymbolPromotion", "ControlFlowRaising"},
+    )
 
 
 def _optimization_pipeline(
@@ -223,11 +227,12 @@ def _build_sdfg(
                             ):
                                 node.schedule = ScheduleType.GPU_Device
 
-            ndsl_log.debug("saving 00-gpu-maps.sdfgz")
-            sdfg.save(
-                os.path.abspath(f"{sdfg.build_folder}/00-gpu-maps.sdfgz"),
-                compress=True,
-            )
+            if config.verbose_orchestration:
+                ndsl_log.debug("saving 00-gpu-maps.sdfgz")
+                sdfg.save(
+                    os.path.abspath(f"{sdfg.build_folder}/00-gpu-maps.sdfgz"),
+                    compress=True,
+                )
 
         with DaCeProgress(config, "Simplify (1)"):
             _simplify(sdfg)
@@ -291,8 +296,12 @@ def _build_sdfg(
         # We want all maps properly collapse to make sure the codegen will see nD parallel
         # axis as a single kernelizable map
         with DaCeProgress(config, "Collapse maps"):
-            # allow `MapCollapse` to collapse maps with different schedules
-            sdfg.apply_transformations_repeated(MapCollapse, permissive=True)
+            # permissive: allow `MapCollapse` to collapse maps with different schedules
+            # progress: do not print intermediate transformations applied
+            # validate: do not validate after applying all transformations
+            sdfg.apply_transformations_repeated(
+                MapCollapse, permissive=True, progress=False, validate=False
+            )
 
         with DaCeProgress(config, "Make transient persistents"):
             # Make the transients array persistents


### PR DESCRIPTION
# Description

Looking through the orchestration log of the DaCe update in #539, I noticed that we are printing intermediate  `MapCollapse` output, i.e.

<img width="1077" height="503" alt="image" src="https://github.com/user-attachments/assets/83c15044-fbc6-467c-80ab-fc34336436e8" />

which imo isn't useful output. I combined the suppression of that output with two other random orchestration tweaks that I had laying around.

## How has this been tested?

Looked at the log of this run and the extra messages are gone

<img width="1046" height="158" alt="image" src="https://github.com/user-attachments/assets/19395819-2aab-4fb2-96c0-0e7ca72212bc" />


All good as long as orchestration CI is still happy.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
