### PR TITLE
fix: make envvar reading more robust

### DIFF
--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -43,7 +43,7 @@ def _sync_gpu_option() -> bool:
     Debugging Dace orchestration deeper can be done by turning on `syncdebug`.
     We control this Dace configuration below with our own override.
     """
-    return os.getenv("NDSL_DACE_FORCE_SYNC_GPU", "False") == "True"
+    return os.getenv("NDSL_DACE_FORCE_SYNC_GPU", "False").lower() == "true"
 
 
 def _is_corner(rank: int, partitioner: Partitioner) -> bool:
@@ -209,10 +209,11 @@ class DaceConfig:
 
         # Verbose optimizations
         self.verbose_orchestration = (
-            os.getenv("NDSL_VERBOSE_ORCHESTRATION", "False") == "True"
+            os.getenv("NDSL_VERBOSE_ORCHESTRATION", "False").lower() == "true"
         )
         self.verbose_schedule_tree_optimizations = (
-            os.getenv("NDSL_VERBOSE_SCHEDULE_TREE_OPTIMIZATIONS", "False") == "True"
+            os.getenv("NDSL_VERBOSE_SCHEDULE_TREE_OPTIMIZATIONS", "False").lower()
+            == "true"
         )
 
         # We hijack the optimization level of GT4Py because we don't

--- a/tests/dsl/orchestration/test_replay.py
+++ b/tests/dsl/orchestration/test_replay.py
@@ -30,7 +30,7 @@ def test_record_and_replay():
     qty = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "")
     code = OrchestratedProgram(stencil_factory)
 
-    record_orginal_value = os.getenv("NDSL_RECORD_ORCHESTRATION", "False")
+    record_original_value = os.getenv("NDSL_RECORD_ORCHESTRATION", "False")
     os.environ["NDSL_RECORD_ORCHESTRATION"] = "True"
 
     code(qty)
@@ -44,4 +44,4 @@ def test_record_and_replay():
 
     loaded_exe.replay()
 
-    os.environ["NDSL_RECORD_ORCHESTRATION"] = record_orginal_value
+    os.environ["NDSL_RECORD_ORCHESTRATION"] = record_original_value


### PR DESCRIPTION
# Description

Reading some boolean environment variables was case sensitive, i.e. `True` meant on, while `true` != `True` turned the feature off. This PR changes those reads such that both `True` and `true` turn the feature on.

## How has this been tested?

Self code-review and local testing of one of those affected. I didn't systematically test all of them.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
