### PR TITLE
docs/ci: fix docs deploy after moving to uv

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv run -only-group=docs zensical build
+      - run: uv run --only-group=docs zensical build
       - uses: actions/upload-pages-artifact@v5
         with:
           path: site


### PR DESCRIPTION
# Description

Docs deploy currently fail, e.g. [see here](https://github.com/NOAA-GFDL/NDSL/actions/runs/33066452953/job/98497595527). This is the one thing that I didn't test from moving to `uv` :see_no_evil:

## How has this been tested?

Self code review

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
