### PR TITLE
docs: roadmap 2026.08.00 and 2026.09.00 releases

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,9 @@ We are building NDSL in the open. On this page we'll start to share our public r
 
 ## 2026.09.00
 
-- :rocket: More optimizations
+- :rocket: Cache-friendly merger debug
+- :rocket: CPU serial execution merger
+- :rocket: Scalarization and refinement of local memory for better cache access
 - :gear: use `uv` for dependency management
 
 ## 2026.08.00

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,18 @@
 # Roadmap
 
 We are building NDSL in the open. On this page we'll start to share our public roadmap. This allows you to track our progress and see what's coming in the future. Head over to the [community section](./community.md) for discussions, questions, collaboration opportunities, and development updates.
+
+## 2026.09.00
+
+- :rocket: More optimizations
+- :gear: use `uv` for dependency management
+
+## 2026.08.00
+
+- :sparkles: Support for (integer) enum types in stencil code
+- :sparkles: Support for `gcc-16`
+- :rocket: Handle off-grid conditionals when merging cartesian axis
+- :rocket: Avoid allocation of temporaries inside loops
+- :beetle: Register data dimension fields with NDSL `Int` type
+- :construction: Guard usage of `Local`s in non-orchestrated code paths
+- :snake: Drop support for python 3.11


### PR DESCRIPTION
# Description

Add roadmap for `2026.08.00` and `2026.09.00`  releases.

## How has this been tested?

Local render looks like this

<img width="1430" height="954" alt="image" src="https://github.com/user-attachments/assets/a5eeecbe-8d52-4388-9001-544834bf841f" />

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
