### PR TITLE
remove main branch dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -9,21 +9,16 @@ Things to do before the release. Helps to keep the fallout from this release as 
 
 ## Release checklist
 
-What to do to actually release:
-
-- [x] create this PR to merge changes from `develop` into `main`
-  - merge as "Merge commit"
-- [ ] once merged, create a GitHub release and tag the new version
+- [ ] Merge this PR
+- [ ] Create a GitHub release and tag the new version
   - version format is `[year].[month].[patch]`, e.g. `2025.10.00`
   - let GitHub auto-generate release notes from the last tagged version
-- [ ] send an announcement on Mattermost
 
 ## Post-release checklist
 
 What to do after a release:
 
-- [ ] merge `main` down into `develop` to ensure `setuptools_scm` finds the latest release tag
-- [ ] update the pace PR from the pre-commit checklist to include the released version of NDSL and merge it.
-- [ ] merge breaking changes in NDSL (e.g. search for deprecation warnings)
 - [ ] update the pinned version of [pyFV3](https://github.com/NOAA-GFDL/PyFV3/) to the new release-tag
 - [ ] update the pinned version of [pySHiELD](https://github.com/NOAA-GFDL/pySHiELD) to the new release-tag
+- [ ] update the pace PR from the pre-commit checklist to include the released version of NDSL and update the submodules before merging it.
+- [ ] merge breaking changes in NDSL (e.g. search for deprecation warnings)

--- a/internal/release.md
+++ b/internal/release.md
@@ -4,22 +4,8 @@ This internal documentation guides you through the process of releasing a new ve
 
 1. Click [create a release](https://github.com/NOAA-GFDL/NDSL/compare/main...develop?expand=1&template=release.md) and follow the steps in the release checklist.
 
-## Patch release
+2. After merging that PR, create a GitHub release and tag the new version
+    - version format is `[year].[month].[patch]`, e.g. `2025.10.00`
+  - let GitHub auto-generate release notes from the last tagged version
 
-Every now and then, we'll need to patch the currently released version of NDSL. To do so, follow these steps:
-
-1. Create a branch from `main`.
-2. Commit your changes on that branch.
-3. Use the following URL <https://github.com/NOAA-GFDL/NDSL/compare/main...[your-branch-name]?expand=1&template=release-patch.md> and substitute `[your-branch-name]`.
-4. Follow the steps in the patch release checklist.
-
-As an example, you'd go and create branch `my-patches` from `main`
-
-```bash
-git checkout main
-git switch -c my-patches
-# do changes ...
-git push
-```
-
-and in that case, the URL with the patch release template is: <https://github.com/NOAA-GFDL/NDSL/compare/main...my-patches?expand=1&template=release-patch.md>.
+3. Send an announcement on Mattermost


### PR DESCRIPTION
# Description
Remove the outdated release-work around the main branch that is no longer needed due to the updated workflow from the release-checklist.

## How has this been tested?

No need, just md

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
