### PR TITLE
[Feat | OptCycleII.7] Dual merge pass and over-compute guard position dependent on opt hint

### DIFF
--- a/ndsl/dsl/dace/builder/stree/default_pipeline.py
+++ b/ndsl/dsl/dace/builder/stree/default_pipeline.py
@@ -32,6 +32,7 @@ class CPUPipeline(StreePipeline):
                 ppl_passes.append(
                     CartesianMergePipeline(
                         backend,
+                        hint=config.hint,
                         overcompute=config.stree.merger.overcompute,
                         merge_order=config.stree.merger.order,
                     )
@@ -68,6 +69,7 @@ class GPUPipeline(StreePipeline):
                 ppl_passes.append(
                     CartesianMergePipeline(
                         backend,
+                        hint=config.hint,
                         overcompute=config.stree.merger.overcompute,
                     )
                 )

--- a/ndsl/dsl/dace/builder/stree/optimizations/axis_merge.py
+++ b/ndsl/dsl/dace/builder/stree/optimizations/axis_merge.py
@@ -19,6 +19,7 @@ from ndsl.dsl.dace.builder.stree.common import (
 from ndsl.dsl.dace.builder.stree.optimizations.replace_axis_symbol import (
     ReplaceAxisSymbol,
 )
+from ndsl.dsl.optimization_config import OptimizationHint
 
 
 def _both_same_single_axis_maps(
@@ -62,10 +63,12 @@ class InsertOvercomputationGuard(tn.ScheduleNodeTransformer):
         *,
         merged_range: dace.subsets.Range,
         original_range: dace.subsets.Range,
+        hint: OptimizationHint,
     ):
         self._axis_as_string = axis_as_string
         self._merged_range = merged_range
         self._original_range = original_range
+        self._hint = hint
 
     def _execution_condition(self) -> CodeBlock:
         # NOTE range.ranges are inclusive, e.g.
@@ -81,12 +84,15 @@ class InsertOvercomputationGuard(tn.ScheduleNodeTransformer):
         )
 
     def visit_MapScope(self, node: tn.MapScope) -> tn.MapScope:
-        all_children_are_maps = all(
-            isinstance(child, tn.MapScope) for child in node.children
-        )
-        if all_children_are_maps:
-            node.children = self.visit(node.children)
-            return node
+        # To maximize parallelization we push the guard as deep into the cartesian
+        # block as we can in order to surface all maps at the cost of higher FLOPs
+        if self._hint == OptimizationHint.PARALLEL:
+            all_children_are_maps = all(
+                isinstance(child, tn.MapScope) for child in node.children
+            )
+            if all_children_are_maps:
+                node.children = self.visit(node.children)
+                return node
 
         if self._merged_range != self._original_range:
             if_scope = tn.IfScope(
@@ -120,10 +126,13 @@ class CartesianAxisMerge(tn.ScheduleNodeTransformer):
         overcompute: merge at the cost of an if statement.
     """
 
-    def __init__(self, axis: AxisIterator, *, overcompute: bool) -> None:
+    def __init__(
+        self, axis: AxisIterator, *, overcompute: bool, hint: OptimizationHint
+    ) -> None:
         self.axis = axis
         self.failed_due_to_data_dep = 0
         self.overcompute = overcompute
+        self.hint = hint
 
     def __str__(self) -> str:
         suffix = "_overcompute" if self.overcompute else ""
@@ -236,11 +245,13 @@ class CartesianAxisMerge(tn.ScheduleNodeTransformer):
             axis_as_str,
             merged_range=merged_range,
             original_range=first_range,
+            hint=self.hint,
         ).visit(first_map)
         InsertOvercomputationGuard(
             axis_as_str,
             merged_range=merged_range,
             original_range=second_range,
+            hint=self.hint,
         ).visit(second_map)
         assert isinstance(first_map, tn.MapScope)
         assert isinstance(second_map, tn.MapScope)
@@ -287,25 +298,25 @@ class CartesianAxisMerge(tn.ScheduleNodeTransformer):
         return merged
 
     def visit_ScheduleTreeRoot(self, node: tn.ScheduleTreeRoot) -> None:
-        """Merge as many maps as possible.
+        """Merge consecutive maps of the same cartesian axis.
+
+        Dev NOTE: this pass has been implemented in coordination with the rest of the passes
+        deployed in `CartesianMerge`. Some of the other passes aim to surface maps in a way to maximize
+        the efficiency of this pass.
 
         The algorithm works as follows:
-            - Start merging - move nodes to surface maps as much as possible
             - Try to merge the surfaced maps
             - When done, count the number of actual merges
             - If NO merges - restore the previous children
             (undo potential changes that didn't lead to map merge)
+            - If merges - go again since we have modified the tree
             Then exit.
-
 
         ToDo:
             - ForLoop are not merge at the moment, only Maps.
-            - Non-cartesian ForLoop should be merged down _if_ the maps below
-            are unique (e.g. if everything has been merged). This is relevant for
-            linear solvers and other iteration-dependent algorithmics
-            - The K loops have varied indices name of the form _k_x[_y]. This overcomplicates
-            merging and we don't take care of it at the moment. We could write a pass cleaning
-            those first.
+            - Non-cartesian ForLoop could be merged down _if_ the maps below
+            are unique (e.g. if everything has been merged) and the hint is PARALLEL.
+            This is relevant for linear solvers and other iteration-dependent algorithmics
         """
         tn.validate_children_and_parents_align(node)
         overall_merged = 0

--- a/ndsl/dsl/dace/builder/stree/optimizations/cartesian_merge.py
+++ b/ndsl/dsl/dace/builder/stree/optimizations/cartesian_merge.py
@@ -13,6 +13,7 @@ from ndsl.dsl.dace.builder.stree.optimizations.off_grid_tasklet import (
     InlineOffGridTasklet,
 )
 from ndsl.dsl.dace.builder.stree.pipeline import StreePipeline
+from ndsl.dsl.optimization_config import OptimizationHint
 
 
 class CartesianMergePipeline(StreePipeline):
@@ -27,6 +28,7 @@ class CartesianMergePipeline(StreePipeline):
         self,
         backend: Backend,
         *,
+        hint: OptimizationHint,
         overcompute: bool = True,
         merge_order: str = "default",
     ) -> None:
@@ -59,12 +61,24 @@ class CartesianMergePipeline(StreePipeline):
 
         # We are ready to merge
         for axis in axis_merge_order:
+            # If we want to overcompute we first merge the maps that don't need overcomputation
+            # to be merged so we gather the bigger contiguous maps first, before we introduce
+            # the overcomputation guards.
             passes.append(
                 CartesianAxisMerge(
                     axis,
-                    overcompute=self._overcompute,
+                    overcompute=False,
+                    hint=hint,
                 )
             )
+            if self._overcompute:
+                passes.append(
+                    CartesianAxisMerge(
+                        axis,
+                        overcompute=self._overcompute,
+                        hint=hint,
+                    )
+                )
 
         # Optimize cache-friendliness of offgrid conditional
         passes.append(ExtractOffGridConditionals())

--- a/ndsl/dsl/dace/builder/stree/optimizations/local_optimizations.py
+++ b/ndsl/dsl/dace/builder/stree/optimizations/local_optimizations.py
@@ -319,6 +319,7 @@ class _ApplyLocalOptimizations(ScheduleTreeScopeTransformer):
                 if config.stree.merger.enabled:
                     gpu_merger = CartesianMergePipeline(
                         self._backend,
+                        hint=config.hint,
                         overcompute=config.stree.merger.overcompute,
                         merge_order=config.stree.merger.order,
                     )
@@ -358,6 +359,7 @@ class _ApplyLocalOptimizations(ScheduleTreeScopeTransformer):
                 if config.stree.merger.enabled:
                     cpu_merger = CartesianMergePipeline(
                         self._backend,
+                        hint=config.hint,
                         overcompute=config.stree.merger.overcompute,
                         merge_order=config.stree.merger.order,
                     )

--- a/tests/dsl/dace/stree/optimizations/test_merge.py
+++ b/tests/dsl/dace/stree/optimizations/test_merge.py
@@ -317,24 +317,13 @@ class TestStreeMergeMaps:
             for me, state in sdfg.all_nodes_recursive()
             if isinstance(me, nodes.MapEntry)
         ]
-        assert len(all_maps) == 1  # All maps merged and collapsed
 
-    def test_overcompute_merge_maximize_parallelization(
-        self, code: OrchestratedCode, factories: Factories
-    ) -> None:
-        stencil_factory, quantity_factory = factories
-        in_qty = quantity_factory.ones([I_DIM, J_DIM, K_DIM], "")
-        out_qty = quantity_factory.zeros([I_DIM, J_DIM, K_DIM], "")
-
-        code.overcompute_merge(in_qty, out_qty)
-
-        sdfg = get_SDFG_and_purge(stencil_factory).sdfg
-        all_maps = [
-            (me, state)
-            for me, state in sdfg.all_nodes_recursive()
-            if isinstance(me, nodes.MapEntry)
-        ]
-        assert len(all_maps) == 1  # All maps merged and collapsed
+        if self.hint == OptimizationHint.PARALLEL:
+            assert len(all_maps) == 1  # All maps merged and collapsed
+        elif self.hint == OptimizationHint.SERIAL:
+            assert (
+                len(all_maps) == 3
+            )  # K merged - but IJ merge block by overcompute guard
 
     def test_no_overcompute_merge(
         self, code: OrchestratedCode, factories: Factories
@@ -386,7 +375,12 @@ class TestStreeMergeMaps:
         if stencil_factory.backend == Backend("orch:dace:cpu:IJK"):
             assert len(all_maps) == 3  # 1 IJ + 2 Ks (un-merged)
         elif stencil_factory.backend == Backend("orch:dace:cpu:KJI"):
-            assert len(all_maps) == 2  # 2 IJKs (un-merged)
+            if self.hint == OptimizationHint.PARALLEL:
+                assert len(all_maps) == 2  # 2 IJKs (un-merged)
+            elif self.hint == OptimizationHint.SERIAL:
+                assert (
+                    len(all_maps) == 4
+                )  # 1 IJKs and 1 K + IJs merging block by overcompute if-guard
 
     def test_block_merge_write_after_read_with_offset(
         self, code: OrchestratedCode, factories: Factories
@@ -408,7 +402,12 @@ class TestStreeMergeMaps:
         if stencil_factory.backend == Backend("orch:dace:cpu:IJK"):
             assert len(all_maps) == 3  # 1 IJ + 2 Ks (un-merged)
         elif stencil_factory.backend == Backend("orch:dace:cpu:KJI"):
-            assert len(all_maps) == 2  # 2 IJKs (un-merged)
+            if self.hint == OptimizationHint.PARALLEL:
+                assert len(all_maps) == 2  # 2 IJKs (un-merged)
+            elif self.hint == OptimizationHint.SERIAL:
+                assert (
+                    len(all_maps) == 4
+                )  # 1 IJKs and 1 K + IJs merging block by overcompute if-guard
 
     def test_block_merge_write_after_write_with_different_offset(
         self, code: OrchestratedCode, factories: Factories
@@ -430,7 +429,12 @@ class TestStreeMergeMaps:
         if stencil_factory.backend == Backend("orch:dace:cpu:IJK"):
             assert len(all_maps) == 3  # 1 IJ + 2 Ks (un-merged)
         elif stencil_factory.backend == Backend("orch:dace:cpu:KJI"):
-            assert len(all_maps) == 2  # 2 IJKs (un-merged)
+            if self.hint == OptimizationHint.PARALLEL:
+                assert len(all_maps) == 2  # 2 IJKs (un-merged)
+            elif self.hint == OptimizationHint.SERIAL:
+                assert (
+                    len(all_maps) == 4
+                )  # 1 IJKs and 1 K + IJs merging block by overcompute if-guard
 
     def test_push_non_cartesian_for(
         self, code: OrchestratedCode, factories: Factories


### PR DESCRIPTION
# Description

The over-computation guard when doing over-compute merge can either be positioned:
- right after the axis `map`: optimal for FLOPs
- deep in the cartesian block: optimal for further merging and parallelization.

Therefore we pass the `OptimizationHint` down to the axis merger in order to position the guard properly (SERIAL optimize for FLOP, PARALLEL for parallelization).

In order to retain the maximum parallelization, we also introduce a dual merging, first one with no over-computation so the trivial blocks are merged, then potentially with over-computation depending on flags

## How has this been tested?

Modified existing merging tests for new expected patterns.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. add new modules to docs/docstrings/)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
