### PR TITLE
[Fix | DaceExecutable] SDFG compile portability

### DIFF
--- a/ndsl/dsl/dace/dace_executable.py
+++ b/ndsl/dsl/dace/dace_executable.py
@@ -181,6 +181,7 @@ class DaceExecutable:
             original_unoptimized_sdfg = SDFG.from_file(str(gt4py_sdfg_bundle_sdfg))
 
         sdfg = SDFG.from_file(f"{bundle_path}/{_OPTIMIZED_SDFG_NAME}.sdfgz")
+        sdfg.build_folder = f"{os.getcwd()}/.dacecache"
         with open(bundle_path / "backend.txt", "r") as f:
             backend = Backend(f.readlines()[0])
 


### PR DESCRIPTION
# Description

The serialized SDFG carries it's default build folder has saved when serialized. We swap it for the current working directory on open.

## How has this been tested?

Moving DaceRxecutable on HPC

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
