### PR TITLE
Use a proper `DeprecationWarning` instead of `UserWarning`

### DIFF
--- a/ndsl/dsl/dace/build.py
+++ b/ndsl/dsl/dace/build.py
@@ -14,8 +14,8 @@ def set_distributed_caches(config: DaceConfig, force_build: bool = False) -> Non
     """
 
     warnings.warn(
-        "Use DaceConfig.set_distributed_caches",
-        UserWarning,
+        "Use DaceConfig._set_distributed_caches() instead.",
+        DeprecationWarning,
         stacklevel=2,
     )
 


### PR DESCRIPTION
# Description

Quick follow-up from PR https://github.com/NOAA-GFDL/NDSL/pull/543. Use a proper `DeprecationWarning` instead of `UserWarning` for the deprecated method `set_distributed_caches()`  in `ndsl/dsl/dace/build.py`. This will allow us to search for (and remove) the function once the September release is out.

## How has this been tested?

By self code review.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
