### PR TITLE
feat: add support for KIJ loop layout in KernelizeMaps

### DIFF
--- a/ndsl/dsl/dace/builder/stree/optimizations/kernelize_maps.py
+++ b/ndsl/dsl/dace/builder/stree/optimizations/kernelize_maps.py
@@ -80,6 +80,8 @@ class KernelizeMaps(tn.ScheduleNodeVisitor):
             return [AxisIterator._J, AxisIterator._I]
         if self._backend.loop_order == BackendLoopOrder.KJI:
             return [AxisIterator._J, AxisIterator._K]
+        if self._backend.loop_order == BackendLoopOrder.KIJ:
+            return [AxisIterator._I, AxisIterator._K]
 
         raise NotImplementedError(
             f"KernelizeMaps is not configured for loop order {self._backend.loop_order}."


### PR DESCRIPTION
# Description

Since we now also run kernelize maps on CPU, I've hit this running pyFV3 translate tests with `KIJ` loop layout. Just some duct-tape to make that particular layout work too ... 

## How has this been tested?

self code review

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/): N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
