### PR TITLE
docs: update the link / install instructions to pull NDSL 2026.08.00

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ A modern domain-specific language for portable, high-performance atmospheric mod
 
 Install the latest version of NDSL with a few commands and start writing code.
 
-[NDSL v2026.03.00 →](./install_ndsl.md){ .pretty-link }
+[NDSL v2026.08.00 →](./install_ndsl.md){ .pretty-link }
 </div>
 
 <div class="section-card" markdown>

--- a/docs/install_ndsl.md
+++ b/docs/install_ndsl.md
@@ -21,7 +21,7 @@ All other dependencies are installed with NDSL.
 NDSL uses Git submodules for dependencies including GT4Py and DaCe, so be sure to clone recursively.
 
 ```shell
-git clone --recurse-submodules git@github.com:NOAA-GFDL/NDSL.git
+git clone --branch 2026.08.00 --recurse-submodules git@github.com:NOAA-GFDL/NDSL.git
 cd NDSL/
 ```
 


### PR DESCRIPTION
# Description

Two line change to update our public docs to point to the newly released `2026.08.00` version of NDSL.

## How has this been tested?

Did a quick local checkout to make sure that the `git clone`  command is correct.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
