### PR TITLE
Remove unused optimization config name

### DIFF
--- a/ndsl/dsl/optimization_config.py
+++ b/ndsl/dsl/optimization_config.py
@@ -78,5 +78,3 @@ class OptimizationConfig:
 
     hint: OptimizationHint = OptimizationHint.PARALLEL
     """Hint for all optimizations passes"""
-
-    name: str = "unset"


### PR DESCRIPTION
# Description

Looking at stree opt output a bit more closely, I've found that the `OptimizationConfig` still has that `name` attribute. I've added it back in June for testing purposes. The attribute is not used and I don't think we need it. It was really just to have an easy way to track different / overwritten versions of local configs.

This is technically a breaking change, but since all the stree opt is still experimental, I don't see the point in making a big fuss about it.

## How has this been tested?

I've checked `pyFV3`  and `pyMoist`. Both use the optimization config and don't use/set a `name`. We thus should be safe.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
