### PR TITLE
cleanup dace config

### DIFF
--- a/ndsl/dsl/dace/dace_config.py
+++ b/ndsl/dsl/dace/dace_config.py
@@ -228,6 +228,22 @@ class DaceConfig:
             # NDSL has its own rank-aware system
             dace.config.Config.set("cache_distaware", value=False)
 
+            compiler_build_type = "Release"
+            if optimization_level == 0:
+                compiler_build_type = "Debug"
+            elif optimization_level == 2 or optimization_level == 1:
+                compiler_build_type = "RelWithDebInfo"
+            dace.config.Config.set(
+                "compiler",
+                "build_type",
+                value=compiler_build_type,
+            )
+            dace.config.Config.set(
+                "compiler",
+                "cpp_standard",
+                value="20",
+            )
+
             # Detecting neoverse-v1/2 requires an external package, we swap it
             # for a read on GH200 nodes themselves.
             is_arm_neoverse = (
@@ -235,13 +251,6 @@ class DaceConfig:
                 and cp.cuda.runtime.getDeviceProperties(0)["name"]
                 == b"NVIDIA GH200 480GB"
             )
-
-            if optimization_level == 0:
-                dace.config.Config.set("compiler", "build_type", value="Debug")
-            elif optimization_level == 2 or optimization_level == 1:
-                dace.config.Config.set("compiler", "build_type", value="RelWithDebInfo")
-            else:
-                dace.config.Config.set("compiler", "build_type", value="Release")
 
             # Resolve "march/mtune" option for GPU
             # - turn on numeric-centric SSE by default
@@ -255,7 +264,7 @@ class DaceConfig:
                 "compiler",
                 "cpu",
                 "args",
-                value=f"-march={march_cpu} -std=c++20 -fPIC {warnings_policy} -O{optimization_level} {cxx_defaults.cxx_compile_flags}",
+                value=f"-march={march_cpu} {warnings_policy} {cxx_defaults.cxx_compile_flags}",
             )
             # Potentially buggy - deactivate
             dace.config.Config.set(
@@ -264,6 +273,7 @@ class DaceConfig:
                 "openmp_sections",
                 value=0,
             )
+
             # Resolve "march/mtune" option for GPU
             # - turn on numeric-centric SSE by default
             # - Neoverse-V2 Grace CPU will fail
@@ -276,9 +286,8 @@ class DaceConfig:
                 "compiler",
                 "cuda",
                 "args",
-                value=f"-std=c++14 {warnings_policy} -Xcompiler -fPIC -O{optimization_level} -Xcompiler {march_option} {gpu_cflags}",
+                value=f"{warnings_policy} -Xcompiler -Xcompiler {march_option} {gpu_cflags}",
             )
-
             # Target compilation for hardware micro-code capacities
             gpu_defaults = get_gpu_hardware_defaults()
             dace.config.Config.set(
@@ -287,7 +296,6 @@ class DaceConfig:
                 "cuda_arch",
                 value=f"{gpu_defaults.compute_capability}",
             )
-
             # Default block size for kernels launch
             dace.config.Config.set(
                 "compiler",
@@ -302,14 +310,6 @@ class DaceConfig:
                 "max_concurrent_streams",
                 value=-1,  # no concurrent streams, every kernel on defaultStream
             )
-
-            # Required to True for gt4py storage/memory
-            dace.config.Config.set(
-                "compiler",
-                "allow_view_arguments",
-                value=True,
-            )
-
             # Speed up built time
             dace.config.Config.set(
                 "compiler",
@@ -317,6 +317,34 @@ class DaceConfig:
                 "unique_functions",
                 value="none",
             )
+            # Enable to debug GPU failures
+            dace.config.Config.set(
+                "compiler",
+                "cuda",
+                "syncdebug",
+                value=_sync_gpu_option(),
+            )
+            # Required to True for gt4py storage/memory
+            dace.config.Config.set(
+                "compiler",
+                "allow_view_arguments",
+                value=True,
+            )
+            # Debug lineinfo is incorrect anyway for the stencils
+            dace.config.Config.set(
+                "compiler",
+                "lineinfo",
+                value="none",
+            )
+            if NDSL_GLOBAL_PRECISION == 32:
+                # When using 32-bit float, we flip the default dtypes to be all
+                # C, e.g. 32 bit.
+                dace.Config.set(
+                    "compiler",
+                    "default_data_types",
+                    value="c",
+                )
+
             # Required for HaloEx callbacks and general code sanity
             dace.config.Config.set(
                 "frontend",
@@ -325,9 +353,9 @@ class DaceConfig:
             )
             # Unroll no loop.
             # Dev NOTE: while unrolling small loop could have an impact on speed
-            #           espcially small loop, the cost of potential increase in
+            #           especially small loop, the cost of potential increase in
             #           build time is too high. The user needs to use `nounroll`
-            #           on it's own code, shifting an optimization responsability
+            #           on it's own code, shifting an optimization responsibility
             #           away from the DSL. We opt for the default - no unrolling.
             dace.config.Config.set(
                 "frontend",
@@ -345,23 +373,6 @@ class DaceConfig:
                 "store_history",
                 value=False,
             )
-
-            # Enable to debug GPU failures
-            dace.config.Config.set(
-                "compiler", "cuda", "syncdebug", value=_sync_gpu_option()
-            )
-
-            if NDSL_GLOBAL_PRECISION == 32:
-                # When using 32-bit float, we flip the default dtypes to be all
-                # C, e.g. 32 bit.
-                dace.Config.set(
-                    "compiler",
-                    "default_data_types",
-                    value="c",
-                )
-
-            # Debug lineinfo is incorrect anyway for the stencils
-            dace.config.Config.set("compiler", "lineinfo", value="none")
 
         # Attempt to kill the dace.conf to avoid confusion
         dace_conf_to_kill = dace.config.Config.cfg_filename()


### PR DESCRIPTION
# Description

This PR does three things:

1. `-O` flag will be derived from `compiler.build_type`
2. c++ standard has its own config option: `compiler.cpp_standard`
3. re-ordered options to keep similar configurations close to each other

## How has this been tested?

Code review and CI.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
