### PR TITLE
`ndsl-codegen`: fully typed output and other improvements

### DIFF
--- a/.github/workflows/codegen_tests.yaml
+++ b/.github/workflows/codegen_tests.yaml
@@ -1,0 +1,42 @@
+# This file tests `ndsl-gencode`, the code generator that's shipped with NDSL.
+name: "NDSL codgen tests"
+
+# Run these these whenever ...
+on:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  push:
+    branches:
+      - main # ... when merging into the main branch
+
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ndsl_gencode_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12', '3.13']
+      fail-fast: true
+    name: ndsl-gencode (py${{ matrix.python-version }})
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install openmpi
+          pip install .
+
+      - name: Generate executable code
+        run: ndsl-gencode --exec --output test_ndsl_gencode.py
+
+      - name: Run generated code
+        run: python test_ndsl_gencode.py

--- a/ndsl/boilerplate/generate_code.py
+++ b/ndsl/boilerplate/generate_code.py
@@ -1,12 +1,10 @@
 """Generate boilerplate code with configurable executor at the bottom."""
 
-from __future__ import annotations
-
 import argparse
 import textwrap
 
 TEMPLATE = textwrap.dedent("""\
-    from ndsl import NDSLRuntime
+    from ndsl import NDSLRuntime, StencilFactory
     from ndsl.boilerplate import get_factories_single_tile
     from ndsl.config import Backend
     from ndsl.constants import I_DIM, J_DIM, K_DIM
@@ -14,50 +12,57 @@ TEMPLATE = textwrap.dedent("""\
     from ndsl.dsl.typing import FloatField
 
 
-    def copy_stencil(input_field: FloatField, output_field: FloatField):
-        \"""All stencil code should live in the global space.\"""
+    def square_stencil(input_field: FloatField, output_field: FloatField) -> None:
+        \"""Saves the squared values of `input_field`  in `output_field`.
+
+        Stencils usually live in the global space. Simple stencils (e.g. `copy`)
+        can be imported from `ndsl.stencils`.\"""
 
         with computation(PARALLEL), interval(...):
-            output_field = input_field
+            output_field = input_field * input_field
 
 
     class {class_name}(NDSLRuntime):
-        \"""All model code should be wrapped in NDSLRuntime object.\"""
+        \"""All model code should derive from NDSLRuntime objects.\"""
 
-        def __init__(self, stencil_factory):
+        def __init__(self, stencil_factory: StencilFactory) -> None:
             super().__init__(stencil_factory)
 
-            self._copy = stencil_factory.from_dims_halo(
-                func=copy_stencil,
+            self._square = stencil_factory.from_dims_halo(
+                func=square_stencil,
                 compute_dims=[I_DIM, J_DIM, K_DIM],
             )
 
-        def __call__(self, input_field: FloatField, output_field: FloatField):
-            self._copy(input_field, output_field)
+        def __call__(self, input_field: FloatField, output_field: FloatField) -> None:
+            self._square(input_field, output_field)
+
+
     {main_section}
     """)
 
 MAIN_SECTION = textwrap.dedent("""\
-
     def main() -> None:
-
         # We setup a single tile grid here
         stencil_factory, quantity_factory = get_factories_single_tile(
             nx=8,
             ny=8,
             nz=4,
             nhalo=1,
-            backend=Backend({backend!r}),
+            backend=Backend("{backend}"),
         )
 
         {instance_name} = {class_name}(stencil_factory)
 
-        qty_in = quantity_factory.full(dims=[I_DIM, J_DIM, K_DIM], units="n/a", value=42.42)
-        qty_out = quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="n/a")
+        quantity = quantity_factory.full(
+            value=42.42, dims=[I_DIM, J_DIM, K_DIM], units="n/a"
+        )
+        squared = quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="n/a")
 
-        {instance_name}(qty_in, qty_out)
+        {instance_name}(quantity, squared)
 
-        assert (qty_out.field[:] == qty_in.field[:]).all(), "{class_name} does a copy"
+        assert (
+            squared.field[:] == quantity.field[:] * quantity.field[:]
+        ).all(), "{class_name} saves squared values."
 
 
     if __name__ == "__main__":
@@ -118,11 +123,12 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    output = build_script(args.name, args.backend, args.exec_main)
+    output = build_script(args.name, args.backend, args.exec_main).rstrip()
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as handle:
             handle.write(output)
+            handle.write("\n")
     else:
         print(output)
 

--- a/ndsl/constants.py
+++ b/ndsl/constants.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from enum import Enum
 from typing import Literal
 
@@ -32,7 +33,8 @@ def _get_constant_version(
 
 
 CONST_VERSION = ConstantVersions[_get_constant_version()]
-ndsl_log.info(f"Constant selected: {CONST_VERSION}")
+if not sys.argv[0].endswith("ndsl-gencode"):
+    ndsl_log.info(f"Constant selected: {CONST_VERSION}")
 
 #####################
 # Common constants

--- a/ndsl/dsl/__init__.py
+++ b/ndsl/dsl/__init__.py
@@ -55,7 +55,8 @@ if not any([name.startswith("dace") for name in gt_backend.REGISTRY.names]):
     )
 
 
-ndsl_log.info(f"Literal precision: {NDSL_GLOBAL_PRECISION}")
+if not sys.argv[0].endswith("ndsl-gencode"):
+    ndsl_log.info(f"Literal precision: {NDSL_GLOBAL_PRECISION}")
 
 # We remove warnings from the compiler for higher level of logging
 NDSL_COMPILER_SILENCE = os.getenv("NDSL_COMPILER_SILENCE", "False").lower() == "true"

--- a/ndsl/logging.py
+++ b/ndsl/logging.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import os
 import sys
@@ -99,7 +97,9 @@ def _ndsl_logger_on_rank_0() -> logging.Logger:
 ndsl_log: Annotated[logging.Logger, "NDSL Python logger, logs on all rank"] = (
     _ndsl_logger()
 )
-ndsl_log.info(f"Log level: {_get_log_level()}")
+if not sys.argv[0].endswith("ndsl-gencode"):
+    ndsl_log.info(sys.argv[0])
+    ndsl_log.info(f"Log level: {_get_log_level()}")
 
 ndsl_log_on_rank_0: Annotated[
     logging.Logger, "NDSL Python logger, logs on rank 0 only"


### PR DESCRIPTION
# Description

In the context of updating the README (and other docs) after moving to `uv` (PR #538), I was playing a bit with `ndsl-codegen`. I noticed (and changed) the following things

- Added missing type hints in generated code
- Changed `copy_stencil` to `square_stencil` and added a hint to `ndsl.stencils` for basic stencil operations
- Avoid printing constants, log level, and literal precision (because it's not important in codgen mode)

## How has this been tested?

- Local testing
- Added new workflow to generate executable code and run it. Just a very basic safety net.

Not so sure about the format. I might change it with the `uv` PR to a more user driven approach: Something like

1. start from a blank slate
2. run `uv init example`
3. add ndsl to example project
4. run ndsl-gencode and test that we can run the output

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
